### PR TITLE
run_protocols() bug fix

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4506,7 +4506,7 @@ run_protocols() {
                ;;                                  # GCM cipher in TLS 1.2: very good!
           1)
                pr_svrty_mediumln "not offered"
-               if ! "$using_sockets" || ! "$EXPERIMENTAL" || [[ -z $latest_supported ]]; then
+               if ! "$using_sockets" || [[ -z $latest_supported ]]; then
                     fileout "tls1_2" "MEDIUM" "TLSv1.2 is not offered" # no GCM, penalty
                else
                     pr_svrty_criticalln " -- connection failed rather than downgrading to $latest_supported_string"

--- a/testssl.sh
+++ b/testssl.sh
@@ -4505,8 +4505,9 @@ run_protocols() {
                add_tls_offered "tls1_2"
                ;;                                  # GCM cipher in TLS 1.2: very good!
           1)
-               pr_svrty_mediumln "not offered"
+               pr_svrty_medium "not offered"
                if ! "$using_sockets" || [[ -z $latest_supported ]]; then
+                    outln
                     fileout "tls1_2" "MEDIUM" "TLSv1.2 is not offered" # no GCM, penalty
                else
                     pr_svrty_criticalln " -- connection failed rather than downgrading to $latest_supported_string"


### PR DESCRIPTION
Since the test for TLS 1.2 in `run_protocols()` now uses `tls_sockets()` whenever `$ssl_native` is `true` (i.e., there is no longer a requirement for `$EXPERIMENTAL` to be true as well), the `$EXPERIMENTAL` flag should no longer be checked if the return value is 1.