### PR TITLE
Increase HEADER_MAXSLEEP value to 10

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -162,7 +162,7 @@ SERVER_SIZE_LIMIT_BUG=false             # Some servers have either a ClientHello
 
 # tuning vars, can not be set by a cmd line switch
 EXPERIMENTAL=${EXPERIMENTAL:-false}
-HEADER_MAXSLEEP=${HEADER_MAXSLEEP:-5}   # we wait this long before killing the process to retrieve a service banner / http header
+HEADER_MAXSLEEP=${HEADER_MAXSLEEP:-10}   # we wait this long before killing the process to retrieve a service banner / http header
 readonly MAX_WAITSOCK=10                # waiting at max 10 seconds for socket reply
 readonly CCS_MAX_WAITSOCK=5             # for the two CCS payload (each)
 readonly HEARTBLEED_MAX_WAITSOCK=8      # for the heartbleed payload


### PR DESCRIPTION
There is a case where using this on a network with some (slight) instability or slowness can sometimes fail to detect or retrieve headers.  Currently, in my testing here, I've seen this range anywhere from 5.7 seconds to 7.8 seconds for a response from getting the headers, so maybe we should consider increasing the time slightly for the header max sleep value.  10 seconds is arbitrary, but still 'short' enough to die off quickly.

(Feel free to discuss or decline, but I'm hoping we can incorporate this to adapt for slightly slower networks)