### PR TITLE
run_allciphers(),run_cipher_per_proto(), and SSLv2

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1571,16 +1571,18 @@ test_just_one(){
 run_allciphers() {
      local tmpfile
      local -i nr_ciphers=0
-     local n sslvers auth mac export
-     local -a hexcode ciph kx enc export2
+     local n auth mac export
+     local -a hexcode ciph sslvers kx enc export2
      local -i i j parent child end_of_bundle round_num bundle_size num_bundles mod_check
      local -a ciphers_found
      local dhlen
      local available
      local ciphers_to_test
+     local sslv2_locally_supported=false sslv2_supported=false
 
-     # get a list of all the cipher suites to test (only need the hexcode, ciph, kx, enc, and export values)
-     while read hexcode[nr_ciphers] n ciph[nr_ciphers] sslvers kx[nr_ciphers] auth enc[nr_ciphers] mac export2[nr_ciphers]; do
+     # get a list of all the cipher suites to test (only need the hexcode, ciph, sslvers, kx, enc, and export values)
+     while read hexcode[nr_ciphers] n ciph[nr_ciphers] sslvers[nr_ciphers] kx[nr_ciphers] auth enc[nr_ciphers] mac export2[nr_ciphers]; do
+          [[ "${sslvers[nr_ciphers]}" == "SSLv2" ]] && sslv2_locally_supported=true
           nr_ciphers=$nr_ciphers+1
      done < <($OPENSSL ciphers -V 'ALL:COMPLEMENTOFALL:@STRENGTH' 2>>$ERRFILE)
 
@@ -1589,6 +1591,12 @@ run_allciphers() {
      "$HAS_DH_BITS" || pr_warningln "    (Your $OPENSSL cannot show DH/ECDH bits)"
      outln
      neat_header
+
+     if $sslv2_locally_supported; then
+          $OPENSSL s_client $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY -ssl2 >$TMPFILE 2>$ERRFILE </dev/null
+          sclient_connect_successful "$?" "$TMPFILE"
+          [[ "$?" -eq 0 ]] && sslv2_supported=true
+     fi
 
      # Split ciphers into bundles of size 4**n, starting with an "n" that
      # splits the ciphers into 4 bundles, and then reducing "n" by one in each
@@ -1622,17 +1630,24 @@ run_allciphers() {
                  end_of_bundle=$i*$bundle_size+$bundle_size
                  [[ $end_of_bundle -gt $nr_ciphers ]] && end_of_bundle=$nr_ciphers
                  for ((j=i*bundle_size;j<end_of_bundle;j++)); do
-                     ciphers_to_test="${ciphers_to_test}:${ciph[j]}"
+                     [[ "${sslvers[j]}" != "SSLv2" ]] && ciphers_to_test="${ciphers_to_test}:${ciph[j]}"
                  done
                  ciphers_found[child]=false
-                 $OPENSSL s_client -cipher "${ciphers_to_test:1}" $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI >$TMPFILE 2>$ERRFILE </dev/null
-                 sclient_connect_successful "$?" "$TMPFILE"
-                 [[ "$?" -eq 0 ]] && ciphers_found[child]=true
+                 if [[ -n "${ciphers_to_test:1}" ]]; then
+                      $OPENSSL s_client -cipher "${ciphers_to_test:1}" $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI >$TMPFILE 2>$ERRFILE </dev/null
+                      sclient_connect_successful "$?" "$TMPFILE"
+                      [[ "$?" -eq 0 ]] && ciphers_found[child]=true
+                 fi
              else
                  # No need to test, since test of parent demonstrated none of these ciphers work.
                  ciphers_found[child]=false
              fi
 
+             if $sslv2_supported && [[ $bundle_size -eq 1 ]] && [[ "${sslvers[i]}" == "SSLv2" ]]; then
+                 $OPENSSL s_client -cipher "${ciph[i]}" $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY -ssl2 >$TMPFILE 2>$ERRFILE </dev/null
+                 sclient_connect_successful "$?" "$TMPFILE"
+                 [[ "$?" -eq 0 ]] && ciphers_found[child]=true
+             fi
              # If this is a "leaf" of the test tree, then print out the results.
              if [[ $bundle_size -eq 1 ]] && ( ${ciphers_found[child]} || "$SHOW_EACH_C"); then
                  export=${export2[i]}
@@ -1729,7 +1744,12 @@ run_cipher_per_proto() {
                           ciphers_to_test="${ciphers_to_test}:${ciph[j]}"
                       done
                       ciphers_found[child]=false
-                      $OPENSSL s_client -cipher "${ciphers_to_test:1}" $proto $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI >$TMPFILE 2>$ERRFILE  </dev/null
+                      if [[ "$proto" =~ ssl ]]; then
+                           # SSLv2 and SSLv3 do not have SNI
+                           $OPENSSL s_client -cipher "${ciphers_to_test:1}" $proto $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY >$TMPFILE 2>$ERRFILE  </dev/null
+                      else
+                           $OPENSSL s_client -cipher "${ciphers_to_test:1}" $proto $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI >$TMPFILE 2>$ERRFILE  </dev/null
+                      fi
                       sclient_connect_successful "$?" "$TMPFILE"
                       [[ "$?" -eq 0 ]] && ciphers_found[child]=true
                   else


### PR DESCRIPTION
This PR addresses two problems related to SSLv2 in run_allciphers() and run_cipher_per_proto().

In run_cipher_per_proto(), the call to "$OPENSSL s_client" is changed to that $SNI is not included if $proto is -sslv2 or -sslv3. As noted in a comment within run_prototest_openssl(), "newer openssl throw an error if SNI is supplied with SSLv2" and "SSLv3 doesn't have SNI (openssl doesn't complain though -- yet)."

run_allciphers() will sometimes incorrectly report that a server supports an SSLv2 cipher, even if the server does not support SSLv2 at all. The problem occurs if there is a supported SSLv3 cipher suite that has the same OpenSSL name as an SSLv2 cipher suite (e.g., RC4-MD5). Since the call to "$OPENSSL s_client" only uses the OpenSSL name, but the results report both the name, hexcode, and RFC cipher suite name, both the SSLv2 and SSLv3 cipher suites are reported as being supported (e.g., 0x04=RC4-MD5=TLS_RSA_WITH_RC4_128_MD5 and x010080=RC4-MD5=SSL_CK_RC4_128_WITH_MD5). This PR fixes the problem by testing SSLv2 cipher suites separately from non-SSLv2 cipher suites.