### PR TITLE
Replaced xxd with hexdump

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1006,11 +1006,11 @@ ccs_injection(){
 
 	client_hello="
 	# TLS header ( 5 bytes)
-	,x16,               # Content type (x16 for handshake)
+	,x16,               # Content type (0x16 for handshake)
 	x03, tls_version,   # TLS Version
 	x00, x93,           # Length
 	# Handshake header
-	x01,                # Type (x01 for ClientHello)
+	x01,                # Type (0x01 for ClientHello)
 	x00, x00, x8f,      # Length
 	x03, tls_version,   # TLS Version
 	# Random (32 byte) 
@@ -1035,8 +1035,9 @@ ccs_injection(){
 	x00, x07, x00, x06, x00, x05, x00, x04,
 	x00, x03, x00, x02, x00, x01, x01, x00"
 
-	msg=`echo "$client_hello" | sed -e 's/# .*$//g' -e 's/,/\\\/g' | sed -e 's/ //g' -e 's/[ \t]//g' | tr -d '\n'`
-
+	msg=`echo "$client_hello" | grep -o '\bx[[:xdigit:]]\{2\}\b\|tls_version' | sed -e 's/x/\\\x/g' -e 's/tls_version/\\\tls_version/g' | tr -d '\n'`
+	#msg=`echo "$client_hello" | sed -e 's/# .*$//g' -e 's/,/\\\/g' | sed -e 's/ //g' -e 's/[ \t]//g' | tr -d '\n'`
+	
 	fd_socket 5 || return 6
 
 	[ $VERBOSE -eq 1 ] && out " sending client hello, "
@@ -1104,11 +1105,11 @@ heartbleed(){
 
 		client_hello="
 		# TLS header ( 5 bytes)
-		,x16,                      # Content type (x16 for handshake)
+		,x16,                      # Content type (0x16 for handshake)
 		x03, tls_version,          # TLS Version
 		x00, xdc,                  # Length
 		# Handshake header
-		x01,                       # Type (x01 for ClientHello)
+		x01,                       # Type (0x01 for ClientHello)
 		x00, x00, xd8,             # Length
 		x03, tls_version,          # TLS Version
           # Random (32 byte)
@@ -1133,7 +1134,7 @@ heartbleed(){
 		x00, x09, x00, x14, x00, x11, x00, x08,
 		x00, x06, x00, x03, x00, xff,
 		x01,                       # Compression methods length
-		x00,                       # Compression method (x00 for NULL)
+		x00,                       # Compression method (0x00 for NULL)
 		x00, x49,                  # Extensions length
           # Extension: ec_point_formats
 		x00, x0b, x00, x04, x03, x00, x01, x02,
@@ -1150,7 +1151,8 @@ heartbleed(){
           # Extension: Heartbeat
 		x00, x0f, x00, x01, x01"
 
-		msg=`echo "$client_hello" | sed -e 's/# .*$//g' -e 's/,/\\\/g' | sed -e 's/ //g' -e 's/[ \t]//g' | tr -d '\n'`
+		msg=`echo "$client_hello" | grep -o '\bx[[:xdigit:]]\{2\}\b\|tls_version' | sed -e 's/x/\\\x/g' -e 's/tls_version/\\\tls_version/g' | tr -d '\n'`
+		#msg=`echo "$client_hello" | sed -e 's/# .*$//g' -e 's/,/\\\/g' | sed -e 's/ //g' -e 's/[ \t]//g' | tr -d '\n'`
 
 		fd_socket 5 || return 6
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -462,7 +462,7 @@ std_cipherlists() {
 socksend() {
 	data=`echo $1 | sed 's/tls_version/'"$2"'/g'`
 	[ $VERBOSE -eq 1 ] && echo "\"$data\""
-	out "$data" >&5 &
+	printf $data >&5 &
 	sleep $3
 }
 
@@ -1062,7 +1062,7 @@ ccs_injection(){
 		outln
 	fi
 
-	reply_sanitized=`echo "$SOCKREPLY" | "${HEXDUMPPLAIN[@]}" | tr -cd '[:print:]' | sed 's/^..........//'`
+	reply_sanitized=`echo "$SOCKREPLY" | "${HEXDUMPPLAIN[@]}" | sed 's/^..........//'`
 	lines=`echo "$SOCKREPLY" | "${HEXDUMP[@]}" | wc -l`
 
 	if [ "$reply_sanitized" == "0a" ] || [ "$lines" -gt 1 ] ; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -81,8 +81,9 @@ IPS=""
 MAX_WAITSOCK=10			# waiting at max 10 seconds for socket reply
 
 # The various hexdump commands we need to replace xdd
-HEXDUMP=(hexdump -ve '"%07_ax  " 16/2 "%06o  " " \n"')
-HEXDUMPPLAIN=(hexdump -ve '30/1 "%.2x" "\n"')
+HEXDUMPVIEW=(hexdump -C)	# This is used in verbose mode to see what's going on
+HEXDUMP=(hexdump -ve '16/1 "%02x " " \n"')	# This is used to analyse the reply
+HEXDUMPPLAIN=(hexdump -ve '1/1 "%.2x"')	# Replaces both xxd -p and tr -cd '[:print:]'
         
 go2_column() { $ECHO "\033[${1}G"; }
 
@@ -1044,7 +1045,7 @@ ccs_injection(){
 
 	if [ $VERBOSE -eq 1 ]; then
 		outln "\n server hello:"
-		echo "$SOCKREPLY" | "${HEXDUMP[@]}" | head -20
+		echo "$SOCKREPLY" | "${HEXDUMPVIEW[@]}" | head -20
 		outln "[...]"
 		outln "payload with TLS version $tls_hexcode:"
 	fi
@@ -1056,7 +1057,7 @@ ccs_injection(){
 
 	if [ $VERBOSE -eq 1 ]; then
 		outln "\n reply: "
-		echo "$SOCKREPLY" | "${HEXDUMP[@]}"
+		echo "$SOCKREPLY" | "${HEXDUMPVIEW[@]}"
 		outln
 	fi
 
@@ -1159,7 +1160,7 @@ heartbleed(){
 
 		if [ $VERBOSE -eq 1 ]; then
 			outln "\n server hello:"
-			echo "$SOCKREPLY" | "${HEXDUMP[@]}" | head -20
+			echo "$SOCKREPLY" | "${HEXDUMPVIEW[@]}" | head -20
 			outln "[...]"
 			outln " sending payload with TLS version $tls_hexcode:"
 		fi
@@ -1170,11 +1171,10 @@ heartbleed(){
 
 		if [ $VERBOSE -eq 1 ]; then
 			outln "\n heartbleed reply: "
-			echo "$SOCKREPLY" | "${HEXDUMP[@]}"
+			echo "$SOCKREPLY" | "${HEXDUMPVIEW[@]}"
 			outln
 		fi
 
-		# iS - Does this need to be a different hexdump command?
 		lines_returned=`echo "$SOCKREPLY" | "${HEXDUMP[@]}" | wc -l`
 		if [ $lines_returned -gt 1 ]; then
 			red "VULNERABLE"

--- a/testssl.sh
+++ b/testssl.sh
@@ -82,7 +82,7 @@ MAX_WAITSOCK=10			# waiting at max 10 seconds for socket reply
 
 # The various hexdump commands we need to replace xdd
 HEXDUMP=(hexdump -ve '"%07_ax  " 16/2 "%06o  " " \n"')
-HEXDUMPPLAIN=(hexdump -ve '1/1 "%.2x"')
+HEXDUMPPLAIN=(hexdump -ve '30/1 "%.2x" "\n"')
         
 go2_column() { $ECHO "\033[${1}G"; }
 


### PR DESCRIPTION
This has been tested on FreeBSD and Ubuntu.

The verbose output for Heartbleed and CCS is slightly different due to the different endian used by `xdd`and `hexdump` when presenting results.
