### PR TITLE
Apple ATS9 client simulation

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2822,6 +2822,24 @@ run_client_simulation() {
      minEcdsaBits+=(-1)
      requiresSha2+=(false)
 
+     names+=("Apple ATS 9 iOS 9        ")
+     short+=("safari_9_osx1011")
+     protos+=("-no_ssl2 -no_ssl3 -no_tls1 -no_tls1_1")
+     ciphers+=("ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA")
+     tlsvers+=("-tls1_2")
+     sni+=("$SNI")
+     warning+=("")
+     handshakebytes+=("16030100b9010000b50303282275d1356ba8ceec8897786197b80f96d83a06d9205200a677f850c4b822f2000018c02cc02bc024c023c00ac009c030c02fc028c027c01300ff0201000073000b000403000102000a003a0038000e000d0019001c000b000c001b00180009000a001a00160017000800060007001400150004000500120013000100020003000f0010001100230000000d0020001e060106020603050105020503040104020403030103020303020102020203000f000101")
+     lowest_protocol+=("0x0303")
+     highest_protocol+=("0x0303")
+     service+=("HTTP")
+     minDhBits+=(768)
+     maxDhBits+=(-1)
+     minRsaBits+=(-1)
+     maxRsaBits+=(8192)
+     minEcdsaBits+=(-1)
+     requiresSha2+=(false)
+
      outln
      if "$using_sockets"; then
           pr_headlineln " Running browser simulations via sockets (experimental) "


### PR DESCRIPTION
I had the need to test for Apple ATS9 compatibility last week, and found that only SSLLabs had the option. This client simulation has been created using the cipher/protocol spec from SSLLabs and the handshake bytes for that spec from the bundled openssl.