### PR TITLE
logfile, jsonfile and csvfile parameters work without =

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6656,7 +6656,7 @@ parse_cmd_line() {
                     do_logging=true
                     ;;   # DEFINITION of LOGFILE if no arg specified: automagically in parse_hn_port()
                     # following does the same but we can specify a log location additionally
-               --logfile=*)
+               --logfile|--logfile=*)
                     LOGFILE=$(parse_opt_equal_sign "$1" "$2")
                     [[ $? -eq 0 ]] && shift
                     do_logging=true
@@ -6665,7 +6665,7 @@ parse_cmd_line() {
                     do_json=true
                     ;;   # DEFINITION of JSONFILE is not arg specified: automagically in parse_hn_port()
                     # following does the same but we can specify a log location additionally
-               --jsonfile=*)
+               --jsonfile|--jsonfile=*)
                     JSONFILE=$(parse_opt_equal_sign "$1" "$2")
                     [[ $? -eq 0 ]] && shift
                     do_json=true
@@ -6674,7 +6674,7 @@ parse_cmd_line() {
                     do_csv=true
                     ;;   # DEFINITION of CSVFILE is not arg specified: automagically in parse_hn_port()
                     # following does the same but we can specify a log location additionally
-               --csvfile=*)
+               --csvfile|--csvfile=*)
                     CSVFILE=$(parse_opt_equal_sign "$1" "$2")
                     [[ $? -eq 0 ]] && shift
                     do_csv=true


### PR DESCRIPTION
(as documented in help)