### PR TITLE
Update fix to 587

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6198,7 +6198,7 @@ certificate_info() {
                fileout "${json_prefix}crl" "INFO" "No CRL provided"
           else
                pr_svrty_highln "-- (NOT ok)"
-               fileout "${json_prefix}crl" "HIGH" "Neither CRL nor  OCSP URL provided"
+               fileout "${json_prefix}crl" "HIGH" "Neither CRL nor OCSP URL provided"
           fi
      elif grep -q http <<< "$crl"; then
           if [[ $(count_lines "$crl") -eq 1 ]]; then
@@ -6214,7 +6214,7 @@ certificate_info() {
      fi
 
      out "$indent"; pr_bold " OCSP URI                     "
-     if [[ -z "$ocsp_uri" ]] && [[ -n "$crl" ]]; then
+     if [[ -z "$ocsp_uri" ]]; then
           outln "--"
           fileout "${json_prefix}ocsp_uri" "INFO" "OCSP URI : --"
      else


### PR DESCRIPTION
In the revised code that was created to address #587, nothing is printed after "OCSP URI" if there is neither an OCSP URI nor a CRL URI. Instead, "--" should be printed (perhaps it should be printed in red, just as the "--" for the CRL is).

I still believe that there is an inconsistency in the reporting of the output, however. At the moment, the "Certificate Revocation List" and "OCSP URI" lines indicate it is acceptable as long as the certificate contains either a CRL URI or an OCSP URI. However, the "OCSP stapling" line reports a minor finding if an OCSP response was not included in the server's reply. Shouldn't we just assume that if the certificate doesn't include an OCSP URI, then it wouldn't be possible for the server to obtain an OCSP response to staple to its reply? If so, then it seems that no OCSP stapling should only be considered a finding if an OCSP URI is present.