### PR TITLE
Fix check for self-signed certificate

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4151,7 +4151,7 @@ certificate_info() {
      issuer_C="$(awk -F'=' '/ C=/ { print $2 }' <<< "$issuer")"
      issuer_DC="$(awk -F'=' '/DC=/ { print $2 }' <<< "$issuer")"
 
-     if [[ "$issuer_O" == "issuer=" ]] || [[ "$issuer_O" == "issuer= " ]] || [[ "$issuer_CN" == "$CN" ]]; then
+     if [[ "$issuer_O" == "issuer=" ]] || [[ "$issuer_O" == "issuer= " ]] || [[ "$issuer_CN" == "$cn" ]]; then
           pr_svrty_criticalln "self-signed (NOT ok)"
           fileout "${json_prefix}issuer" "NOT ok" "Issuer: selfsigned (NOT ok)"
      else


### PR DESCRIPTION
The check for whether a certificate is self-signed was using the undefined variable `$CN` rather than `$cn`.

Note: I didn't change the rest of the line, but I can't understand why `issuer_O` being `issuer=` or `issuer= ' would indicate that a certificate is self-signed certificate.

It seems that a better check would be to compare the entire issuer name to the entire subject name, since the names could be different even if they have the same `CN` attribute:

```
   issuer=$($OPENSSL x509 -in "$HOSTNAME" -noout -issuer | sed '/^issuer= //')
   subject=$($OPENSSL x509 -in "$HOSTNAME" -noout -subject | sed 's/^subject= //')
   if [[ "$issuer" == "$subject ]]; then
     # certificate is self-signed
   else
    # certificate is not self-signed
   fi
```