### PR TITLE
More extensions in socksend_tls_clienthello()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4272,10 +4272,16 @@ socksend_tls_clienthello() {
           ,00                      # server_name type (hostname)
           ,00, $len_servername_hex # server_name length. We assume len(hostname) < FF - 9
           ,$servername_hexstr      # server_name target
-          ,$extension_signature_algorithms
           ,$extension_heartbeat
           ,$extension_session_ticket
           ,$extension_next_protocol"
+
+          # RFC 5246 says that clients MUST NOT offer the signature algorithms
+          # extension if they are offering TLS versions prior to 1.2.
+          if [[ "$tls_low_byte" == "03" ]]; then
+               all_extensions="$all_extensions
+               ,$extension_signature_algorithms"
+          fi
 
           if $ecc_cipher_suite_found; then
                all_extensions="$all_extensions

--- a/testssl.sh
+++ b/testssl.sh
@@ -4278,7 +4278,7 @@ socksend_tls_clienthello() {
 
           # RFC 5246 says that clients MUST NOT offer the signature algorithms
           # extension if they are offering TLS versions prior to 1.2.
-          if [[ "$tls_low_byte" == "03" ]]; then
+          if [[ "0x$tls_low_byte" -ge "0x03" ]]; then
                all_extensions="$all_extensions
                ,$extension_signature_algorithms"
           fi


### PR DESCRIPTION
This PR adds the signature algorithms, heartbeat, session ticket, and next protocol extensions to the client hello message created by socksend_tls_clienthello() for TLS 1.0 and above. It also adds the supported elliptic curves and ec points format extensions if the client hello message includes any ECC cipher suites.

I tested this version against several servers with $EXPERIMENTAL set to true and get the same results as with the current code with $EXPERIMENTAL set to false.