### PR TITLE
Fix alignment problem in test_just_one()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2229,8 +2229,6 @@ test_just_one(){
                          if [[ $sclient_success -eq 0 ]]; then
                               dhlen=$(read_dhbits_from_file $TMPFILE quiet)
                               kx="$kx $dhlen"
-                         else
-                              kx="$kx$grey TBD $off "
                          fi
                     fi
                     neat_list $HEXC $ciph "$kx" $enc


### PR DESCRIPTION
When `test_just_one()` uses `neat_list()` with a cipher that is not available and that uses DH for key exchange, the columns do not line up correctly. `test_just_one()` adds "TBD" in gray to "DH", and while `neat_list()` tries to adjust for the presence of color codes, it doesn't seem to correctly handle the gray color code here.

Rather than try to fix this in `neat_list()`, I propose to just remove the "TBD". Adding it is inconsistent with other functions (like `run_allciphers()`), and it seems inappropriate, since there is nothing "to be determined," as the cipher suite isn't supported by the server.

If adding "TBD" were appropriate anywhere, it would seem to be in cases in which the server does support the cipher, but the number of bits in the ephemeral key couldn't be determined because the version of OpenSSL being used can't show DH/ECDH bits. (Not that I'm proposing this. I think the one-line warning, "(Your $OPENSSL cannot show DH/ECDH bits)", is enough.

Here is an example of `test_just_one()` with some ciphers not supported by the server that use DH key exchange:

```
 Testing single cipher with word pattern "CAMELLIA" (ignore case) 

Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.  Encryption Bits     Cipher Suite Name (RFC)
---------------------------------------------------------------------------------------------------------------------------
 xc077   ECDHE-RSA-CAMELLIA256-SHA384      ECDH TBD   Camellia  256      TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384           not a/v
 xc073   ECDHE-ECDSA-CAMELLIA256-SHA384    ECDH TBD   Camellia  256      TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384         not a/v
 xc4     DHE-RSA-CAMELLIA256-SHA256        DH TBD   Camellia  256      TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256             not a/v
 xc3     DHE-DSS-CAMELLIA256-SHA256        DH TBD   Camellia  256      TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256             not a/v
 xc2     DH-RSA-CAMELLIA256-SHA256         DH/RSA     Camellia  256      TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256              not a/v
 xc1     DH-DSS-CAMELLIA256-SHA256         DH/DSS     Camellia  256      TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256              not a/v
 x88     DHE-RSA-CAMELLIA256-SHA           DH 2048    Camellia  256      TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA                available
 x87     DHE-DSS-CAMELLIA256-SHA           DH TBD   Camellia  256      TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA                not a/v
 x86     DH-RSA-CAMELLIA256-SHA            DH/RSA     Camellia  256      TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA                 not a/v
 x85     DH-DSS-CAMELLIA256-SHA            DH/DSS     Camellia  256      TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA                 not a/v
 xc5     ADH-CAMELLIA256-SHA256            DH TBD   Camellia  256      TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256             not a/v
 x89     ADH-CAMELLIA256-SHA               DH TBD   Camellia  256      TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA                not a/v
 xc079   ECDH-RSA-CAMELLIA256-SHA384       ECDH/RSA   Camellia  256      TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384            not a/v
 xc075   ECDH-ECDSA-CAMELLIA256-SHA384     ECDH/ECDSA Camellia  256      TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384          not a/v
 xc0     CAMELLIA256-SHA256                RSA        Camellia  256      TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256                 not a/v
 x84     CAMELLIA256-SHA                   RSA        Camellia  256      TLS_RSA_WITH_CAMELLIA_256_CBC_SHA                    not a/v
 xc076   ECDHE-RSA-CAMELLIA128-SHA256      ECDH TBD   Camellia  128      TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256           not a/v
 xc072   ECDHE-ECDSA-CAMELLIA128-SHA256    ECDH TBD   Camellia  128      TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256         not a/v
 xbe     DHE-RSA-CAMELLIA128-SHA256        DH TBD   Camellia  128      TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256             not a/v
 xbd     DHE-DSS-CAMELLIA128-SHA256        DH TBD   Camellia  128      TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256             not a/v
 xbc     DH-RSA-CAMELLIA128-SHA256         DH/RSA     Camellia  128      TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256              not a/v
 xbb     DH-DSS-CAMELLIA128-SHA256         DH/DSS     Camellia  128      TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256              not a/v
 x45     DHE-RSA-CAMELLIA128-SHA           DH 2048    Camellia  128      TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA                available
 x44     DHE-DSS-CAMELLIA128-SHA           DH TBD   Camellia  128      TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA                not a/v
 x43     DH-RSA-CAMELLIA128-SHA            DH/RSA     Camellia  128      TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA                 not a/v
 x42     DH-DSS-CAMELLIA128-SHA            DH/DSS     Camellia  128      TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA                 not a/v
 xbf     ADH-CAMELLIA128-SHA256            DH TBD   Camellia  128      TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256             not a/v
 x46     ADH-CAMELLIA128-SHA               DH TBD   Camellia  128      TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA                not a/v
 xc078   ECDH-RSA-CAMELLIA128-SHA256       ECDH/RSA   Camellia  128      TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256            not a/v
 xc074   ECDH-ECDSA-CAMELLIA128-SHA256     ECDH/ECDSA Camellia  128      TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256          not a/v
 xba     CAMELLIA128-SHA256                RSA        Camellia  128      TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256                 not a/v
 x41     CAMELLIA128-SHA                   RSA        Camellia  128      TLS_RSA_WITH_CAMELLIA_128_CBC_SHA                    not a/v
```