### PR TITLE
 SSLv2 fixes for determine_optimal_proto()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7839,9 +7839,11 @@ determine_optimal_proto() {
                all_failed=0
           done
           debugme echo "OPTIMAL_PROTO: $OPTIMAL_PROTO"
-          pr_warningln "$NODEIP:$PORT appears to only support SSLv2."
-          ignore_no_or_lame " Type \"yes\" to accept some false negatives or positives "
-          [[ $? -ne 0 ]] && exit -2
+          if [[ "$OPTIMAL_PROTO" == "-ssl2" ]]; then
+               pr_warningln "$NODEIP:$PORT appears to only support SSLv2."
+               ignore_no_or_lame " Type \"yes\" to accept some false negatives or positives "
+               [[ $? -ne 0 ]] && exit -2
+          fi
      fi
      grep -q '^Server Temp Key' $TMPFILE && HAS_DH_BITS=true     # FIX #190
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -7840,7 +7840,7 @@ determine_optimal_proto() {
           done
           debugme echo "OPTIMAL_PROTO: $OPTIMAL_PROTO"
           if [[ "$OPTIMAL_PROTO" == "-ssl2" ]]; then
-               pr_warningln "$NODEIP:$PORT appears to only support SSLv2."
+               pr_magentaln "$NODEIP:$PORT appears to only support SSLv2."
                ignore_no_or_lame " Type \"yes\" to accept some false negatives or positives "
                [[ $? -ne 0 ]] && exit -2
           fi


### PR DESCRIPTION
This PR makes three changes to `determine_optimal_proto()`:
* It no longer tries an empty string for `$OPTIMAL_PROTO` twice.
* It does not include `-servername` for `-ssl2` or `-ssl3`, since some versions of OpenSSL that support SSLv2 will fail if `s_client` is provided both the `-ssl2` and `-servername` options.
* It displays a warning if `$OPTIMAL_PROTO` is `-ssl2`, since some tests in testssl.sh will not work correctly for SSLv2-only servers.