### PR TITLE
run_allciphers() bug fixes

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2321,9 +2321,9 @@ run_allciphers() {
      else
           pr_headlineln " Testing all $nr_ciphers_tested locally available ciphers against the server, ordered by encryption strength "
           outln
-          [[ $TLS_NR_CIPHERS == 0 ]] && pr_warning " Cipher mapping not available, doing a fallback to openssl"
+          [[ $TLS_NR_CIPHERS == 0 ]] && ! "$SSL_NATIVE" && ! "$FAST" && pr_warning " Cipher mapping not available, doing a fallback to openssl"
           if ! "$HAS_DH_BITS"; then
-               [[ $TLS_NR_CIPHERS == 0 ]] && out "."
+               [[ $TLS_NR_CIPHERS == 0 ]] && ! "$SSL_NATIVE" && ! "$FAST" && out "."
                pr_warningln " Your $OPENSSL cannot show DH/ECDH bits"
           fi
      fi
@@ -2450,7 +2450,7 @@ run_allciphers() {
      done
 
      for (( i=0 ; i<nr_ciphers; i++ )); do
-          if "${ciphers_found[i]}" || ( "$SHOW_EACH_C" && ( "$using_sockets" || "${TLS_CIPHER_OSSL_SUPPORTED[i]}" ) ); then
+          if "${ciphers_found[i]}" || ( "$SHOW_EACH_C" && ( "$using_sockets" || "${ossl_supported[i]}" ) ); then
                export=${export2[i]}
                neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}"
                available=""


### PR DESCRIPTION
This PR fixes two minor bugs in run_allciphers():

* If `$SSL_NATIVE` or `$FAST` is `true`, then the cipher mapping file will not be used (unless `$OPENSSL ciphers` does not support the `-V` option), so there is no "fallback" to openssl, even if `[[ $TLS_NR_CIPHERS == 0 ]]`.

* If `$using_sockets` is `false` and `$SHOW_EACH_C` is `true`, then `ossl_supported` should be checked to see if the cipher was tested, not `TLS_CIPHER_OSSL_SUPPORTED`.