### PR TITLE
Fix case where query fails without SNI

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3839,7 +3839,7 @@ certificate_info() {
      local ocsp_response=$5
      local ocsp_response_status=$6
      local cert_sig_algo cert_sig_hash_algo cert_key_algo
-     local expire days2expire secs2warn ocsp_uri crl startdate enddate issuer_C issuer_O issuer sans san cn cn_nosni
+     local expire days2expire secs2warn ocsp_uri crl startdate enddate issuer_C issuer_O issuer sans san cn cn_nosni=""
      local cert_fingerprint_sha1 cert_fingerprint_sha2 cert_fingerprint_serial
      local policy_oid
      local spaces=""
@@ -4079,8 +4079,10 @@ certificate_info() {
 
      # no cipher suites specified here. We just want the default vhost subject
      $OPENSSL s_client $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $OPTIMAL_PROTO 2>>$ERRFILE </dev/null | awk '/-----BEGIN/,/-----END/ { print $0 }'  >$HOSTCERT.nosni
-     cn_nosni="$(get_cn_from_cert "$HOSTCERT.nosni")"
-     [[ -z "$cn_nosni" ]] && cn_nosni="no CN field in subject"
+     if grep -q "\-\-\-\-\-BEGIN" "$HOSTCERT.nosni"; then
+          cn_nosni="$(get_cn_from_cert "$HOSTCERT.nosni")"
+          [[ -z "$cn_nosni" ]] && cn_nosni="no CN field in subject"
+     fi
 
 #FIXME: check for SSLv3/v2 and look whether it goes to a different CN (probably not polite)
 


### PR DESCRIPTION
In `certificate_info()`, there are two possible outputs depending on whether `$cn_nosni` is empty or contains `*"no CN field"*`:
```
          elif [[ -z "$cn_nosni" ]]; then
               out " (request w/o SNI didn't succeed";
               cnfinding+=" (request w/o SNI didn't succeed"
               if [[ $cert_sig_algo =~ ecdsa ]]; then
                    out ", usual for EC certificates"
                    cnfinding+=", usual for EC certificates"
               fi
               outln ")"
               cnfinding+=")"
          elif [[ "$cn_nosni" == *"no CN field"* ]]; then
               outln ", (request w/o SNI: $cn_nosni)"
               cnfinding+=", (request w/o SNI: $cn_nosni)"
```
However, `$cn_nosni` can never be empty due to a preceding line:
```
 [[ -z "$cn_nosni" ]] && cn_nosni="no CN field in subject"
```
So, this PR changes the code to only set `$cn_nosni` to a non-empty string ("no CN field in subject") if the call to `$OPENSSL s_client` without SNI succeeded and returned a certificate.