### PR TITLE
Added support for using a web/http proxy

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,6 +40,9 @@
 * Bug reports:
   - Viktor Szépe, Olivier Paroz, Jan H. Terstegge, Lorenz Adena
 
+* Proxy support:
+ - John Newbigin
+
 ##### Last but not least:
 
 * OpenSSL team

--- a/testssl.sh
+++ b/testssl.sh
@@ -3320,7 +3320,7 @@ tuning options:
      --assuming-http                if protocol check fails it assumes HTTP protocol and enforces HTTP checks
      --ssl-native                   fallback to checks with OpenSSL where sockets are normally used
      --openssl <PATH>               use this openssl binary (default: look in \$PATH, RUN_DIR of $PROG_NAME
-     --proxy <host>:<port>          connect via a web proxy
+     --proxy <host>:<port>          connect via the specified HTTP proxy
      --sneaky                       be less verbose wrt referer headers
      --wide                         wide output for tests like RC4, BEAST. also with hexcode, kx, strength
      --show-each                    for each wide output (see --wide, -V, -x, e, -E): display all ciphers not only succeeded ones

--- a/testssl.sh
+++ b/testssl.sh
@@ -1961,6 +1961,13 @@ fd_socket() {
 		echo "CONNECT $NODEIP:$PORT" >&5
 		while true ; do
 			read x <&5
+			if [ "${x%/*}" = "HTTP" ] ; then
+				x=${x#* }
+				if [ "${x%% *}" != "200" ] ; then
+					pr_magenta "Unable to CONNECT via proxy"
+					return 6
+				fi
+			fi
 			if [ "$x" = $'\r' ] ; then
 				break
 			fi

--- a/testssl.sh
+++ b/testssl.sh
@@ -3313,6 +3313,7 @@ tuning options:
      --assuming-http                if protocol check fails it assumes HTTP protocol and enforces HTTP checks
      --ssl-native                   fallback to checks with OpenSSL where sockets are normally used
      --openssl <PATH>               use this openssl binary (default: look in \$PATH, RUN_DIR of $PROG_NAME
+     --proxy <host>:<port>          connect via a web proxy
      --sneaky                       be less verbose wrt referer headers
      --wide                         wide output for tests like RC4, BEAST. also with hexcode, kx, strength
      --show-each                    for each wide output (see --wide, -V, -x, e, -E): display all ciphers not only succeeded ones


### PR DESCRIPTION
Some servers I wanted to scan were not directly accessible so I though I would try via a proxy server. Recent openssl has support for this built in. I had to code up support in fs_socket.

This is working well for me. Only tested on CentOS-6 using openssl-1.0.2-chacha.pm
