### PR TITLE
Missing closing parenteses in help output for --openssl

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6817,7 +6817,7 @@ tuning options (can also be preset via environment variables):
      --bugs                        enables the "-bugs" option of s_client, needed e.g. for some buggy F5s
      --assuming-http               if protocol check fails it assumes HTTP protocol and enforces HTTP checks
      --ssl-native                  fallback to checks with OpenSSL where sockets are normally used
-     --openssl <PATH>              use this openssl binary (default: look in \$PATH, \$RUN_DIR of $PROG_NAME
+     --openssl <PATH>              use this openssl binary (default: look in \$PATH, \$RUN_DIR of $PROG_NAME)
      --proxy <host>:<port>         connect via the specified HTTP proxy
      -6                            use also IPv6. Works only with supporting OpenSSL version and IPv6 connectivity
      --sneaky                      leave less traces in target logs: user agent, referer


### PR DESCRIPTION
Missing a closing parentheses `)`.

------

This is a very minor issue and doesn't affect functionality.  The lack of a closing parentheses character was irking me on that one line of the help output.