### PR TITLE
don't parse invalid server reply for SSLv2

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6349,6 +6349,7 @@ parse_sslv2_serverhello() {
      # [cipher spec length] ==> ciphers GOOD: HERE ARE ALL CIPHERS ALREADY!
 
      local ret=3
+     local invalid=0
      if [[ "$2" == "true" ]]; then
           echo "======================================" > $TMPFILE
      fi
@@ -6372,6 +6373,7 @@ parse_sslv2_serverhello() {
 
           if [[ $v2_hello_initbyte != "8" ]] || [[ $v2_hello_handshake != "04" ]]; then
                ret=1
+               invalid=1
                if [[ $DEBUG -ge 2 ]]; then
                     echo "no correct server hello"
                     echo "SSLv2 server init byte:    0x0$v2_hello_initbyte"
@@ -6400,7 +6402,7 @@ parse_sslv2_serverhello() {
      fi
 
      # Output list of supported ciphers
-     if [[ "$2" == "true" ]]; then
+     if [[ "$2" == "true" && "$invalid" == 0 ]]; then
           let offset=26+$certificate_len
           nr_ciphers_detected=$((V2_HELLO_CIPHERSPEC_LENGTH / 3))
           for (( i=0 ; i<nr_ciphers_detected; i++ )); do


### PR DESCRIPTION
SSLv2 is dying. However, we test against it. Let’s not waste precious cycles on parsing an already invalid response against 300+ possible ciphers.

Note there is another block of code around [L6390](https://github.com/drwetter/testssl.sh/compare/2.9dev...typingArtist:parsing_sslv2_shortcut?expand=1#diff-2b772c01e86977452d2db64b3031f913R6392) that could be guarded as well … what do you think @drwetter?