### PR TITLE
Handle renaming of the Supported Elliptic Curves Extension

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5427,7 +5427,10 @@ determine_tls_extensions() {
                success=$?
           fi
           if [[ $success -eq 0 ]]; then
-               tls_extensions=$(grep -a 'TLS server extension ' $TMPFILE | sed -e 's/TLS server extension //g' -e 's/\" (id=/\/#/g' -e 's/,.*$/,/g' -e 's/),$/\"/g')
+               tls_extensions=$(grep -a 'TLS server extension ' $TMPFILE | \
+                    sed -e 's/TLS server extension //g' -e 's/\" (id=/\/#/g' \
+                        -e 's/,.*$/,/g' -e 's/),$/\"/g' \
+                        -e 's/elliptic curves\/#10/supported_groups\/#10/g')
                tls_extensions=$(echo $tls_extensions)       # into one line
           fi
           tmpfile_handle $FUNCNAME.txt
@@ -5519,7 +5522,10 @@ get_server_certificate() {
      # this is not beautiful (grep+sed)
      # but maybe we should just get the ids and do a private matching, according to
      # https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
-     tls_extensions=$(grep -a 'TLS server extension ' $TMPFILE | sed -e 's/TLS server extension //g' -e 's/\" (id=/\/#/g' -e 's/,.*$/,/g' -e 's/),$/\"/g')
+     tls_extensions=$(grep -a 'TLS server extension ' $TMPFILE | \
+          sed -e 's/TLS server extension //g' -e 's/\" (id=/\/#/g' \
+              -e 's/,.*$/,/g' -e 's/),$/\"/g' \
+              -e 's/elliptic curves\/#10/supported_groups\/#10/g')
      tls_extensions=$(echo $tls_extensions)       # into one line
 
      # check to see if any new TLS extensions were returned and add any new ones to TLS_EXTENSIONS
@@ -8036,7 +8042,7 @@ parse_tls_serverhello() {
                     0007) tls_extensions+=" \"client authz/#7\"" ;;
                     0008) tls_extensions+=" \"server authz/#8\"" ;;
                     0009) tls_extensions+=" \"cert type/#9\"" ;;
-                    000A) tls_extensions+=" \"supported groups/#10\"" ;;
+                    000A) tls_extensions+=" \"supported_groups/#10\"" ;;
                     000B) tls_extensions+=" \"EC point formats/#11\"" ;;
                     000C) tls_extensions+=" \"SRP/#12\"" ;;
                     000D) tls_extensions+=" \"signature algorithms/#13\"" ;;


### PR DESCRIPTION
[RFC 4492](https://www.rfc-editor.org/rfc/rfc4492.txt) introduced the Supported Elliptic Curves Extension, but this extension was renamed Supported Groups in [RFC 7919](https://www.rfc-editor.org/rfc/rfc7919.txt). Following [RFC 7919](https://www.rfc-editor.org/rfc/rfc7919.txt) (and [TLSv1.3](https://www.ietf.org/id/draft-ietf-tls-tls13-18.txt)), `parse_tls_serverhello()` refers to this extension as "supported groups/#10". Since, at the moment, OpenSSL's s_client refers to this extension as "elliptic curves/#10", the extension sometimes appears twice in the "TLS extensions" line, if it is detected by both OpenSSL (in `get_server_certificate()`) and `tls_sockets()` (in `determine_tls_extensions()`):
```
 TLS extensions (standard)    "renegotiation info/#65281" "elliptic curves/#10" "EC point formats/#11" "supported groups/#10"
```
This PR fixes the problem of the extension appearing twice in the "TLS extensions" line by replacing any instances of "elliptic curves/#10" with "supported_groups/#10" in the `$tls_extensions` line extracted from `$OPENSSL s_client`. This PR also changes "supported groups/#10" to "supported_groups/#10" in `parse_tls_serverhello()`, since the current development branch of OpenSSL uses "supported_groups" to refer to this extension (see https://github.com/openssl/openssl/pull/1825).