### PR TITLE
Add HTTP2/ALPN support

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2485,6 +2485,7 @@ run_spdy() {
 run_http2() {
      local tmpstr
      local -i ret=0	
+     local had_alpn_proto
 
      pr_bold " HTTP2/ALPN "
      if ! http2_pre ; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -1744,8 +1744,8 @@ run_server_preference() {
 
                [[ -n "$PROXY" ]] && arg="   SPDY/NPN is"
                [[ -n "$STARTTLS" ]] && arg="    "
-               if spdy_pre " $arg" >/dev/null; then                                       # is NPN/SPDY supported and is this no STARTTLS? / no PROXY
-                    $OPENSSL s_client -host $NODE -port $PORT $BUGS -nextprotoneg "$NPN_PROTOs" </dev/null 2>>$ERRFILE >$TMPFILE
+               if spdy_pre " $arg" ; then                                       # is NPN/SPDY supported and is this no STARTTLS? / no PROXY
+                    $OPENSSL s_client -connect $NODEIP:$PORT $BUGS -nextprotoneg "$NPN_PROTOs" </dev/null 2>>$ERRFILE >$TMPFILE
                     if sclient_connect_successful $? $TMPFILE; then
                          proto[i]=$(grep -aw "Next protocol" $TMPFILE | sed -e 's/^Next protocol://' -e 's/(.)//' -e 's/ //g')
                          if [[ -z "${proto[i]}" ]]; then
@@ -1755,8 +1755,8 @@ run_server_preference() {
                               [[ $DEBUG -ge 2 ]] && outln "Default cipher for ${proto[i]}: ${cipher[i]}"
                          fi
                     fi
-               #else
-                    #outln     # we miss for STARTTLS 1x LF otherwise
+               else
+                    outln     # we miss for STARTTLS 1x LF otherwise
                fi
 
                for i in 1 2 3 4 5 6; do

--- a/testssl.sh
+++ b/testssl.sh
@@ -2458,7 +2458,7 @@ run_spdy() {
           outln "\n"
           return 0
      fi
-     $OPENSSL s_client -connect $NODEIP:$PORT $BUGS -nextprotoneg $NPN_PROTOs $SNI </dev/null 2>$ERRFILE >$TMPFILE
+     $OPENSSL s_client -connect $NODEIP:$PORT $BUGS $SNI -nextprotoneg $NPN_PROTOs </dev/null 2>$ERRFILE >$TMPFILE
      tmpstr=$(grep -a '^Protocols' $TMPFILE | sed 's/Protocols.*: //')
      if [[ -z "$tmpstr" ]] || [[ "$tmpstr" == " " ]]; then
           outln "not offered"
@@ -2493,7 +2493,7 @@ run_http2() {
      fi
      for proto in $ALPN_PROTOs; do
           # for some reason OpenSSL doesn't list the advertised protocols, so instead try common protocols
-          $OPENSSL s_client -connect $NODEIP:$PORT $BUGS -alpn $proto $SNI </dev/null 2>$ERRFILE >$TMPFILE
+          $OPENSSL s_client -connect $NODEIP:$PORT $BUGS $SNI -alpn $proto </dev/null 2>$ERRFILE >$TMPFILE
           tmpstr=$(grep -a '^ALPN protocol' $TMPFILE | sed 's/ALPN protocol.*: //')
           if [[ "$tmpstr" = "$proto" ]]; then
               if [[ -z "$had_alpn_proto" ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -2465,7 +2465,7 @@ run_spdy() {
           ret=1
      else
           # now comes a strange thing: "Protocols advertised by server:" is empty but connection succeeded
-          if echo $tmpstr | egrep -aq "spdy|http" ; then
+          if echo $tmpstr | egrep -aq "h2|spdy|http" ; then
                out "$tmpstr" 
                outln " (advertised)"
                ret=0

--- a/testssl.sh
+++ b/testssl.sh
@@ -2455,7 +2455,7 @@ run_spdy() {
 
      pr_bold " SPDY/NPN   "
      if ! spdy_pre ; then
-          outln "\n"
+          outln
           return 0
      fi
      $OPENSSL s_client -connect $NODEIP:$PORT $BUGS $SNI -nextprotoneg $NPN_PROTOs </dev/null 2>$ERRFILE >$TMPFILE
@@ -2488,7 +2488,7 @@ run_http2() {
 
      pr_bold " HTTP2/ALPN "
      if ! http2_pre ; then
-          outln "\n"
+          outln
           return 0
      fi
      for proto in $ALPN_PROTOs; do

--- a/testssl.sh
+++ b/testssl.sh
@@ -1744,7 +1744,7 @@ run_server_preference() {
 
                [[ -n "$PROXY" ]] && arg="   SPDY/NPN is"
                [[ -n "$STARTTLS" ]] && arg="    "
-               if spdy_pre " $arg"; then                                                  # is NPN/SPDY supported and is this no STARTTLS? / no PROXY
+               if spdy_pre " $arg" >/dev/null; then                                       # is NPN/SPDY supported and is this no STARTTLS? / no PROXY
                     $OPENSSL s_client -host $NODE -port $PORT $BUGS -nextprotoneg "$NPN_PROTOs" </dev/null 2>>$ERRFILE >$TMPFILE
                     if sclient_connect_successful $? $TMPFILE; then
                          proto[i]=$(grep -aw "Next protocol" $TMPFILE | sed -e 's/^Next protocol://' -e 's/(.)//' -e 's/ //g')
@@ -1755,8 +1755,8 @@ run_server_preference() {
                               [[ $DEBUG -ge 2 ]] && outln "Default cipher for ${proto[i]}: ${cipher[i]}"
                          fi
                     fi
-               else
-                    outln     # we miss for STARTTLS 1x LF otherwise
+               #else
+                    #outln     # we miss for STARTTLS 1x LF otherwise
                fi
 
                for i in 1 2 3 4 5 6; do

--- a/testssl.sh
+++ b/testssl.sh
@@ -133,7 +133,7 @@ DEBUG=${DEBUG:-0}                       # 1.: the temp files won't be erased.
                                         # 3: slight hexdumps + other info, 
                                         # 4: display bytes sent via sockets, 5: display bytes received via sockets, 6: whole 9 yards
 WIDE=${WIDE:-false}                     # whether to display for some options the cipher or the table with hexcode/KX,Enc,strength etc.
-LOGFILE=${LOGILE-""}                    # logfile if used
+LOGFILE=${LOGFILE:-""}                  # logfile if used
 HAS_IPv6=${HAS_IPv6:-false}             # if you have OPENSSL with IPv6 support AND IPv6 networking set it to yes and testssl.sh works!
 
 # tuning vars, can not be set by a cmd line switch
@@ -220,7 +220,7 @@ readonly UA_SNEAKY="Mozilla/5.0 (X11; Linux x86_64; rv:41.0) Gecko/20100101 Fire
 TLS_LOW_BYTE=""
 HEX_CIPHER=""
 
-                                             # The various hexdump commands we need to replace xxd (BSD compatibility))
+                                             # The various hexdump commands we need to replace xxd (BSD compatibility)
 HEXDUMPVIEW=(hexdump -C)                     # This is used in verbose mode to see what's going on
 HEXDUMP=(hexdump -ve '16/1 "%02x " " \n"')   # This is used to analyze the reply
 HEXDUMPPLAIN=(hexdump -ve '1/1 "%.2x"')      # Replaces both xxd -p and tr -cd '[:print:]'


### PR DESCRIPTION
OpenSSL doesn't show the ALPN advertised protocols, so I try to test the common ones (HTTP/2, recent HTTP/2 drafts, SPDY/3.1, and HTTP/1.1). I also changed some of the SPDY code because connecting to `$NODE` will cause `gethostbyname` errors with the static binaries, and the extra line that `run_spdy` prints seems redundant.