### PR TITLE
Warning on Poodle test when no local SSLv3 support

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6447,10 +6447,11 @@ run_ssl_poodle() {
 
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for SSLv3 POODLE (Padding Oracle On Downgraded Legacy Encryption) " && outln
      pr_bold " POODLE, SSL"; out " (CVE-2014-3566)               "
+     locally_supported "-ssl3" || return 1
      cbc_ciphers=$(actually_supported_ciphers $cbc_ciphers)
 
      debugme echo $cbc_ciphers
-     $OPENSSL s_client -ssl3 $STARTTLS $BUGS -cipher $cbc_ciphers -connect $NODEIP:$PORT $PROXY $SNI >$TMPFILE 2>$ERRFILE </dev/null
+     $OPENSSL s_client -ssl3 $STARTTLS $BUGS -cipher $cbc_ciphers -connect $NODEIP:$PORT $PROXY >$TMPFILE 2>$ERRFILE </dev/null
      sclient_connect_successful $? $TMPFILE
      sclient_success=$?
      [[ "$DEBUG" -eq 2 ]] && egrep -q "error|failure" $ERRFILE | egrep -av "unable to get local|verify error"

--- a/testssl.sh
+++ b/testssl.sh
@@ -6447,7 +6447,7 @@ run_ssl_poodle() {
 
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for SSLv3 POODLE (Padding Oracle On Downgraded Legacy Encryption) " && outln
      pr_bold " POODLE, SSL"; out " (CVE-2014-3566)               "
-     locally_supported "-ssl3" || return 1
+     locally_supported "-ssl3" || return 0
      cbc_ciphers=$(actually_supported_ciphers $cbc_ciphers)
 
      debugme echo $cbc_ciphers


### PR DESCRIPTION
If the version of OpenSSL being used doesn't support `s_client -ssl3` (e.g., OpenSSL 1.1.0), `run_ssl_poodle()` displays "not vulnerable (OK)" even though it can't test whether the server is vulnerable.

This PR fixes it so that a "Local problem" warning is displayed if `s_client -ssl3` isn't supported.

The PR also removes the `$SNI` from the call to `$OPENSSL s_client`, since SSLv3 doesn't have SNI.