### PR TITLE
Output correct error for unsupported certificate purpose

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3697,6 +3697,7 @@ verify_retcode_helper() {
 
 	case $retcode in
 		# codes from ./doc/apps/verify.pod | verify(1ssl)
+		26) out "(unsupported certificate purpose)" ;; 	# X509_V_ERR_INVALID_PURPOSE
 		24) out "(certificate unreadable)" ;; 	# X509_V_ERR_INVALID_CA
 		23) out "(certificate revoked)" ;; 		# X509_V_ERR_CERT_REVOKED
 		21) out "(chain incomplete, only 1 cert provided)" ;; 	# X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE
@@ -3779,8 +3780,8 @@ determine_trust() {
 		if ! $some_ok; then
 		     # all failed (we assume with the same issue), we're displaying the reason
                out " "
-			verify_retcode_helper "${verify_retcode[2]}"
-               fileout "${json_prefix}chain_of_trust" "NOT ok" "All certificate trust checks failed: $(verify_retcode_helper "${verify_retcode[2]}"). $addtl_warning"
+			verify_retcode_helper "${verify_retcode[1]}"
+               fileout "${json_prefix}chain_of_trust" "NOT ok" "All certificate trust checks failed: $(verify_retcode_helper "${verify_retcode[1]}"). $addtl_warning"
 		else
 			# is one ok and the others not ==> display the culprit store
 			if $some_ok ; then


### PR DESCRIPTION
This PR is in response to issue #454. I tried repeating the reported problem by creating a certificate in which the extendedKeyUsage extension was present and only included the anyExtendedKeyUsage OID. In running the test, I discovered two problems.

First, when `determine_trust()` is calling `verify_retcode_helper()` to display the reason that path validation failed, it assumes that there are at least two certificate bundles provided. (I was running the test using just one certificate bundle, containing my local root.) So, I changed `determine_trust()` to use `${verify_retcode[1]}` rather than `${verify_retcode[2]}` in the case that all bundles failed (it seems that 2 vs. 1 was an arbitrary choice).

Once that was fixed, testssl.sh output "NOT ok  (unknown, pls report) 26". So, the second thing this PR fixes is to output "NOT ok (unsupported certificate purpose)" if OpenSSL responds with an unsupported certificate purpose error.