### PR TITLE
Detect $TESTSSL_INSTALL_DIR when testssl is a symlinked command

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -148,7 +148,7 @@ BUGS=${BUGS:-""}                        # -bugs option from openssl, needed for 
 DEBUG=${DEBUG:-0}                       # 1: normal putput the files in /tmp/ are kept for further debugging purposes
                                         # 2: list more what's going on , also lists some errors of connections
                                         # 3: slight hexdumps + other info,
-                                        # 4: display bytes sent via sockets 
+                                        # 4: display bytes sent via sockets
                                         # 5: display bytes received via sockets
                                         # 6: whole 9 yards
 FAST=${FAST:-false}                     # preference: show only first cipher, run_allciphers with openssl instead of sockets
@@ -159,7 +159,7 @@ CSVFILE=${CSVFILE:-""}                  # csvfile if used
 APPEND=${APPEND:-false}                 # append to csv/json file instead of overwriting it
 GIVE_HINTS=false                   # give an addtional info to findings
 HAS_IPv6=${HAS_IPv6:-false}             # if you have OpenSSL with IPv6 support AND IPv6 networking set it to yes
-UNBRACKTD_IPV6=${UNBRACKTD_IPV6:-false} # some versions of OpenSSL (like Gentoo) don't support [bracketed] IPv6 addresses 
+UNBRACKTD_IPV6=${UNBRACKTD_IPV6:-false} # some versions of OpenSSL (like Gentoo) don't support [bracketed] IPv6 addresses
 SERVER_SIZE_LIMIT_BUG=false             # Some servers have either a ClientHello total size limit or cipher limit of ~128 ciphers (e.g. old ASAs)
 
 # tuning vars, can not be set by a cmd line switch
@@ -556,7 +556,7 @@ declare TLS_CIPHER_OSSL_SUPPORTED=()
 
 ###### output functions ######
 # a little bit of sanitzing with bash internal search&replace -- otherwise printf will hiccup at '%' and '--' does the rest.
-out(){ 
+out(){
 #     if [[ "$BASH_VERSINFO" -eq 4 ]]; then
           printf -- "%b" "${1//%/%%}"
 #     else
@@ -590,10 +590,10 @@ pr_greyln()     { pr_grey "$1"; outln; }
 
 pr_done_good()       { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out "\033[0;34m$1" || out "\033[0;32m$1" ) || out "$1"; pr_off; }   # litegreen (liteblue), This is good
 pr_done_goodln()     { pr_done_good "$1"; outln; }
-pr_done_best()       { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out "\033[1;34m$1" || out "\033[1;32m$1" ) ||  out "$1"; pr_off; }  # green (blue), This is the best 
+pr_done_best()       { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out "\033[1;34m$1" || out "\033[1;32m$1" ) ||  out "$1"; pr_off; }  # green (blue), This is the best
 pr_done_bestln()     { pr_done_best "$1"; outln; }
 
-pr_svrty_minor()     { [[ "$COLOR" -eq 2 ]] && out "\033[1;33m$1" || out "$1"; pr_off; }                   # yellow brown | academic or minor problem 
+pr_svrty_minor()     { [[ "$COLOR" -eq 2 ]] && out "\033[1;33m$1" || out "$1"; pr_off; }                   # yellow brown | academic or minor problem
 pr_svrty_minorln()   { pr_svrty_minor "$1"; outln; }
 pr_svrty_medium()    { [[ "$COLOR" -eq 2 ]] && out "\033[0;33m$1" || out "$1"; pr_off; }                   # brown | it is not a bad problem but you shouldn't do this
 pr_svrty_mediumln()  { pr_svrty_medium "$1"; outln; }
@@ -1082,7 +1082,7 @@ string_to_asciihex() {
      [[ -n "$string" ]] && output+="$(printf "%02x" "'${string:eos:1}")"
      out "$output"
      return 0
-     
+
 }
 
 ###### check code starts here ######
