### PR TITLE
Check result of openssl when renegotiating

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2081,10 +2081,16 @@ renego() {
 	pr_bold " Renegotiation "; out "(CVE 2009-3555)             "
 	NEG_STR="Secure Renegotiation IS NOT"
 	echo "R" | $OPENSSL s_client $STARTTLS -connect $NODEIP:$PORT $SNI 2>&1 | grep -iq "$NEG_STR"
-	secreg=$?						# 0= Secure Renegotiation IS NOT supported
+    pipe_result=("${PIPESTATUS[@]}") # catch the return values of all commands
+    secreg=${pipe_result[2]} 	# 0= Secure Renegotiation IS NOT supported
+    if [[ ${pipe_result[1]} -ge 1 ]]; then
+        let secreg+=2 # OpenSSL didn't exit correctly
+    fi
 	case $secreg in
 		0) pr_redln "VULNERABLE (NOT ok)" ;;
 		1) pr_greenln "not vulnerable (OK)" ;;
+        2) pr_magentaln "Looks vulnerable but generates error" ;;
+        3) pr_magentaln "probably not vulnerable but error (OK)" ;;
 		*) outln "FIXME: $secreg" ;;
 	esac
 


### PR DESCRIPTION
Hi @drwetter , I don't know whether you'll agree with the formatting and text (please DO change the request to your liking), but I added an extra test for the return value of openssl when doing a renegotiation check. Sometimes servers *say* they do secure renegotiation when in fact they do not, thereby increasing false positives.

Cheers,

Peter