### PR TITLE
More fixes for missing cipher mapping file

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7102,7 +7102,8 @@ parse_tls_serverhello() {
 
      # Now parse the server key exchange message
      if [[ $tls_serverkeyexchange_ascii_len -ne 0 ]]; then
-          if [[ $rfc_cipher_suite =~ "TLS_ECDHE_" ]] || [[ $rfc_cipher_suite =~ "TLS_ECDH_anon" ]]; then
+          if [[ $rfc_cipher_suite =~ "TLS_ECDHE_" ]] || [[ $rfc_cipher_suite =~ "TLS_ECDH_anon" ]] || \
+             [[ $rfc_cipher_suite == ECDHE* ]] || [[ $rfc_cipher_suite == AECDH* ]]; then
                if [[ $tls_serverkeyexchange_ascii_len -lt 6 ]]; then
                     debugme echo "Malformed ServerKeyExchange Handshake message in ServerHello."
                     tmpfile_handle $FUNCNAME.txt
@@ -7153,7 +7154,9 @@ parse_tls_serverhello() {
                     debugme echo "dh_bits:                $named_curve_str, $dh_bits bits"
                     echo "Server Temp Key: $named_curve_str, $dh_bits bits" >> $TMPFILE
                fi
-          elif [[ $rfc_cipher_suite =~ "TLS_DHE_" ]] || [[ $rfc_cipher_suite =~ "TLS_DH_anon" ]]; then
+          elif [[ $rfc_cipher_suite =~ "TLS_DHE_" ]] || [[ $rfc_cipher_suite =~ "TLS_DH_anon" ]] || \
+               [[ $rfc_cipher_suite == "DHE-"* ]] || [[ $rfc_cipher_suite == "EDH-"* ]] || \
+               [[ $rfc_cipher_suite == "EXP1024-DHE-"* ]]; then
                # For DH ephemeral keys the first field is p, and the length of
                # p is the same as the length of the public key.
                if [[ $tls_serverkeyexchange_ascii_len -lt 4 ]]; then


### PR DESCRIPTION
> The dh_bits are still not shown, maybe because of #531.

This PR fixes the issue of dh_bits not being shown if the cipher-mapping.txt file is missing. The problem is that the code in `parse_tls_serverhello()` that parses the ServerKeyExchange message assumes that `$rfc_cipher_suite` has the RFC version of the name the cipher suite. However, if the cipher-mapping.txt file is missing, `$rfc_cipher_suite` will have the OpenSSL name of the cipher suite. This PR changes the code to recognize either the RFC or OpenSSL names for ciphers with ephemeral DH or ECDH keys.