### PR TITLE
Printing of subjectAltName extension

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3442,15 +3442,18 @@ certificate_info() {
      fi
      fileout "${json_prefix}cn" "$cnok" "$cnfinding"
 
-     sans=$($OPENSSL x509 -in $HOSTCERT -noout -text 2>>$ERRFILE | grep -A3 "Subject Alternative Name" | grep "DNS:" | \
-          sed -e 's/DNS://g' -e 's/ //g' -e 's/,/ /g' -e 's/othername:<unsupported>//g')
-#                                                       ^^^ CACert
+     sans=$($OPENSSL x509 -in $HOSTCERT -noout -text 2>>$ERRFILE | grep -A3 "Subject Alternative Name" | \
+          egrep "DNS:|IP Address:|email:|URI:|DirName:|Registered ID:" | \
+          sed -e 's/ *DNS://g' -e 's/ *IP Address://g' -e 's/ *email://g' -e 's/ *URI://g' -e 's/ *DirName://g' \
+              -e 's/ *Registered ID://g' -e 's/,/\n/g' \
+              -e 's/ *othername:<unsupported>//g' -e 's/ *X400Name:<unsupported>//g' -e 's/ *EdiPartyName:<unsupported>//g')
+#                   ^^^ CACert
      out "$indent"; pr_bold " subjectAltName (SAN)         "
      if [[ -n "$sans" ]]; then
-          for san in $sans; do
-               pr_dquoted "$san"
+          while read san; do
+               [[ -n "$san" ]] && pr_dquoted "$san"
                out " "
-          done
+          done <<< "$sans"
           fileout "${json_prefix}san" "INFO" "subjectAltName (SAN) : $sans"
      else
           out "-- "


### PR DESCRIPTION
The current code in certificate_info() for extracting the subjectAltName extension from a certificate is:
```
     sans=$($OPENSSL x509 -in $HOSTCERT -noout -text 2>>$ERRFILE | grep -A3 "Subject Alternative Name" | grep "DNS:" | \
          sed -e 's/DNS://g' -e 's/ //g' -e 's/,/ /g' -e 's/othername:<unsupported>//g')
#                                                       ^^^ CACert
```
with this code, the contents of the subjectAltName extension are not printed unless the extension contains a DNS name. If a DNS name is present, then the string "DNS:" is removed from any DNS names and any instance of "othername:<unsupported>" is not displayed, but all other names in the subjectAltName extension are displayed as they are output by OpenSSL (with the exception of directory names, where all space characters are removed from the names). For example, if OpenSSL displays the subjectAltName extension as:

```
            X509v3 Subject Alternative Name: 
                DNS:localhost, IP Address:127.0.0.1, othername:<unsupported>, IP Address:0:0:0:0:0:0:0:1, email:anemailaddress@example.com, URI:http://localhost, DNS:notreal.example.com, DirName:/C=US/O=Test testssl.sh Test Certificates/CN=Funny SAN names Test Certificate, Registered ID:2.16.840.1.101.3.2.1.48.87
```
then testssl.sh displays it as:
```
 subjectAltName (SAN)         "localhost" "IPAddress:127.0.0.1" "IPAddress:0:0:0:0:0:0:0:1" "email:anemailaddress@example.com" "URI:http://localhost" "notreal.example.com" "DirName:/C=US/O=Testtestssl.shTestCertificates/CN=FunnySANnamesTestCertificate" "RegisteredID:2.16.840.1.101.3.2.1.48.87"
```
This PR address these issues by:
- printing the contents of the SAN as long as at least one name that is supported by OpenSSL is present in the extension (OpenSSL supports DNS names, IP addresses, email addresses, URIs, directory names, and registered IDs).
- removing all names that are not supported by OpenSSL (other name, X.400 names, and EDI party names).
- not removing space characters from within directory names.

The result for the above example is:
```
 subjectAltName (SAN)         "localhost" "127.0.0.1"  "0:0:0:0:0:0:0:1" "anemailaddress@example.com" "http://localhost" "notreal.example.com" "/C=US/O=Test testssl.sh Test Certificates/CN=Funny SAN names Test Certificate" "2.16.840.1.101.3.2.1.48.87"
```
