### PR TITLE
Public key pinning check code causes invalid arithmetic operator (OSX)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -710,7 +710,7 @@ hpkp() {
 		preload "$TMPFILE"
 
 		# get the key fingerprints
-		sed -i -e 's/Public-Key-Pins://g' -e s'/Public-Key-Pins-Report-Only://' $TMPFILE
+		sed -i '' -e 's/Public-Key-Pins://' -e 's/Public-Key-Pins-Report-Only://' $TMPFILE
 		[ -s "$HOSTCERT" ] || get_host_cert
 		hpkp_key_hostcert="$($OPENSSL x509 -in $HOSTCERT -pubkey -noout | grep -v PUBLIC | \
 			$OPENSSL base64 -d | $OPENSSL dgst -sha256 -binary | $OPENSSL base64)"

--- a/testssl.sh
+++ b/testssl.sh
@@ -688,7 +688,7 @@ hpkp() {
 	fi
 	#pr_bold " HPKP                         "
 	pr_bold " Public Key Pinning           "
-	egrep -aiw '^Public-Key-Pins|Public-Key-Pins-Report-Only' $HEADERFILE >$TMPFILE
+	egrep -aiw '^Public-Key-Pins|Public-Key-Pins-Report-Only' $HEADERFILE | tr -d '\r' >$TMPFILE
 	if [ $? -eq 0 ]; then
 		egrep -aciw '^Public-Key-Pins|Public-Key-Pins-Report-Only' $HEADERFILE | egrep -waq "1" || out "(two HPKP headers, using 1st one) "
 		# dirty trick so that grep -c really counts occurrences and not lines w/ occurrences:
@@ -696,7 +696,7 @@ hpkp() {
 		if [ $hpkp_nr_keys -eq 1 ]; then
 			pr_litered "One key is not sufficent, "
 		fi
-		hpkp_age_sec=$(sed -e 's/\r//g' -e 's/^.*max-age=//' -e 's/;.*//' $TMPFILE)
+		hpkp_age_sec=$(sed -e 's/^.*max-age=//' -e 's/;.*//' $TMPFILE)
 #FIXME: test for number!
 		hpkp_age_days=$((hpkp_age_sec / 86400))
 		if [ $hpkp_age_days -ge $HPKP_MIN ]; then


### PR DESCRIPTION
Running the HEAD of testssl.sh on Mac OS X against https://testssl.sh is broken.

```
$ ./testssl.sh -H testssl.sh
[...]
--> Testing HTTP header response @ "/"

 HTTP Status Code             200 OK
 HTTP clock skew              0 sec from localtime
 Strict Transport Security    362 days=31337000 s, just this domain
")syntax error: invalid arithmetic operator (error token is "tssl.sh: line 699: 2592000
```

I fixed the error by normalising to LF on line 691 to remove CRs from the HTTP headers before writing out the HPKP `TMPFILE`, and removed the CR handling code from line 699:
```
691:    egrep -aiw '^Public-Key-Pins|Public-Key-Pins-Report-Only' $HEADERFILE | tr -d '\r' >$TMPFILE
699:    hpkp_age_sec=$(sed -e 's/^.*max-age=//' -e 's/;.*//' $TMPFILE)
```

Then I got another error on line 713 because sed on OS X doesn't like `sed -i` without a file name extension.

After these fixes to get it running the HPKP results still look wrong. https://testssl.sh provides two keys so the counting on line 695 doesn't seem to work (at least on OS X):
```
 Public Key Pinning           One key is not sufficent, 30 days=2592000 s, just this domain
                              No matching key for pin found
```

Could you please confirm the results are correct on Linux so I know the remaining issues are caused by tool differences.