@@ -6221,7 +6221,7 @@ run_pfs() {
           done < <($OPENSSL ciphers -V "$pfs_cipher_list" 2>$ERRFILE)
      fi
      export=""
-     
+
      if "$using_sockets"; then
           tls_sockets "03" "${pfs_hex_cipher_list:2}"
           sclient_success=$?
@@ -7101,7 +7101,7 @@ parse_sslv2_serverhello() {
      rm -f $HOSTCERT $TEMPDIR/intermediatecerts.pem
      if [[ $ret -eq 3 ]]; then
           certificate_len=2*$(hex2dec "$v2_hello_cert_length")
-     
+
           if [[ "$v2_cert_type" == "01" ]] && [[ "$v2_hello_cert_length" != "00" ]]; then
                tmp_der_certfile=$(mktemp $TEMPDIR/der_cert.XXXXXX) || return $ret
                asciihex_to_binary_file "${v2_hello_ascii:26:certificate_len}" "$tmp_der_certfile"
@@ -7222,7 +7222,7 @@ parse_tls_serverhello() {
      local process_full="$2"
      local tls_handshake_ascii="" tls_alert_ascii=""
      local -i tls_hello_ascii_len tls_handshake_ascii_len tls_alert_ascii_len msg_len
-     local tls_serverhello_ascii="" tls_certificate_ascii="" 
+     local tls_serverhello_ascii="" tls_certificate_ascii=""
      local tls_serverkeyexchange_ascii="" tls_certificate_status_ascii=""
      local -i tls_serverhello_ascii_len=0 tls_certificate_ascii_len=0
      local -i tls_serverkeyexchange_ascii_len=0 tls_certificate_status_ascii_len=0
@@ -8029,7 +8029,7 @@ parse_tls_serverhello() {
                     len1="82$(printf "%04x" $((dh_param_len/2)))"
                fi
                dh_param="30${len1}${dh_p}${dh_g}"
-               
+
                # Make a SEQUENCE of the paramters SEQUENCE and the OID
                dh_param_len=22+${#dh_param}
                if [[ $dh_param_len -lt 256 ]]; then
@@ -8069,7 +8069,7 @@ parse_tls_serverhello() {
                [[ -n "$key_bitstring" ]] && echo "$key_bitstring" >> $TMPFILE
 
                # Check to see whether the ephemeral public key uses one of the groups from
-               # RFC 7919 for parameters               
+               # RFC 7919 for parameters
                case $dh_bits in
                     2048) named_curve=256; named_curve_str=" ffdhe2048," ;;
                     3072) named_curve=257; named_curve_str=" ffdhe3072," ;;
@@ -8263,7 +8263,7 @@ socksend_tls_clienthello() {
                00, 01, 00, 02, 00, 03, 00, 0f, 00, 10, 00, 11"
                # Supported Point Formats Extension
                extension_supported_point_formats="
-               00, 0b,                    # Type: Supported Point Formats , see RFC 4492 
+               00, 0b,                    # Type: Supported Point Formats , see RFC 4492
                00, 02,                    # len
                01, 00"
           fi
@@ -9641,7 +9641,7 @@ run_rc4() {
                     ciphers_found[nr_ciphers]=false
                     sigalg[nr_ciphers]=""
                     ossl_supported[nr_ciphers]="${TLS_CIPHER_OSSL_SUPPORTED[i]}"
-                    if "$using_sockets" && "$WIDE" && ! "$HAS_DH_BITS" && 
+                    if "$using_sockets" && "$WIDE" && ! "$HAS_DH_BITS" &&
                        ( [[ ${kx[nr_ciphers]} == "Kx=ECDH" ]] || [[ ${kx[nr_ciphers]} == "Kx=DH" ]] || [[ ${kx[nr_ciphers]} == "Kx=EDH" ]] ); then
                          ossl_supported[nr_ciphers]=false
                     fi
@@ -9897,7 +9897,7 @@ get_install_dir() {
      fi
 
      if [[ ! -r "$CIPHERS_BY_STRENGTH_FILE" ]] ; then
-          unset ADD_RFC_STR 
+          unset ADD_RFC_STR
           debugme echo "$CIPHERS_BY_STRENGTH_FILE"
           pr_warningln "\nATTENTION: No cipher mapping file found!"
           outln "Please note from 2.9dev on $PROG_NAME needs files in \"\$TESTSSL_INSTALL_DIR/etc/\" to function correctly."
@@ -10045,9 +10045,9 @@ check4openssl_oldfarts() {
           pr_warningln " Your \"$OPENSSL\" is way too old (<version 1.0) !"
           case $SYSTEM in
                *BSD|Darwin)
-                    outln " Please use binary provided in \$INSTALLDIR/bin/ or from ports/brew or compile from github.com/PeterMosmans/openssl" 
+                    outln " Please use binary provided in \$INSTALLDIR/bin/ or from ports/brew or compile from github.com/PeterMosmans/openssl"
                     fileout "too_old_openssl" "WARN" "Your $OPENSSL $OSSL_VER version is way too old. Please use binary provided in \$INSTALLDIR/bin/ or from ports/brew or compile from github.com/PeterMosmans/openssl ." ;;
-               *)   outln " Update openssl binaries or compile from github.com/PeterMosmans/openssl" 
+               *)   outln " Update openssl binaries or compile from github.com/PeterMosmans/openssl"
                     fileout "too_old_openssl" "WARN" "Update openssl binaries or compile from github.com/PeterMosmans/openssl .";;
           esac
           ignore_no_or_lame " Type \"yes\" to accept false negatives or positives" "yes"
@@ -10076,8 +10076,8 @@ help() {
 
 
 "$PROG_NAME URI", where URI is:
-     
-     URI                           host|host:port|URL|URL:port   port 443 is default, URL can only contain HTTPS protocol) 
+
+     URI                           host|host:port|URL|URL:port   port 443 is default, URL can only contain HTTPS protocol)
 
 "$PROG_NAME <options>", where <options> is:
 
@@ -10092,7 +10092,7 @@ help() {
 
 "$PROG_NAME <options> URI", where <options> is:
 
-     -t, --starttls <protocol>     does a default run against a STARTTLS enabled <protocol, 
+     -t, --starttls <protocol>     does a default run against a STARTTLS enabled <protocol,
                                    protocol is <ftp|smtp|pop3|imap|xmpp|telnet|ldap|postgres> (latter three require supplied openssl)
      --xmpphost <to_domain>        for STARTTLS enabled XMPP it supplies the XML stream to-'' domain -- sometimes needed
      --mx <domain/host>            tests MX records from high to low priority (STARTTLS, port 25)
@@ -10281,7 +10281,7 @@ EOF
                          ossl_ciph="$(grep -w "$hexc" <<< "$ossl_supported_tls" | awk '{ print $3 }')"
                          if [[ -n "$ossl_ciph" ]]; then
                               TLS_CIPHER_OSSL_SUPPORTED[TLS_NR_CIPHERS]=true
-                              [[ "$ossl_ciph" != "${TLS_CIPHER_OSSL_NAME[TLS_NR_CIPHERS]}" ]] && TLS_CIPHER_OSSL_NAME[TLS_NR_CIPHERS]="$ossl_ciph" 
+                              [[ "$ossl_ciph" != "${TLS_CIPHER_OSSL_NAME[TLS_NR_CIPHERS]}" ]] && TLS_CIPHER_OSSL_NAME[TLS_NR_CIPHERS]="$ossl_ciph"
                          fi
                     fi
                elif [[ $OSSL_VER_MAJOR -lt 1 ]]; then
@@ -11708,4 +11708,3 @@ else
 fi
 
 exit $?
-

--- a/testssl.sh
+++ b/testssl.sh
@@ -9896,6 +9896,16 @@ get_install_dir() {
           [[ -r "$TESTSSL_INSTALL_DIR/cipher-mapping.txt" ]] && CIPHERS_BY_STRENGTH_FILE="$TESTSSL_INSTALL_DIR/cipher-mapping.txt"
      fi
 
+     # still no cipher mapping file (and realpath is not present):
+     if [[ ! -r "$CIPHERS_BY_STRENGTH_FILE" ]] && which readlink &>/dev/null ; then
+         readlink -f ls &>/dev/null && \
+              TESTSSL_INSTALL_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]})) || \
+              TESTSSL_INSTALL_DIR=$(dirname $(readlink ${BASH_SOURCE[0]}))
+              # not sure whether Darwin has -f
+          CIPHERS_BY_STRENGTH_FILE="$TESTSSL_INSTALL_DIR/etc/cipher-mapping.txt"
+          [[ -r "$TESTSSL_INSTALL_DIR/cipher-mapping.txt" ]] && CIPHERS_BY_STRENGTH_FILE="$TESTSSL_INSTALL_DIR/cipher-mapping.txt"
+     fi
+
      if [[ ! -r "$CIPHERS_BY_STRENGTH_FILE" ]] ; then
           unset ADD_RFC_STR
           debugme echo "$CIPHERS_BY_STRENGTH_FILE"


### PR DESCRIPTION
I have a symlink to testssl.sh in /usr/local/bin/testssl so I can run it outside the git repository.  With the latest pull from the 2.9dev branch I wasn't able to do that anymore.  This works without having realpath installed.  I also removed trailing whitespace since that is a pet peeve of mine.