### PR TITLE
removed brackets from plain IPv6 addresses.

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7101,7 +7101,6 @@ nodeip_to_proper_ip6() {
      local len_nodeip=0
 
      if is_ipv6addr $NODEIP; then
-          NODEIP="[$NODEIP]"
           len_nodeip=${#NODEIP}
           CORRECT_SPACES="$(draw_line " " "$((len_nodeip - 16))" )"
           # IPv6 addresses are longer, this varaible takes care that "further IP" and "Service" is properly aligned


### PR DESCRIPTION
• the supplied openssl.Linux.x86_64 does not support plain IPv6 addresses at all.
• Gentoo’s openssl-1.0.2h does support IPv6 addresses, but without the brackets only.
• lookups using dig, host, etc. don’t need the brackets either.
So, it’s better to use the IPv6 address without brackets.