### PR TITLE
drwetter#365 fix ipv6 handling

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -167,6 +167,7 @@ readonly CLIENT_MIN_PFS=5               # number of ciphers needed to run a test
 DAYS2WARN1=${DAYS2WARN1:-60}            # days to warn before cert expires, threshold 1
 DAYS2WARN2=${DAYS2WARN2:-30}            # days to warn before cert expires, threshold 2
 VULN_THRESHLD=${VULN_THRESHLD:-1}       # if vulnerabilities to check >$VULN_THRESHLD we DON'T show a separate header line in the output each vuln. check
+UNBRACKETED_IPV6=${UNBRACKETED_IPV6:-false} # some versions of OpenSSL don't support [bracketed] IPv6 addresses as a connect parameter
 
 HAD_SLEPT=0
 CAPATH="${CAPATH:-/etc/ssl/certs/}"     # Does nothing yet (FC has only a CA bundle per default, ==> openssl version -d)
@@ -7112,7 +7113,7 @@ nodeip_to_proper_ip6() {
      local len_nodeip=0
 
      if is_ipv6addr $NODEIP; then
-          NODEIP="[$NODEIP]"
+          ${UNBRACKETED_IPV6} || NODEIP="[$NODEIP]"
           len_nodeip=${#NODEIP}
           CORRECT_SPACES="$(draw_line " " "$((len_nodeip - 16))" )"
           # IPv6 addresses are longer, this varaible takes care that "further IP" and "Service" is properly aligned

--- a/testssl.sh
+++ b/testssl.sh
@@ -6338,21 +6338,23 @@ determine_ip_addresses() {
 determine_rdns() {
      local saved_openssl_conf="$OPENSSL_CONF"
      OPENSSL_CONF=""                         # see https://github.com/drwetter/testssl.sh/issues/134
+     local nodeip="$(tr -d '[]' <<< $NODEIP)"          # sockets do not need the square brackets we have of IPv6 addresses
+                                                       # we just need do it here, that's all!
 
      if [[ "$NODE" == *.local ]]; then
           if which avahi-resolve &>/dev/null; then
-               rDNS=$(avahi-resolve -a $NODEIP 2>/dev/null | awk '{ print $2 }')
+               rDNS=$(avahi-resolve -a $nodeip 2>/dev/null | awk '{ print $2 }')
           elif which dig &>/dev/null; then
-               rDNS=$(dig -x $NODEIP @224.0.0.251 -p 5353 +notcp +noall +answer | awk '/PTR/ { print $NF }')
+               rDNS=$(dig -x $nodeip @224.0.0.251 -p 5353 +notcp +noall +answer | awk '/PTR/ { print $NF }')
           fi
      elif which dig &> /dev/null; then
-          rDNS=$(dig -x $NODEIP +noall +answer | awk  '/PTR/ { print $NF }')    # +short returns also CNAME, e.g. openssl.org
+          rDNS=$(dig -x $nodeip +noall +answer | awk  '/PTR/ { print $NF }')    # +short returns also CNAME, e.g. openssl.org
      elif which host &> /dev/null; then
-          rDNS=$(host -t PTR $NODEIP 2>/dev/null | awk '/pointer/ { print $NF }')
+          rDNS=$(host -t PTR $nodeip 2>/dev/null | awk '/pointer/ { print $NF }')
      elif which drill &> /dev/null; then
-          rDNS=$(drill -x ptr $NODEIP 2>/dev/null | awk '/^\;\;\sANSWER\sSECTION\:$/,/\;\;\sAUTHORITY\sSECTION\:$/ { print $5,$6 }' | sed '/^\s$/d')
+          rDNS=$(drill -x ptr $nodeip 2>/dev/null | awk '/^\;\;\sANSWER\sSECTION\:$/,/\;\;\sAUTHORITY\sSECTION\:$/ { print $5,$6 }' | sed '/^\s$/d')
      elif which nslookup &> /dev/null; then
-          rDNS=$(nslookup -type=PTR $NODEIP 2>/dev/null | grep -v 'canonical name =' | grep 'name = ' | awk '{ print $NF }' | sed 's/\.$//')
+          rDNS=$(nslookup -type=PTR $nodeip 2>/dev/null | grep -v 'canonical name =' | grep 'name = ' | awk '{ print $NF }' | sed 's/\.$//')
      fi
      OPENSSL_CONF="$saved_openssl_conf"      # see https://github.com/drwetter/testssl.sh/issues/134
      rDNS="$(echo $rDNS)"


### PR DESCRIPTION
This patch should fix https://github.com/drwetter/testssl.sh/issues/365, the IPv6 lookup problem. 

Without this patch, PTR records cannot be found for IPv6 addresses due to superfluous brackets around the address. Furthermore, the patch supports freaky OpenSSL builds, like Gentoo’s, where the binary doesn’t support the bracketed IPv6 address as part of the -connect parameter and requires the unbracketed address instead.

Dirk, if you don’t like https://github.com/drwetter/testssl.sh/commit/2c69e83f5b98974ffe87422fa45a30d4824ed4a9, please at least merge https://github.com/drwetter/testssl.sh/commit/cf62353fc6d55322b927baad8467f67521a7b497 because that will be required by anybody who wants to see rDNS for his IPv6 test runs.
