### PR TITLE
Mark export ciphers in run_rc4()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9382,6 +9382,7 @@ run_rc4() {
                fi
                if "$WIDE"; then
                     #FIXME: JSON+CSV in wide mode is missing
+                    export="${export2[i]}"
                     neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}"
                     if "$SHOW_EACH_C"; then
                          if "${ciphers_found[i]}"; then


### PR DESCRIPTION
This PR adds ",exp" to the bits column when `run_rc4()` is run in the "--wide" mode and the cipher is an export cipher. This makes the wide mode of `run_rc4()` align with other functions, such as `run_allciphers()`.