### PR TITLE
Fix neat_list() for Camellia GCM

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1937,6 +1937,7 @@ neat_list(){
 
      enc="${enc//POLY1305/}"            # remove POLY1305
      enc="${enc//\//}"                  # remove "/"
+     enc="${enc/CamelliaGCM/Camellia}"  # "CamelliaGCM" is too long
 
      echo "$export" | grep -iq export && strength="$strength,exp"
 


### PR DESCRIPTION
The string "CamelliaGCM" is too long for the "Encryption" column printed by `neat_list()`. So, either "CamelliaGCM" needs to be shortened to "Camellia" (as this PR does), or the "Encryption" column needs to be made wider.