### PR TITLE
Fix typo in tls_sockets()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8882,7 +8882,7 @@ tls_sockets() {
           fi
           debugme outln
      else
-          debugme "stuck on sending: $ret"
+          debugme echo "stuck on sending: $ret"
      fi
 
      close_socket


### PR DESCRIPTION
This PR just fixes a minor bug in `tls_sockets()`, changing
```
debugme "stuck on sending: $ret"
```
to
```
debugme echo "stuck on sending: $ret"
```