### PR TITLE
Redirect test that doesn't depend om JSON/CSV output

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -66,6 +66,9 @@
 * Dmitri S
  - inspiration & help for Darwin port
 
+* Frank Breedijk
+ - Detection of insecure redirect
+
 * Bug reports:
   - Viktor Szépe, Olivier Paroz, Jan H. Terstegge, Lorenz Adena, Jonathon Rossi, Stefan Stidl
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -643,7 +643,14 @@ run_http_header() {
 
      out "  $status_code$msg_thereafter" 
      case $status_code in
-          301|302|307|308)    out ", redirecting to \"$(grep -a '^Location' $HEADERFILE | sed 's/Location: //' | tr -d '\r\n')\"" ;;
+          301|302|307|308)    
+               out ", redirecting to \"$(grep -a '^Location' $HEADERFILE | sed 's/Location: //' | tr -d '\r\n')\"" 
+               if [[ ( $redirect == https* ) || ( $redirect == /* ) ]]; then
+                    # Ok
+               else
+                    pr_litered " -- Redirect to insecure url (NOT ok)"
+               fi
+               ;;
           200) ;;
           206) out " -- WTF?" ;;
           400) pr_litemagenta " (Hint: better try another URL)" ;;


### PR DESCRIPTION
@drwetter you can add this one first if you do'nt want to go through #242 first. but #259 adds support for JSON/CSV as well.

And... No backticks in this one ;)