### PR TITLE
testssl.sh hangs on local testing

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3861,7 +3861,7 @@ run_client_simulation() {
 # generic function whether $1 is supported by s_client ($2: string to display)
 locally_supported() {
      [[ -n "$2" ]] && out "$2 "
-     if $OPENSSL s_client "$1" 2>&1 | grep -aq "unknown option"; then
+     if $OPENSSL s_client "$1" -connect x 2>&1 | grep -aq "unknown option"; then
           local_problem_ln "$OPENSSL doesn't support \"s_client $1\""
           return 7
      fi
@@ -6043,7 +6043,7 @@ run_pfs() {
           # find out what elliptic curves are supported.
           curves_offered=""
           for curve in "${curves_ossl[@]}"; do
-               $OPENSSL s_client -curves $curve 2>&1 | egrep -iaq "Error with command|unknown option"
+               $OPENSSL s_client -curves $curve -connect x 2>&1 | egrep -iaq "Error with command|unknown option"
                [[ $? -ne 0 ]] && nr_curves+=1 && supported_curves+=("$curve")
           done
 
@@ -9544,13 +9544,13 @@ find_openssl_binary() {
 
      OPENSSL_NR_CIPHERS=$(count_ciphers "$($OPENSSL ciphers 'ALL:COMPLEMENTOFALL:@STRENGTH' 2>/dev/null)")
 
-     $OPENSSL s_client -ssl2 2>&1 | grep -aq "unknown option" || \
+     $OPENSSL s_client -ssl2 -connect x 2>&1 | grep -aq "unknown option" || \
           HAS_SSL2=true
 
-     $OPENSSL s_client -ssl3 2>&1 | grep -aq "unknown option" || \
+     $OPENSSL s_client -ssl3 -connect x 2>&1 | grep -aq "unknown option" || \
           HAS_SSL3=true
 
-     $OPENSSL s_client -no_ssl2 2>&1 | grep -aq "unknown option" || \
+     $OPENSSL s_client -no_ssl2 -connect x 2>&1 | grep -aq "unknown option" || \
           HAS_NO_SSL2=true
 
      $OPENSSL s_client -help 2>$s_client_has


### PR DESCRIPTION
In a few places testssl.sh tries to determine $OPENSSL s_client's capabilities by calling `$OPENSSL s_client` without specifying a host to which to connect. For example:
```
$OPENSSL s_client -no_ssl2 2>&1
```
This idea is that `$OPENSSL s_client` should reveal something about its capabilities without actually trying to connect to a host.

This works in most cases. However, the manual pages for s_client states:
```
-connect host:port
    This specifies the host and optional port to connect to. If not specified then an attempt is made to connect to the local host on port 4433.
```
So, the above call is actually trying to connect to the local host on port 4433. If the local host is running `$OPENSSL s_server`, then `$OPENSSL s_server` will by default be listening on port 4433, and the connection attempt will most likely succeed. Since the `OPENSSL s_client` command does not include a `< /dev/null`, the `OPENSSL s_client` will just hang waiting for additional input.

Adding `-connect x` to the `$OPENSSL s_client` prevents $OPENSSL from trying to connect to a host, but seems to still provide the necessary information about OpenSSL's capabilities.