### PR TITLE
Generate html

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -158,6 +158,7 @@ LOGFILE=${LOGFILE:-""}                  # logfile if used
 JSONFILE=${JSONFILE:-""}                # jsonfile if used
 CSVFILE=${CSVFILE:-""}                  # csvfile if used
 HTMLFILE=${CSVFILE:-""}                 # HTML if used
+HTMLHEADER=true                         # include HTML headers and footers in HTML file, if one is being created
 APPEND=${APPEND:-false}                 # append to csv/json file instead of overwriting it
 GIVE_HINTS=false                   # give an addtional info to findings
 HAS_IPv6=${HAS_IPv6:-false}             # if you have OpenSSL with IPv6 support AND IPv6 networking set it to yes
@@ -586,106 +587,111 @@ outln_term() { out_term "$1\n"; }
 retstring(){
           printf -- "%b" "${1//%/%%}"
 }
+
+# For HTML output, replace any HTML reserved characters with the entity name
+html_reserved(){
+    echo "$1" | sed  -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&quot;/g"
+}
 #TODO: Still no shell injection safe but if just run it from the cmd line: that's fine
 
 # color print functions, see also http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
 pr_liteblue_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;32m$1" || out_term "\033[0;34m$1" ) || out_term "$1"; pr_off; }    # not yet used
-pr_liteblue()      { pr_liteblue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#00cd00;\">$1</span>" || out_html "<span style=\"color:#0000ee;\">$1</span>"; }
+pr_liteblue()      { pr_liteblue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#00cd00;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#0000ee;\">$(html_reserved "$1")</span>"; }
 pr_liteblueln_term() { pr_liteblue_term "$1"; outln_term; }
 pr_liteblueln() { pr_liteblue "$1"; outln; }
 pr_blue_term()  { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;32m$1" || out_term "\033[1;34m$1" ) || out_term "$1"; pr_off; }    # used for head lines of single tests
-pr_blue()       { pr_blue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:lime;font-weight:bold;\">$1</span>" || out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$1</span>"; }
+pr_blue()       { pr_blue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:lime;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_blueln_term() { pr_blue_term "$1"; outln_term; }
 pr_blueln()     { pr_blue "$1"; outln; }
 
 pr_warning_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;35m$1" || pr_underline_term "$1"; pr_off; }                     # some local problem: one test cannot be done
-pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:#cd00cd;\">$1</span>"; }
+pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:#cd00cd;\">$(html_reserved "$1")</span>"; }
 pr_warningln_term() { pr_warning_term "$1"; outln_term; }                                                                    # litemagenta
 pr_warningln()      { pr_warning "$1"; outln; }
 pr_magenta_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;35m$1" || pr_underline_term "$1"; pr_off; }                   # fatal error: quitting because of this!
-pr_magenta()        { pr_magenta_term "$1"; out_html "<span style=\"color:magenta;font-weight:bold;\">$1</span>"; }
+pr_magenta()        { pr_magenta_term "$1"; out_html "<span style=\"color:magenta;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_magentaln_term() { pr_magenta_term "$1"; outln_term; }
 pr_magentaln()      { pr_magenta "$1"; outln; }
 
 pr_litecyan_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;36m$1" || out_term "$1"; pr_off; }                           # not yet used
-pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:#00cdcd;\">$1</span>"; }
+pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:#00cdcd;\">$(html_reserved "$1")</span>"; }
 pr_litecyanln_term() { pr_litecyan_term "$1"; outln_term; }
 pr_litecyanln() { pr_litecyan "$1"; outln; }
 pr_cyan_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;36m$1" || out_term "$1"; pr_off; }                                # additional hint
-pr_cyan()       { pr_cyan_term "$1"; out_html "<span style=\"color:cyan;font-weight:bold;\">$1</span>"; }
+pr_cyan()       { pr_cyan_term "$1"; out_html "<span style=\"color:cyan;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_cyanln_term() { pr_cyan_term "$1"; outln_term; }
 pr_cyanln()     { pr_cyan "$1"; outln; }
 
 pr_litegreyln_term() { pr_litegrey_term "$1"; outln_term; }                                                                  # not really usable on a black background, see ..
 pr_litegreyln() { pr_litegrey "$1"; outln; }
 pr_litegrey_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;37m$1" || out_term "$1"; pr_off; }                             # ... https://github.com/drwetter/testssl.sh/pull/600#issuecomment-276129876
-pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:darkgray;\">$1</span>"; }
+pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:darkgray;\">$(html_reserved "$1")</span>"; }
 pr_grey_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;30m$1" || out_term "$1"; pr_off; }
-pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:#7f7f7f;font-weight:bold;\">$1</span>"; }
+pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:#7f7f7f;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_greyln_term() { pr_grey_term "$1"; outln_term; }
 pr_greyln()     { pr_grey "$1"; outln; }
 
 pr_done_good_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;34m$1" || out_term "\033[0;32m$1" ) || out_term "$1"; pr_off; }   # litegreen (liteblue), This is good
-pr_done_good()      { pr_done_good_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#0000ee;\">$1</span>" || out_html "<span style=\"color:#00cd00;\">$1</span>"; }
+pr_done_good()      { pr_done_good_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#0000ee;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#00cd00;\">$(html_reserved "$1")</span>"; }
 pr_done_goodln_term() { pr_done_good_term "$1"; outln_term; }
 pr_done_goodln()    { pr_done_good "$1"; outln; }
 pr_done_best_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;34m$1" || out_term "\033[1;32m$1" ) ||  out_term "$1"; pr_off; }  # green (blue), This is the best
-pr_done_best()      { pr_done_best_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$1</span>" || out_html "<span style=\"color:lime;font-weight:bold;\">$1</span>"; }
+pr_done_best()      { pr_done_best_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:lime;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_done_bestln_term() { pr_done_best_term "$1"; outln_term; }
 pr_done_bestln()    { pr_done_best "$1"; outln; }
 
 pr_svrty_low_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;33m$1" || out_term "$1"; pr_off; }         # yellow brown | academic or minor problem
-pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:#cdcd00;font-weight:bold;\">$1</span>"; }
+pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:#cdcd00;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_svrty_lowln_term() { pr_svrty_low_term "$1"; outln_term; }
 pr_svrty_lowln()     { pr_svrty_low "$1"; outln; }
 pr_svrty_medium_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;33m$1" || out_term "$1"; pr_off; }       # brown | it is not a bad problem but you shouldn't do this
-pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:#cd8000;\">$1</span>"; }
+pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:#cd8000;\">$(html_reserved "$1")</span>"; }
 pr_svrty_mediumln_term() { pr_svrty_medium_term "$1"; outln_term; }
 pr_svrty_mediumln()  { pr_svrty_medium "$1"; outln; }
 
 pr_svrty_high_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;31m$1" || pr_bold_term "$1"; pr_off; }               # litered
-pr_svrty_high()      { pr_svrty_high_term "$1"; out_html "<span style=\"color:#cd0000;\">$1</span>"; }
+pr_svrty_high()      { pr_svrty_high_term "$1"; out_html "<span style=\"color:#cd0000;\">$(html_reserved "$1")</span>"; }
 pr_svrty_highln_term() { pr_svrty_high_term "$1"; outln_term; }
 pr_svrty_highln()    { pr_svrty_high "$1"; outln; }
 pr_svrty_critical_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;31m$1" || pr_bold_term "$1"; pr_off; }           # red
-pr_svrty_critical()  { pr_svrty_critical_term "$1"; out_html "<span style=\"color:red;font-weight:bold;\">$1</span>"; }
+pr_svrty_critical()  { pr_svrty_critical_term "$1"; out_html "<span style=\"color:red;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_svrty_criticalln_term() { pr_svrty_critical_term "$1"; outln_term; }
 pr_svrty_criticalln(){ pr_svrty_critical "$1"; outln; }
 
 pr_deemphasize_term() { out_term "$1"; }                                                                   # hook for a weakened screen output, see #600
-pr_deemphasize()      { pr_deemphasize_term "$1"; out_html "<span style=\"color:darkgray;\">$1</span>"; }
+pr_deemphasize()      { pr_deemphasize_term "$1"; out_html "<span style=\"color:darkgray;\">$(html_reserved "$1")</span>"; }
 pr_deemphasizeln_term() { pr_deemphasize_term "$1"; outln_term; }
 pr_deemphasizeln()    { pr_deemphasize "$1"; outln; }
 
 # color=1 functions
 pr_off()          { [[ "$COLOR" -ne 0 ]] && out_term "\033[m"; }
 pr_bold_term()    { [[ "$COLOR" -ne 0 ]] && out_term "\033[1m$1" || out_term "$1"; pr_off; }
-pr_bold()         { pr_bold_term "$1"; out_html "<span style=\"font-weight:bold;\">$1</span>"; }
+pr_bold()         { pr_bold_term "$1"; out_html "<span style=\"font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_boldln_term()  { pr_bold_term "$1"; outln_term; }
 pr_boldln()       { pr_bold "$1" ; outln; }
 pr_italic_term()  { [[ "$COLOR" -ne 0 ]] && out_term "\033[3m$1" || out_term "$1"; pr_off; }
-pr_italic()       { pr_italic_term "$1"; out_html "<i>$1</i>"; }
+pr_italic()       { pr_italic_term "$1"; out_html "<i>$(html_reserved "$1")</i>"; }
 pr_italicln_term() { pr_italic_term "$1"; outln_term; }
 pr_italicln()     { pr_italic "$1" ; outln; }
 pr_strikethru_term() { [[ "$COLOR" -ne 0 ]] && out "\033[9m$1" || out "$1"; pr_off; }                          # ugly!
-pr_strikethru()   { pr_strikethru_term "$1"; out_html "<strike>$1</strike>"; }
+pr_strikethru()   { pr_strikethru_term "$1"; out_html "<strike>$(html_reserved "$1")</strike>"; }
 pr_strikethruln_term() { pr_strikethru_term "$1"; outln_term; }
 pr_strikethruln() { pr_strikethru "$1" ; outln; }
 pr_underline_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[4m$1" || out_term "$1"; pr_off; }
-pr_underline()    { pr_underline_term "$1"; out_html "<u>$1</u>"; }
+pr_underline()    { pr_underline_term "$1"; out_html "<u>$(html_reserved "$1")</u>"; }
 pr_underlineln_term() { pr_underline_term "$1"; outln_term; }
 pr_underlineln()  { pr_underline "$1"; outln; }
 pr_reverse_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[7m$1" || out_term "$1"; pr_off; }
-pr_reverse()      { pr_reverse_term "$1"; out_html "<span style=\"color:white;background-color:black;\">$1</span>"; }
+pr_reverse()      { pr_reverse_term "$1"; out_html "<span style=\"color:white;background-color:black;\">$(html_reserved "$1")</span>"; }
 pr_reverse_bold_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[7m\033[1m$1" || out_term "$1"; pr_off; }
-pr_reverse_bold() { pr_reverse_bold_term "$1"; out_html "<span style=\"color:white;background-color:black;font-weight:bold;\">$1</span>"; }
+pr_reverse_bold() { pr_reverse_bold_term "$1"; out_html "<span style=\"color:white;background-color:black;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 
 #pr_headline() { pr_blue "$1"; }
 #http://misc.flogisoft.com/bash/tip_colors_and_formatting
 
 #pr_headline() { [[ "$COLOR" -eq 2 ]] && out "\033[1;30m\033[47m$1" || out "$1"; pr_off; }
 pr_headline_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[1m\033[4m$1" || out_term "$1"; pr_off; }
-pr_headline() { pr_headline_term "$1"; out_html "<span style=\"text-decoration:underline;font-weight:bold;\">$1</span>"; }
+pr_headline() { pr_headline_term "$1"; out_html "<span style=\"text-decoration:underline;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_headlineln_term() { pr_headline_term "$1"; outln_term; }
 pr_headlineln() { pr_headline "$1" ; outln; }
 
@@ -963,21 +969,28 @@ fileout() { # ID, SEVERITY, FINDING, CVE, CWE, HINT
 ################### FILE FORMATING END #########################
 
 html_header() {
-     out_html "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
-     out_html "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-     out_html "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
-     out_html "<head>\n"
-     out_html "<meta http-equiv=\"Content-Type\" content=\"application/xml+xhtml; charset=UTF-8\" />\n"
-     out_html "<title>testssl.sh</title>\n"
-     out_html "</head>\n"
-     out_html "<body>\n"
-     out_html "<pre>\n"
+     if "$HTMLHEADER"; then
+          rm -f "$HTMLFILE"
+          out_html "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+          out_html "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+          out_html "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+          out_html "<head>\n"
+          out_html "<meta http-equiv=\"Content-Type\" content=\"application/xml+xhtml; charset=UTF-8\" />\n"
+          out_html "<title>testssl.sh</title>\n"
+          out_html "</head>\n"
+          out_html "<body>\n"
+          out_html "<pre>\n"
+     fi
+     return 0
 }
 
 html_footer() {
-     out_html "</pre>\n"
-     out_html "</body>\n"
-     out_html "</html>\n"
+     if "$HTMLHEADER"; then
+          out_html "</pre>\n"
+          out_html "</body>\n"
+          out_html "</html>\n"
+     fi
+     return 0
 }
 
 ###### helper function definitions ######
@@ -11322,6 +11335,7 @@ cleanup () {
      fi
      outln
      "$APPEND" || fileout_footer
+     html_footer
 }
 
 fatal() {
@@ -11386,7 +11400,7 @@ ignore_no_or_lame() {
      [[ "$WARNINGS" == off ]] && return 0
      [[ "$WARNINGS" == false ]] && return 0
      [[ "$WARNINGS" == batch ]] && return 1
-     pr_warning "$1 --> "
+     pr_warning_term "$1 --> "
      read a
      if [[ "$a" == "$(tolower "$2")" ]]; then
           $ok_arg return 0
@@ -12002,7 +12016,7 @@ datebanner() {
 
 # one line with char $1 over screen width $2
 draw_line() {
-     printf -- "$1"'%.s' $(eval "echo {1.."$(($2))"}")
+     out "$(printf -- "$1"'%.s' $(eval "echo {1.."$(($2))"}"))"
 }
 
 
@@ -12092,7 +12106,7 @@ run_mass_testing() {
           cmdline=$(filter_input "$cmdline")
           [[ -z "$cmdline" ]] && continue
           [[ "$cmdline" == "EOF" ]] && break
-          cmdline="$0 $global_cmdline --warnings=batch -q --append $cmdline"
+          cmdline="$0 $global_cmdline --warnings=batch -q --no-html-header --append $cmdline"
           draw_line "=" $((TERM_WIDTH / 2)); outln;
           outln "$cmdline"
           $cmdline
@@ -12516,7 +12530,9 @@ parse_cmd_line() {
                          exit -6
                     fi
                     do_html=true
-                    html_header
+                    ;;
+               --no-html-header)
+                    HTMLHEADER=false
                     ;;
                --append)
                     APPEND=true
@@ -12700,6 +12716,7 @@ lets_roll() {
 
 initialize_globals
 parse_cmd_line "$@"
+html_header
 get_install_dir
 set_color_functions
 maketempf
@@ -12760,6 +12777,5 @@ else
           fi
      fi
 fi
-html_footer
 
 exit $?

--- a/testssl.sh
+++ b/testssl.sh
@@ -1423,7 +1423,7 @@ run_http_header() {
      case $HTTP_STATUS_CODE in
           301|302|307|308)
                redirect=$(grep -a '^Location' $HEADERFILE | sed 's/Location: //' | tr -d '\r\n')
-               out ", redirecting to \"$redirect\""
+               out ", redirecting to \""; pr_url "$redirect"; out "\""
                if [[ $redirect == "http://"* ]]; then
                     pr_svrty_high " -- Redirect to insecure URL (NOT ok)"
                     fileout "HTTP_STATUS_CODE" "HIGH" \, "Redirect to insecure URL. Url: \"$redirect\""

--- a/testssl.sh
+++ b/testssl.sh
@@ -598,65 +598,65 @@ retstring(){
 
 # color print functions, see also http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
 pr_liteblue_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;32m$1" || out_term "\033[0;34m$1" ) || out_term "$1"; pr_off; }    # not yet used
-pr_liteblue()      { pr_liteblue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#00cd00;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#0000ee;\">$(html_reserved "$1")</span>"; }
+pr_liteblue()      { pr_liteblue_term "$1"; [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_html "<span style=\"color:#00cd00;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#0000ee;\">$(html_reserved "$1")</span>" ) || out_html "$(html_reserved "$1")"; }
 pr_liteblueln_term() { pr_liteblue_term "$1"; outln_term; }
 pr_liteblueln() { pr_liteblue "$1"; outln; }
 pr_blue_term()  { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;32m$1" || out_term "\033[1;34m$1" ) || out_term "$1"; pr_off; }    # used for head lines of single tests
-pr_blue()       { pr_blue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:lime;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_blue()       { pr_blue_term "$1"; [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_html "<span style=\"color:lime;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$(html_reserved "$1")</span>" ) || out_html "$(html_reserved "$1")"; }
 pr_blueln_term() { pr_blue_term "$1"; outln_term; }
 pr_blueln()     { pr_blue "$1"; outln; }
 
 pr_warning_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;35m$1" || pr_underline_term "$1"; pr_off; }                     # some local problem: one test cannot be done
-pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:#cd00cd;\">$(html_reserved "$1")</span>"; }
+pr_warning()      { pr_warning_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:#cd00cd;\">$(html_reserved "$1")</span>" || ( [[ "$COLOR" -eq 1 ]] && out_html "<u>$(html_reserved "$1")</u>" || out_html "$(html_reserved "$1")" ); }
 pr_warningln_term() { pr_warning_term "$1"; outln_term; }                                                                    # litemagenta
 pr_warningln()      { pr_warning "$1"; outln; }
 pr_magenta_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;35m$1" || pr_underline_term "$1"; pr_off; }                   # fatal error: quitting because of this!
-pr_magenta()        { pr_magenta_term "$1"; out_html "<span style=\"color:magenta;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_magenta()        { pr_magenta_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:magenta;font-weight:bold;\">$(html_reserved "$1")</span>" || ( [[ "$COLOR" -eq 1 ]] && out_html "<u>$(html_reserved "$1")</u>" || out_html "$(html_reserved "$1")" ); }
 pr_magentaln_term() { pr_magenta_term "$1"; outln_term; }
 pr_magentaln()      { pr_magenta "$1"; outln; }
 
 pr_litecyan_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;36m$1" || out_term "$1"; pr_off; }                           # not yet used
-pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:#00cdcd;\">$(html_reserved "$1")</span>"; }
+pr_litecyan()   { pr_litecyan_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:#00cdcd;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_litecyanln_term() { pr_litecyan_term "$1"; outln_term; }
 pr_litecyanln() { pr_litecyan "$1"; outln; }
 pr_cyan_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;36m$1" || out_term "$1"; pr_off; }                                # additional hint
-pr_cyan()       { pr_cyan_term "$1"; out_html "<span style=\"color:cyan;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_cyan()       { pr_cyan_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:cyan;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_cyanln_term() { pr_cyan_term "$1"; outln_term; }
 pr_cyanln()     { pr_cyan "$1"; outln; }
 
 pr_litegreyln_term() { pr_litegrey_term "$1"; outln_term; }                                                                  # not really usable on a black background, see ..
 pr_litegreyln() { pr_litegrey "$1"; outln; }
 pr_litegrey_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[0;37m$1" || out_term "$1"; pr_off; }                             # ... https://github.com/drwetter/testssl.sh/pull/600#issuecomment-276129876
-pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:darkgray;\">$(html_reserved "$1")</span>"; }
+pr_litegrey()   { pr_litegrey_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<span style=\"color:darkgray;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_grey_term()  { [[ "$COLOR" -ne 0 ]] && out_term "\033[1;30m$1" || out_term "$1"; pr_off; }
-pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:#7f7f7f;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_grey()       { pr_grey_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<span style=\"color:#7f7f7f;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_greyln_term() { pr_grey_term "$1"; outln_term; }
 pr_greyln()     { pr_grey "$1"; outln; }
 
 pr_done_good_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;34m$1" || out_term "\033[0;32m$1" ) || out_term "$1"; pr_off; }   # litegreen (liteblue), This is good
-pr_done_good()      { pr_done_good_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#0000ee;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#00cd00;\">$(html_reserved "$1")</span>"; }
+pr_done_good()      { pr_done_good_term "$1"; [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_html "<span style=\"color:#0000ee;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:#00cd00;\">$(html_reserved "$1")</span>" ) || out_html "$(html_reserved "$1")"; }
 pr_done_goodln_term() { pr_done_good_term "$1"; outln_term; }
 pr_done_goodln()    { pr_done_good "$1"; outln; }
 pr_done_best_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;34m$1" || out_term "\033[1;32m$1" ) ||  out_term "$1"; pr_off; }  # green (blue), This is the best
-pr_done_best()      { pr_done_best_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:lime;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_done_best()      { pr_done_best_term "$1"; [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "<span style=\"color:lime;font-weight:bold;\">$(html_reserved "$1")</span>" ) || out_html "$(html_reserved "$1")"; }
 pr_done_bestln_term() { pr_done_best_term "$1"; outln_term; }
 pr_done_bestln()    { pr_done_best "$1"; outln; }
 
 pr_svrty_low_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;33m$1" || out_term "$1"; pr_off; }         # yellow brown | academic or minor problem
-pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:#cdcd00;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_svrty_low()       { pr_svrty_low_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:#cdcd00;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_svrty_lowln_term() { pr_svrty_low_term "$1"; outln_term; }
 pr_svrty_lowln()     { pr_svrty_low "$1"; outln; }
 pr_svrty_medium_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;33m$1" || out_term "$1"; pr_off; }       # brown | it is not a bad problem but you shouldn't do this
-pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:#cd8000;\">$(html_reserved "$1")</span>"; }
+pr_svrty_medium()    { pr_svrty_medium_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:#cd8000;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_svrty_mediumln_term() { pr_svrty_medium_term "$1"; outln_term; }
 pr_svrty_mediumln()  { pr_svrty_medium "$1"; outln; }
 
 pr_svrty_high_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;31m$1" || pr_bold_term "$1"; pr_off; }               # litered
-pr_svrty_high()      { pr_svrty_high_term "$1"; out_html "<span style=\"color:#cd0000;\">$(html_reserved "$1")</span>"; }
+pr_svrty_high()      { pr_svrty_high_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:#cd0000;\">$(html_reserved "$1")</span>" || ( [[ "$COLOR" -eq 1 ]] && out_html "<span style=\"font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")" ); }
 pr_svrty_highln_term() { pr_svrty_high_term "$1"; outln_term; }
 pr_svrty_highln()    { pr_svrty_high "$1"; outln; }
 pr_svrty_critical_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;31m$1" || pr_bold_term "$1"; pr_off; }           # red
-pr_svrty_critical()  { pr_svrty_critical_term "$1"; out_html "<span style=\"color:red;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_svrty_critical()  { pr_svrty_critical_term "$1"; [[ "$COLOR" -eq 2 ]] && out_html "<span style=\"color:red;font-weight:bold;\">$(html_reserved "$1")</span>" || ( [[ "$COLOR" -eq 1 ]] && out_html "<span style=\"font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")" ); }
 pr_svrty_criticalln_term() { pr_svrty_critical_term "$1"; outln_term; }
 pr_svrty_criticalln(){ pr_svrty_critical "$1"; outln; }
 
@@ -668,32 +668,32 @@ pr_deemphasizeln()    { pr_deemphasize "$1"; outln; }
 # color=1 functions
 pr_off()          { [[ "$COLOR" -ne 0 ]] && out_term "\033[m"; }
 pr_bold_term()    { [[ "$COLOR" -ne 0 ]] && out_term "\033[1m$1" || out_term "$1"; pr_off; }
-pr_bold()         { pr_bold_term "$1"; out_html "<span style=\"font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_bold()         { pr_bold_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<span style=\"font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_boldln_term()  { pr_bold_term "$1"; outln_term; }
 pr_boldln()       { pr_bold "$1" ; outln; }
 pr_italic_term()  { [[ "$COLOR" -ne 0 ]] && out_term "\033[3m$1" || out_term "$1"; pr_off; }
-pr_italic()       { pr_italic_term "$1"; out_html "<i>$(html_reserved "$1")</i>"; }
+pr_italic()       { pr_italic_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<i>$(html_reserved "$1")</i>" || out_html "$(html_reserved "$1")"; }
 pr_italicln_term() { pr_italic_term "$1"; outln_term; }
 pr_italicln()     { pr_italic "$1" ; outln; }
-pr_strikethru_term() { [[ "$COLOR" -ne 0 ]] && out "\033[9m$1" || out "$1"; pr_off; }                          # ugly!
-pr_strikethru()   { pr_strikethru_term "$1"; out_html "<strike>$(html_reserved "$1")</strike>"; }
+pr_strikethru_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[9m$1" || out_term "$1"; pr_off; }                          # ugly!
+pr_strikethru()   { pr_strikethru_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<strike>$(html_reserved "$1")</strike>" || out_html "$(html_reserved "$1")"; }
 pr_strikethruln_term() { pr_strikethru_term "$1"; outln_term; }
 pr_strikethruln() { pr_strikethru "$1" ; outln; }
 pr_underline_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[4m$1" || out_term "$1"; pr_off; }
-pr_underline()    { pr_underline_term "$1"; out_html "<u>$(html_reserved "$1")</u>"; }
+pr_underline()    { pr_underline_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<u>$(html_reserved "$1")</u>" || out_html "$(html_reserved "$1")"; }
 pr_underlineln_term() { pr_underline_term "$1"; outln_term; }
 pr_underlineln()  { pr_underline "$1"; outln; }
 pr_reverse_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[7m$1" || out_term "$1"; pr_off; }
-pr_reverse()      { pr_reverse_term "$1"; out_html "<span style=\"color:white;background-color:black;\">$(html_reserved "$1")</span>"; }
+pr_reverse()      { pr_reverse_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<span style=\"color:white;background-color:black;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_reverse_bold_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[7m\033[1m$1" || out_term "$1"; pr_off; }
-pr_reverse_bold() { pr_reverse_bold_term "$1"; out_html "<span style=\"color:white;background-color:black;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_reverse_bold() { pr_reverse_bold_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<span style=\"color:white;background-color:black;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 
 #pr_headline() { pr_blue "$1"; }
 #http://misc.flogisoft.com/bash/tip_colors_and_formatting
 
 #pr_headline() { [[ "$COLOR" -eq 2 ]] && out "\033[1;30m\033[47m$1" || out "$1"; pr_off; }
 pr_headline_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[1m\033[4m$1" || out_term "$1"; pr_off; }
-pr_headline() { pr_headline_term "$1"; out_html "<span style=\"text-decoration:underline;font-weight:bold;\">$(html_reserved "$1")</span>"; }
+pr_headline() { pr_headline_term "$1"; [[ "$COLOR" -ne 0 ]] && out_html "<span style=\"text-decoration:underline;font-weight:bold;\">$(html_reserved "$1")</span>" || out_html "$(html_reserved "$1")"; }
 pr_headlineln_term() { pr_headline_term "$1"; outln_term; }
 pr_headlineln() { pr_headline "$1" ; outln; }
 
@@ -1826,6 +1826,10 @@ emphasize_stuff_in_headers(){
      local text="$1"
      local -i len
 
+     if [[ $COLOR -ne 2 ]]; then
+          out "$text"
+          text=""
+     fi
      len=${#text}
      while [[ $len -gt 0 ]]; do
           if [[ -z "$(tr -d '0-9' <<< "${text:0:1}")" ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -626,9 +626,9 @@ pr_cyanln()     { pr_cyan "$1"; outln; }
 
 pr_litegreyln_term() { pr_litegrey_term "$1"; outln_term; }                                                                  # not really usable on a black background, see ..
 pr_litegreyln() { pr_litegrey "$1"; outln; }
-pr_litegrey_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;37m$1" || out_term "$1"; pr_off; }                             # ... https://github.com/drwetter/testssl.sh/pull/600#issuecomment-276129876
+pr_litegrey_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[0;37m$1" || out_term "$1"; pr_off; }                             # ... https://github.com/drwetter/testssl.sh/pull/600#issuecomment-276129876
 pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:darkgray;\">$(html_reserved "$1")</span>"; }
-pr_grey_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;30m$1" || out_term "$1"; pr_off; }
+pr_grey_term()  { [[ "$COLOR" -ne 0 ]] && out_term "\033[1;30m$1" || out_term "$1"; pr_off; }
 pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:#7f7f7f;font-weight:bold;\">$(html_reserved "$1")</span>"; }
 pr_greyln_term() { pr_grey_term "$1"; outln_term; }
 pr_greyln()     { pr_grey "$1"; outln; }
@@ -11380,7 +11380,7 @@ EOF
      pr_bold "$bb1"
      pr_boldurl "$SWURL"; outln
      pr_bold "    ("
-     [[ "$COLOR" -ne 0 ]] && pr_grey "$idtag" || out "$idtag"
+     pr_grey "$idtag"
      pr_boldln ")"
      pr_bold "$bb2"
      pr_boldurl "https://testssl.sh/bugs/"; outln

--- a/testssl.sh
+++ b/testssl.sh
@@ -590,16 +590,16 @@ retstring(){
 
 # color print functions, see also http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
 pr_liteblue_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;32m$1" || out_term "\033[0;34m$1" ) || out_term "$1"; pr_off; }    # not yet used
-pr_liteblue()      { pr_liteblue_term "$1"; out_html "<span style=\"color:lightblue;\">$1</span>"; }
+pr_liteblue()      { pr_liteblue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#00cd00;\">$1</span>" || out_html "<span style=\"color:#0000ee;\">$1</span>"; }
 pr_liteblueln_term() { pr_liteblue_term "$1"; outln_term; }
 pr_liteblueln() { pr_liteblue "$1"; outln; }
 pr_blue_term()  { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;32m$1" || out_term "\033[1;34m$1" ) || out_term "$1"; pr_off; }    # used for head lines of single tests
-pr_blue()       { pr_blue_term "$1"; out_html "<span style=\"color:blue;font-weight:bold;\">$1</span>"; }
+pr_blue()       { pr_blue_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:lime;font-weight:bold;\">$1</span>" || out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$1</span>"; }
 pr_blueln_term() { pr_blue_term "$1"; outln_term; }
 pr_blueln()     { pr_blue "$1"; outln; }
 
 pr_warning_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;35m$1" || pr_underline_term "$1"; pr_off; }                     # some local problem: one test cannot be done
-pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:magenta;\">$1</span>"; }
+pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:#cd00cd;\">$1</span>"; }
 pr_warningln_term() { pr_warning_term "$1"; outln_term; }                                                                    # litemagenta
 pr_warningln()      { pr_warning "$1"; outln; }
 pr_magenta_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;35m$1" || pr_underline_term "$1"; pr_off; }                   # fatal error: quitting because of this!
@@ -608,7 +608,7 @@ pr_magentaln_term() { pr_magenta_term "$1"; outln_term; }
 pr_magentaln()      { pr_magenta "$1"; outln; }
 
 pr_litecyan_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;36m$1" || out_term "$1"; pr_off; }                           # not yet used
-pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:lightcyan;\">$1</span>"; }
+pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:#00cdcd;\">$1</span>"; }
 pr_litecyanln_term() { pr_litecyan_term "$1"; outln_term; }
 pr_litecyanln() { pr_litecyan "$1"; outln; }
 pr_cyan_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;36m$1" || out_term "$1"; pr_off; }                                # additional hint
@@ -621,30 +621,30 @@ pr_litegreyln() { pr_litegrey "$1"; outln; }
 pr_litegrey_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;37m$1" || out_term "$1"; pr_off; }                             # ... https://github.com/drwetter/testssl.sh/pull/600#issuecomment-276129876
 pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:darkgray;\">$1</span>"; }
 pr_grey_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;30m$1" || out_term "$1"; pr_off; }
-pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:grey;font-weight:bold;\">$1</span>"; }
+pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:#7f7f7f;font-weight:bold;\">$1</span>"; }
 pr_greyln_term() { pr_grey_term "$1"; outln_term; }
 pr_greyln()     { pr_grey "$1"; outln; }
 
 pr_done_good_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;34m$1" || out_term "\033[0;32m$1" ) || out_term "$1"; pr_off; }   # litegreen (liteblue), This is good
-pr_done_good()      { pr_done_good_term "$1"; out_html "<span style=\"color:green;\">$1</span>"; }
+pr_done_good()      { pr_done_good_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#0000ee;\">$1</span>" || out_html "<span style=\"color:#00cd00;\">$1</span>"; }
 pr_done_goodln_term() { pr_done_good_term "$1"; outln_term; }
 pr_done_goodln()    { pr_done_good "$1"; outln; }
 pr_done_best_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;34m$1" || out_term "\033[1;32m$1" ) ||  out_term "$1"; pr_off; }  # green (blue), This is the best
-pr_done_best()      { pr_done_best_term "$1"; out_html "<span style=\"color:green;font-weight:bold;\">$1</span>"; }
+pr_done_best()      { pr_done_best_term "$1"; "$COLORBLIND" && out_html "<span style=\"color:#5c5cff;font-weight:bold;\">$1</span>" || out_html "<span style=\"color:lime;font-weight:bold;\">$1</span>"; }
 pr_done_bestln_term() { pr_done_best_term "$1"; outln_term; }
 pr_done_bestln()    { pr_done_best "$1"; outln; }
 
 pr_svrty_low_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;33m$1" || out_term "$1"; pr_off; }         # yellow brown | academic or minor problem
-pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:yellow;font-weight:bold;\">$1</span>"; }
+pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:#cdcd00;font-weight:bold;\">$1</span>"; }
 pr_svrty_lowln_term() { pr_svrty_low_term "$1"; outln_term; }
 pr_svrty_lowln()     { pr_svrty_low "$1"; outln; }
 pr_svrty_medium_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;33m$1" || out_term "$1"; pr_off; }       # brown | it is not a bad problem but you shouldn't do this
-pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:chocolate;\">$1</span>"; }
+pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:#cd8000;\">$1</span>"; }
 pr_svrty_mediumln_term() { pr_svrty_medium_term "$1"; outln_term; }
 pr_svrty_mediumln()  { pr_svrty_medium "$1"; outln; }
 
 pr_svrty_high_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;31m$1" || pr_bold_term "$1"; pr_off; }               # litered
-pr_svrty_high()      { pr_svrty_high_term "$1"; out_html "<span style=\"color:red;\">$1</span>"; }
+pr_svrty_high()      { pr_svrty_high_term "$1"; out_html "<span style=\"color:#cd0000;\">$1</span>"; }
 pr_svrty_highln_term() { pr_svrty_high_term "$1"; outln_term; }
 pr_svrty_highln()    { pr_svrty_high "$1"; outln; }
 pr_svrty_critical_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;31m$1" || pr_bold_term "$1"; pr_off; }           # red

--- a/testssl.sh
+++ b/testssl.sh
@@ -977,26 +977,24 @@ fileout() { # ID, SEVERITY, FINDING, CVE, CWE, HINT
 html_header() {
      local fname_prefix="$1"
 
-     if "$HTMLHEADER"; then
-          [[ -z "$fname_prefix" ]] && fname_prefix="$NODE"_"$PORT"
-          if [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]]; then
-               rm -f "$HTMLFILE"
-          elif [[ -z "$HTMLFILE" ]]; then
-               HTMLFILE=$fname_prefix-$(date +"%Y%m%d-%H%M".html)
-          else
-               HTMLFILE=$HTMLFILE/$fname_prefix-$(date +"%Y%m%d-%H%M".html)
-          fi
-          out_html "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
-          out_html "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-          out_html "<!-- This file was created with testssl.sh. https://testssl.sh -->\n"
-          out_html "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
-          out_html "<head>\n"
-          out_html "<meta http-equiv=\"Content-Type\" content=\"application/xml+xhtml; charset=UTF-8\" />\n"
-          out_html "<title>testssl.sh</title>\n"
-          out_html "</head>\n"
-          out_html "<body>\n"
-          out_html "<pre>\n"
+     [[ -z "$fname_prefix" ]] && fname_prefix="$NODE"_"$PORT"
+     if [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]]; then
+          rm -f "$HTMLFILE"
+     elif [[ -z "$HTMLFILE" ]]; then
+          HTMLFILE=$fname_prefix-$(date +"%Y%m%d-%H%M".html)
+     else
+          HTMLFILE=$HTMLFILE/$fname_prefix-$(date +"%Y%m%d-%H%M".html)
      fi
+     out_html "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+     out_html "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+     out_html "<!-- This file was created with testssl.sh. https://testssl.sh -->\n"
+     out_html "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+     out_html "<head>\n"
+     out_html "<meta http-equiv=\"Content-Type\" content=\"application/xml+xhtml; charset=UTF-8\" />\n"
+     out_html "<title>testssl.sh</title>\n"
+     out_html "</head>\n"
+     out_html "<body>\n"
+     out_html "<pre>\n"
      return 0
 }
 
@@ -12999,7 +12997,8 @@ lets_roll() {
 
 initialize_globals
 parse_cmd_line "$@"
-if ! "$do_mass_testing" || ( [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]] ); then
+! "$do_html" && HTMLHEADER=false
+if "$HTMLHEADER" && ( ! "$do_mass_testing" || ( [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]] ) ); then
      if "$do_display_only"; then
           html_header "local-ciphers"
      elif "$do_mass_testing"; then
@@ -13007,7 +13006,7 @@ if ! "$do_mass_testing" || ( [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]] ); t
      elif "$do_mx_all_ips"; then
           html_header "mx-$URI"
      else
-          parse_hn_port "${URI}"    # NODE, URL_PATH, PORT, IPADDR and IP46ADDR is set now
+          ( [[ -z "$HTMLFILE" ]] || [[ -d "$HTMLFILE" ]] ) && parse_hn_port "${URI}"    # NODE, URL_PATH, PORT, IPADDR and IP46ADDR is set now
           html_header
      fi
 fi
@@ -13043,6 +13042,7 @@ if $do_mx_all_ips; then
      run_mx_all_ips "${URI}" $PORT # we should reduce run_mx_all_ips to the stuff neccessary as ~15 lines later we have sililar code
      ret=$?
 else
+     [[ -z "$NODE" ]] && parse_hn_port "${URI}"                                 # NODE, URL_PATH, PORT, IPADDR and IP46ADDR is set now
      prepare_logging
      if ! determine_ip_addresses; then
           fatal "No IP address could be determined" 2

--- a/testssl.sh
+++ b/testssl.sh
@@ -1830,86 +1830,86 @@ emphasize_stuff_in_headers(){
      while [[ $len -gt 0 ]]; do
           if [[ -z "$(tr -d '0-9' <<< "${text:0:1}")" ]]; then
                out_term "$brown${text:0:1}$off"
-               out_html "<span style=\"color:chocolate;\">${text:0:1}</span>"
+               out_html "<span style=\"color:olive;\">${text:0:1}</span>"
                text="${text:1}"
                len=$len-1
           elif [[ $len -ge 31 ]] && [[ "${text:0:31}" == "MicrosoftSharePointTeamServices" ]]; then
                out_term "$yellow${text:0:31}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:31}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:31}</span>"
                text="${text:31}"
                len=$len-31
           elif [[ $len -ge 24 ]] && [[ "${text:0:24}" == "Red Hat Enterprise Linux" ]]; then
                out_term "$yellow${text:0:24}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:24}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:24}</span>"
                text="${text:24}"
                len=$len-24
           elif [[ $len -ge 16 ]] && [[ "${text:0:16}" == "X-AspNet-Version" ]]; then
                out_term "$yellow${text:0:16}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:16}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:16}</span>"
                text="${text:16}"
                len=$len-16
           elif [[ $len -ge 15 ]] && [[ "${text:0:15}" == "X-UA-Compatible" ]]; then
                out_term "$yellow${text:0:15}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:15}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:15}</span>"
                text="${text:15}"
                len=$len-15
           elif [[ $len -ge 14 ]] && ( [[ "${text:0:14}" == "Liferay-Portal" ]] || [[ "${text:0:14}" == "X-Cache-Lookup" ]] || \
                                       [[ "${text:0:14}" == "X-Cache-Status" ]] ) ; then
                out_term "$yellow${text:0:14}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:14}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:14}</span>"
                text="${text:14}"
                len=$len-14
           elif [[ $len -ge 13 ]] && [[ "${text:0:13}" == "X-OWA-Version" ]]; then
                out_term "$yellow${text:0:13}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:13}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:13}</span>"
                text="${text:13}"
                len=$len-13
           elif [[ $len -ge 12 ]] && [[ "${text:0:12}" == "X-Powered-By" ]]; then
                out_term "$yellow${text:0:12}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:12}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:12}</span>"
                text="${text:12}"
                len=$len-12
           elif [[ $len -ge 11 ]] && [[ "${text:0:11}" == "X-Forwarded" ]]; then
                out_term "$yellow${text:0:11}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:11}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:11}</span>"
                text="${text:11}"
                len=$len-11
           elif [[ $len -ge 9 ]] && ( [[ "${text:0:9}" == "X-Varnish" ]] || [[ "${text:0:9}" == "X-Version" ]] ); then
                out_term "$yellow${text:0:9}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:9}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:9}</span>"
                text="${text:9}"
                len=$len-9
           elif [[ $len -ge 8 ]] && [[ "${text:0:8}" == "X-Server" ]]; then
                out_term "$yellow${text:0:8}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:8}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:8}</span>"
                text="${text:8}"
                len=$len-8
           elif [[ $len -ge 7 ]] && ( [[ "${text:0:7}" == "squeeze" ]] || [[ "${text:0:7}" == "Red Hat" ]] || \
                                      [[ "${text:0:7}" == "X-Cache" ]] || [[ "${text:0:7}" == "X-Squid" ]] ) ; then
                out_term "$yellow${text:0:7}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:7}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:7}</span>"
                text="${text:7}"
                len=$len-7
           elif [[ $len -ge 6 ]] && ( [[ "${text:0:6}" == "Debian" ]] || [[ "${text:0:6}" == "Ubuntu" ]] || \
                                      [[ "${text:0:6}" == "ubuntu" ]] || [[ "${text:0:6}" == "jessie" ]] || \
                                      [[ "${text:0:6}" == "wheezy" ]] || [[ "${text:0:6}" == "CentOS" ]] ) ; then
                out_term "$yellow${text:0:6}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:6}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:6}</span>"
                text="${text:6}"
                len=$len-6
           elif [[ $len -ge 5 ]] && ( [[ "${text:0:5}" == "Win32" ]] || [[ "${text:0:5}" == "Win64" ]] || [[ "${text:0:5}" == "lenny" ]] ); then
                out_term "$yellow${text:0:5}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:5}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:5}</span>"
                text="${text:5}"
                len=$len-5
           elif [[ $len -ge 4 ]] && [[ "${text:0:4}" == "SUSE" ]]; then
                out_term "$yellow${text:0:4}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:4}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:4}</span>"
                text="${text:4}"
                len=$len-4
           elif [[ $len -ge 3 ]] && [[ "${text:0:3}" == "Via" ]]; then
                out_term "$yellow${text:0:3}$off"
-               out_html "<span style=\"color:yellow;\">${text:0:3}</span>"
+               out_html "<span style=\"color:olive;font-weight:bold;\">${text:0:3}</span>"
                text="${text:3}"
                len=$len-3
           else

--- a/testssl.sh
+++ b/testssl.sh
@@ -589,7 +589,7 @@ retstring(){
 
 # color print functions, see also http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html
 pr_liteblue_term() { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[0;32m$1" || out_term "\033[0;34m$1" ) || out_term "$1"; pr_off; }    # not yet used
-pr_liteblue()      { pr_liteblue_term "$1"; out_html "<span style=\"color:blue;\">$1</span>"; }
+pr_liteblue()      { pr_liteblue_term "$1"; out_html "<span style=\"color:lightblue;\">$1</span>"; }
 pr_liteblueln_term() { pr_liteblue_term "$1"; outln_term; }
 pr_liteblueln() { pr_liteblue "$1"; outln; }
 pr_blue_term()  { [[ "$COLOR" -eq 2 ]] && ( "$COLORBLIND" && out_term "\033[1;32m$1" || out_term "\033[1;34m$1" ) || out_term "$1"; pr_off; }    # used for head lines of single tests
@@ -598,27 +598,27 @@ pr_blueln_term() { pr_blue_term "$1"; outln_term; }
 pr_blueln()     { pr_blue "$1"; outln; }
 
 pr_warning_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;35m$1" || pr_underline_term "$1"; pr_off; }                     # some local problem: one test cannot be done
-pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:purple;\">$1</span>"; }
+pr_warning()      { pr_warning_term "$1"; out_html "<span style=\"color:magenta;\">$1</span>"; }
 pr_warningln_term() { pr_warning_term "$1"; outln_term; }                                                                    # litemagenta
 pr_warningln()      { pr_warning "$1"; outln; }
 pr_magenta_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;35m$1" || pr_underline_term "$1"; pr_off; }                   # fatal error: quitting because of this!
-pr_magenta()        { pr_magenta_term "$1"; out_html "<span style=\"color:purple;font-weight:bold;\">$1</span>"; }
+pr_magenta()        { pr_magenta_term "$1"; out_html "<span style=\"color:magenta;font-weight:bold;\">$1</span>"; }
 pr_magentaln_term() { pr_magenta_term "$1"; outln_term; }
 pr_magentaln()      { pr_magenta "$1"; outln; }
 
 pr_litecyan_term()   { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;36m$1" || out_term "$1"; pr_off; }                           # not yet used
-pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:teal;\">$1</span>"; }
+pr_litecyan()   { pr_litecyan_term "$1"; out_html "<span style=\"color:lightcyan;\">$1</span>"; }
 pr_litecyanln_term() { pr_litecyan_term "$1"; outln_term; }
 pr_litecyanln() { pr_litecyan "$1"; outln; }
 pr_cyan_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;36m$1" || out_term "$1"; pr_off; }                                # additional hint
-pr_cyan()       { pr_cyan_term "$1"; out_html "<span style=\"color:teal;font-weight:bold;\">$1</span>"; }
+pr_cyan()       { pr_cyan_term "$1"; out_html "<span style=\"color:cyan;font-weight:bold;\">$1</span>"; }
 pr_cyanln_term() { pr_cyan_term "$1"; outln_term; }
 pr_cyanln()     { pr_cyan "$1"; outln; }
 
 pr_litegreyln_term() { pr_litegrey_term "$1"; outln_term; }                                                                  # not really usable on a black background, see ..
 pr_litegreyln() { pr_litegrey "$1"; outln; }
 pr_litegrey_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;37m$1" || out_term "$1"; pr_off; }                             # ... https://github.com/drwetter/testssl.sh/pull/600#issuecomment-276129876
-pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:gray;\">$1</span>"; }
+pr_litegrey()   { pr_litegrey_term "$1"; out_html "<span style=\"color:darkgray;\">$1</span>"; }
 pr_grey_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;30m$1" || out_term "$1"; pr_off; }
 pr_grey()       { pr_grey_term "$1"; out_html "<span style=\"color:grey;font-weight:bold;\">$1</span>"; }
 pr_greyln_term() { pr_grey_term "$1"; outln_term; }
@@ -634,11 +634,11 @@ pr_done_bestln_term() { pr_done_best_term "$1"; outln_term; }
 pr_done_bestln()    { pr_done_best "$1"; outln; }
 
 pr_svrty_low_term()  { [[ "$COLOR" -eq 2 ]] && out_term "\033[1;33m$1" || out_term "$1"; pr_off; }         # yellow brown | academic or minor problem
-pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:olive;font-weight:bold;\">$1</span>"; }
+pr_svrty_low()       { pr_svrty_low_term "$1"; out_html "<span style=\"color:yellow;font-weight:bold;\">$1</span>"; }
 pr_svrty_lowln_term() { pr_svrty_low_term "$1"; outln_term; }
 pr_svrty_lowln()     { pr_svrty_low "$1"; outln; }
 pr_svrty_medium_term() { [[ "$COLOR" -eq 2 ]] && out_term "\033[0;33m$1" || out_term "$1"; pr_off; }       # brown | it is not a bad problem but you shouldn't do this
-pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:olive;\">$1</span>"; }
+pr_svrty_medium()    { pr_svrty_medium_term "$1"; out_html "<span style=\"color:chocolate;\">$1</span>"; }
 pr_svrty_mediumln_term() { pr_svrty_medium_term "$1"; outln_term; }
 pr_svrty_mediumln()  { pr_svrty_medium "$1"; outln; }
 
@@ -652,7 +652,7 @@ pr_svrty_criticalln_term() { pr_svrty_critical_term "$1"; outln_term; }
 pr_svrty_criticalln(){ pr_svrty_critical "$1"; outln; }
 
 pr_deemphasize_term() { out_term "$1"; }                                                                   # hook for a weakened screen output, see #600
-pr_deemphasize()      { pr_deemphasize_term "$1"; out_html "<span style=\"color:gray;\">$1</span>"; }
+pr_deemphasize()      { pr_deemphasize_term "$1"; out_html "<span style=\"color:darkgray;\">$1</span>"; }
 pr_deemphasizeln_term() { pr_deemphasize_term "$1"; outln_term; }
 pr_deemphasizeln()    { pr_deemphasize "$1"; outln; }
 
@@ -673,9 +673,9 @@ pr_strikethruln() { pr_strikethru "$1" ; outln; }
 pr_underline_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[4m$1" || out_term "$1"; pr_off; }
 pr_underline()    { pr_underline_term "$1"; out_html "<u>$1</u>"; }
 pr_reverse_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[7m$1" || out_term "$1"; pr_off; }
-pr_reverse()      { pr_reverse_term "$1"; out_html "<span style=\"color:gray;background-color:black;\">$1</span>"; }
+pr_reverse()      { pr_reverse_term "$1"; out_html "<span style=\"color:white;background-color:black;\">$1</span>"; }
 pr_reverse_bold_term() { [[ "$COLOR" -ne 0 ]] && out_term "\033[7m\033[1m$1" || out_term "$1"; pr_off; }
-pr_reverse_bold() { pr_reverse_bold_term "$1"; out_html "<span style=\"color:gray;background-color:black;font-weight:bold;\">$1</span>"; }
+pr_reverse_bold() { pr_reverse_bold_term "$1"; out_html "<span style=\"color:white;background-color:black;font-weight:bold;\">$1</span>"; }
 
 #pr_headline() { pr_blue "$1"; }
 #http://misc.flogisoft.com/bash/tip_colors_and_formatting


### PR DESCRIPTION
As described in #619, this PR adds the option for testssl.sh to create HTML. The option may be invoked using either `--html` or `--htmlfile <filename>`. If the latter is used, "\<filename\>" may be the name of a file or a directory.

If a file name is provided, then all of the output is sent to that file, and the HTML output looks very similar to what is displayed in the terminal. If a file name is not provided and mass testing is being performed, then the output for each line in the file provided to `--file` is placed in a separate HTML file.

The colors that are used in the HTML output are specified in the `pr_...()` functions and in `emphasize_stuff_in_headers()`. As the choice of colors is subjective, this could certainly use some minor adjustments. In some cases I tried to closely match the colors that appear in the terminal. However, that isn't always possible since testssl.sh creates different colors in different terminals.

One issue to be noted is that when output is created using `out_row_aligned_max_width()`, the width used for the HTML output is `$TERM_WIDTH`. 