### PR TITLE
run_rp_banner(), run_application_banner(): Three issues

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1182,7 +1182,7 @@ run_application_banner() {
           outln "--"
           fileout "app_banner" "INFO" "No Application Banners found"
      else
-          cat $TMPFILE | while read line; do
+          while IFS='' read -r line; do
                line=$(strip_lf "$line")
                if ! $first; then
                     out "$spaces"
@@ -1191,7 +1191,7 @@ run_application_banner() {
                fi
                emphasize_stuff_in_headers "$line"
                app_banners="${app_banners}${line}"
-          done
+          done < "$TMPFILE"
           fileout "app_banner" "WARN" "Application Banners found: $app_banners"
      fi
      tmpfile_handle $FUNCNAME.txt

--- a/testssl.sh
+++ b/testssl.sh
@@ -1156,7 +1156,7 @@ run_rp_banner() {
                     first=false
                fi
                emphasize_stuff_in_headers "$line"
-               rp_banners="$rp_bannersline"
+               rp_banners="${rp_banners}${line}"
           done < $TMPFILE
           fileout "rp_header" "INFO" "Reverse proxy banner(s) found: $rp_banners"
      fi
@@ -1190,7 +1190,7 @@ run_application_banner() {
                     first=false
                fi
                emphasize_stuff_in_headers "$line"
-               app_banners="$app_bannersline"
+               app_banners="${app_banners}${line}"
           done
           fileout "app_banner" "WARN" "Application Banners found: $app_banners"
      fi

--- a/testssl.sh
+++ b/testssl.sh
@@ -1147,7 +1147,7 @@ run_rp_banner() {
      if [[ $? -ne 0 ]]; then
           outln "--"
           fileout "rp_header" "INFO" "No reverse proxy banner found"
-    else
+     else
           while read line; do
                line=$(strip_lf "$line")
                if ! $first; then


### PR DESCRIPTION
- Fix two instances of referenced but not assigned variables.
- Fix a modified in subshell bug in `run_application_banner()`
- Fix indentation in `run_rp_banner()`