### PR TITLE
run_pfs() and run_rc4() show each fixes

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3679,7 +3679,7 @@ run_pfs() {
                          out "$pfs_cipher "
                     fi
                fi
-               pfs_ciphers+="$pfs_cipher "
+               [[ $sclient_success -eq 0 ]] && pfs_ciphers+="$pfs_cipher "
                debugme rm $tmpfile
           done < <($OPENSSL ciphers -V "$pfs_cipher_list" 2>$ERRFILE)      # -V doesn't work with openssl < 1.0
           debugme echo $pfs_offered
@@ -5586,9 +5586,9 @@ run_rc4() {
                     fi
                     outln
                else
-                    pr_svrty_high "$rc4_cipher "
+                    [[ $sclient_success -eq 0 ]] && pr_svrty_high "$rc4_cipher "
                fi
-               rc4_detected+="$rc4_cipher "
+               [[ $sclient_success -eq 0 ]] && rc4_detected+="$rc4_cipher "
           done < <($OPENSSL ciphers -V $rc4_ciphers_list:@STRENGTH)
           outln
           "$WIDE" && pr_svrty_high "VULNERABLE (NOT ok)"


### PR DESCRIPTION
When run_rc4() is run with the "--show-each" option, but without the "--wide" option, a list of all RC4 ciphers is printed, without any distinction between those that are supported by the server and those that are not. This is the same issue I noted in #332 for run_pfs().

In run_pfs(), the displayed output was corrected, but all ciphers were still being added to $pfs_ciphers, so the list of supported PFS ciphers sent to fileout() was incorrect.

This PR fixes both issues.