### PR TITLE
Update OpenSSL reqs - LOGJAM checks need 1.0.2+

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 
 `testssl.sh` is a free command line tool which checks a server's service on any port for the support of TLS/SSL ciphers, protocols as well as some cryptographic flaws. It's designed to provide clear output for your "is this good or bad" decision.
 
-It is working on every Linux distribution out of the box with some limitations of disabled features from the openssl client -- some workarounds are done with bash-socket-based checks. It also works on BSD and other Unices out of the box, supposed they have `/bin/bash` and standard tools like sed and awk installed. MacOS X and Windows (using MSYS2) work too. OpenSSL version >= 1 is highly recommended.
+It is working on every Linux distribution out of the box with some limitations of disabled features from the openssl client -- some workarounds are done with bash-socket-based checks. It also works on BSD and other Unices out of the box, supposed they have `/bin/bash` and standard tools like sed and awk installed. MacOS X and Windows (using MSYS2) work too. OpenSSL version >= 1 is highly recommended.  OpenSSL version >= 1.0.2 is needed for LOGJAM checks.
 
 On github you will find in the master branch the development version of the software -- with new features and maybe some bugs. For the stable version and a more thorough description of the software please see [testssl.sh](https://testssl.sh/ "Go to the site with the stable version and more documentation"). 
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 
 `testssl.sh` is a free command line tool which checks a server's service on any port for the support of TLS/SSL ciphers, protocols as well as some cryptographic flaws. It's designed to provide clear output for your "is this good or bad" decision.
 
-It is working on every Linux distribution out of the box with some limitations of disabled features from the openssl client -- some workarounds are done with bash-socket-based checks. It also works on BSD and other Unices out of the box, supposed they have `/bin/bash` and standard tools like sed and awk installed. MacOS X and Windows (using MSYS2) work too. OpenSSL version >= 1 is highly recommended.  OpenSSL version >= 1.0.2 is needed for LOGJAM checks.
+It is working on every Linux distribution out of the box with some limitations of disabled features from the openssl client -- some workarounds are done with bash-socket-based checks. It also works on BSD and other Unices out of the box, supposed they have `/bin/bash` and standard tools like sed and awk installed. MacOS X and Windows (using MSYS2) work too. OpenSSL version >= 1 is highly recommended.  OpenSSL version >= 1.0.2 is needed for better LOGJAM checks and to display bit strengths for key exchanges.
 
 On github you will find in the master branch the development version of the software -- with new features and maybe some bugs. For the stable version and a more thorough description of the software please see [testssl.sh](https://testssl.sh/ "Go to the site with the stable version and more documentation"). 
 


### PR DESCRIPTION
To effectively analyze the LOGJAM risks, and to display the bitstrength on the DH/ECDH negotiated ciphers, OpenSSL 1.0.2+ is needed.  With anything under 1.0.2 (and greater than 1.0.0), the bitstrengths are not displayed as OpenSSL is 'too old' (as referred to in the script itself when 1.0.2 is newer than what's available).

I suggest that we keep a note that >= 1.0.2 is needed for LOGJAM checks to be truly effective (and to display bitstrengths)