### PR TITLE
Fix "--devel" with SSLv2

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8527,9 +8527,8 @@ lets_roll() {
      determine_rdns
      determine_service "$1"        # any starttls service goes here
 
-     $do_tls_sockets && { [[ $TLS_LOW_BYTE -eq 22 ]] && \
-          sslv2_sockets || \
-          tls_sockets "$TLS_LOW_BYTE" "$HEX_CIPHER"; echo "$?" ; exit 0; }
+     $do_tls_sockets && [[ $TLS_LOW_BYTE -eq 22 ]] && { sslv2_sockets; echo "$?" ; exit 0; }
+     $do_tls_sockets && [[ $TLS_LOW_BYTE -ne 22 ]] && { tls_sockets "$TLS_LOW_BYTE" "$HEX_CIPHER"; echo "$?" ; exit 0; }
      $do_test_just_one && test_just_one ${single_cipher}
 
      # all top level functions  now following have the prefix "run_"


### PR DESCRIPTION
If testssl.sh is called with `--devel 22` and the response from `sslv2_sockets()` is not 0, then `tls_sockets()` will be called, and the result of the `tls_sockets()` command will be output rather than the result of the `sslv2_sockets()` command.