### PR TITLE
Remove duplicated do_rc4 in debug_globals()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8351,7 +8351,7 @@ debug_globals() {
      local gbl
 
      for gbl in do_allciphers do_vulnerabilities do_beast do_breach do_ccs_injection do_cipher_per_proto do_crime \
-               do_freak do_logjam do_drown do_header do_heartbleed do_rc4 do_mx_all_ips do_pfs do_protocols do_rc4 do_renego \
+               do_freak do_logjam do_drown do_header do_heartbleed do_mx_all_ips do_pfs do_protocols do_rc4 do_renego \
                do_std_cipherlists do_server_defaults do_server_preference do_spdy do_http2 do_ssl_poodle do_tls_fallback_scsv \
                do_client_simulation do_test_just_one do_tls_sockets do_mass_testing do_display_only; do
           printf "%-22s = %s\n" $gbl "${!gbl}"


### PR DESCRIPTION
do_rc4 is duplicated in debug_globals(), but this duplication is unnecessary.

Remove this duplication and make the list in debug_globals() consistent with the one in query_globals().