### PR TITLE
Fix #289 - the grep that decides whether a domain is a local address …

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5715,7 +5715,7 @@ get_local_a() {
      local etchosts="/etc/hosts /c/Windows/System32/drivers/etc/hosts"
 
      # for security testing sometimes we have local entries. Getent is BS under Linux for localhost: No network, no resolution
-     ip4=$(grep -wh "$1" $etchosts 2>/dev/null | egrep -v ':|^#' |  egrep  "[[:space:]]$1" | awk '{ print $1 }')
+     ip4=$(grep -wh "$1[^\.]" $etchosts 2>/dev/null | egrep -v ':|^#' |  egrep  "[[:space:]]$1" | awk '{ print $1 }')
      if is_ipv4addr "$ip4"; then
           echo "$ip4"
      else


### PR DESCRIPTION
Fix #289 - the grep that decides whether a domain is a local address doesn't consider the case when the full domain name is in the hosts file, but followed by .some.other.stuff. This PR addresses this case.

Consider the case when you have www.test.com.local in your /etc/hosts and you run testssl.sh www.test.com.

Before: "Unable to open a socket to 127.0.0.1:443. Fatal error: Can't connect to "127.0.0.1:443"
Make sure a firewall is not between you and your scanning target!"
Now: Scans www.test.com.