### PR TITLE
Fix of logjam: path to common_primes was wrong 

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9889,7 +9889,10 @@ run_logjam() {
           len_dh_p="$((4*${#dh_p}))"
           debugme outln "len(dh_p): $len_dh_p  |  dh_p: $dh_p"
           echo "$dh_p" > $TEMPDIR/dh_p.txt
-          if [[ ! -s "$common_primes_file" ]]; then
+
+          DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+          if [[ ! -s "$DIR$common_primes_file" ]]; then
                local_problem_ln "couldn't read common primes file $common_primes_file"
                out "${spaces}"
                fileout "LOGJAM_common primes" "WARN" "couldn't read common primes file $common_primes_file"


### PR DESCRIPTION
```
        "id"           : "LOGJAM_common primes",
        "severity"     : "WARN",
        "cve"          : "CVE-2015-4000",
        "finding"      : "couldn't read common primes file /etc/common-primes.txt"
```
**Output:**

![logjam](https://cloud.githubusercontent.com/assets/9414174/22612972/b3fe6e7e-ea74-11e6-986c-e64582067759.png)

So i see, it is not looking for common-primes.txt from the testssl directory like ../testssl.sh/etc/common-primes.txt, but from root directory.

> local common_primes_file="$TESTSSL_INSTALL_DIR/etc/common-primes.txt"

it seems TESTSSL_INSTALL_DIR is not initialised yet.

So i had to find out the dir myself:
```
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
```

After that i got the right output:

```
         "id"           : "LOGJAM_common primes",
         "severity"     : "OK",
         "cve"          : "CVE-2015-4000",
         "finding"      : "no common primes detected"
```

Dunno, maybe we should look better at TESTSSL_INSTALL_DIR, why is not initialised...and use it after that.