### PR TITLE
Don't ignore response to old OpenSSL warning

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7116,6 +7116,7 @@ check4openssl_oldfarts() {
                *)   outln " Update openssl binaries or compile from github.com/PeterMosmans/openssl" ;;
           esac
           ignore_no_or_lame " Type \"yes\" to accept some false negatives or positives "
+          [[ $? -ne 0 ]] && exit -2
      fi
      outln
 }


### PR DESCRIPTION
In the check for old versions of OpenSSL, the results of the call to `ignore_no_or_lame()` are ignored, and so the program continues even if the user enters `no`.