### PR TITLE
Fix subject alternative name on darwin

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1786,12 +1786,11 @@ run_server_defaults() {
 	fi
 
 	sans=$($OPENSSL x509 -in $HOSTCERT -noout -text | grep -A3 "Subject Alternative Name" | grep "DNS:" | \
-		sed -e 's/DNS://g' -e 's/ //g' -e 's/,/\n/g' -e 's/othername:<unsupported>//g')
-#                                                        ^^^ CACert
+		sed -e 's/DNS://g' -e 's/ //g' -e 's/,/ /g' -e 's/othername:<unsupported>//g')
+#                                                       ^^^ CACert
 
 	pr_bold " subjectAltName (SAN)         "
 	if [ -n "$sans" ]; then
-		sans=$(echo "$sans" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g') # replace line feed by " "
 		for san in $sans; do
 			out "$underline$san$off "
 		done


### PR DESCRIPTION
Fix for #166

On OSX the following line doesn't seem to work (i.e. the input is good the output is empty), however [others have it working on OSX with separated -e args like you've got](http://stackoverflow.com/questions/1251999/how-can-i-replace-a-newline-n-using-sed). I went to change it from sed to tr, however realised we didn't need the new line at all.

```
L1794: sans=$(echo "$sans" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g') # replace line feed by " "
```