### PR TITLE
Add option to print only the RFC cipher names

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -227,8 +227,7 @@ HAS_FALLBACK_SCSV=false
 HAS_PROXY=false
 HAS_XMPP=false
 HAS_POSTGRES=false
-ADD_RFC_STR="rfc"                       # display RFC ciphernames
-SHOW_RFC=""                             # display RFC ciphernames instead of OpenSSL ciphernames
+DISPLAY_CIPHERNAMES="openssl"           # display OpenSSL ciphername (but both OpenSSL and RFC ciphernames in wide mode)
 PORT=443                                # unless otherwise auto-determined, see below
 NODE=""
 NODEIP=""
@@ -2272,8 +2271,21 @@ show_rfc_style(){
 }
 
 neat_header(){
-     printf -- "Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.   Encryption  Bits${ADD_RFC_STR:+     Cipher Suite Name (RFC)}\n"
-     printf -- "%s--------------------------------------------------------------------------${ADD_RFC_STR:+---------------------------------------------------}\n"
+     if [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]]; then
+          printf -- "Hexcode  Cipher Suite Name (RFC)                           KeyExch.   Encryption  Bits"
+          [[ "$DISPLAY_CIPHERNAMES" != "rfc-only" ]] && printf -- "     Cipher Suite Name (OpenSSL)"
+          outln
+          printf -- "%s------------------------------------------------------------------------------------------"
+          [[ "$DISPLAY_CIPHERNAMES" != "rfc-only" ]] && printf -- "---------------------------------------"
+          outln
+     else
+          printf -- "Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.   Encryption  Bits"
+          [[ "$DISPLAY_CIPHERNAMES" != "openssl-only" ]] && printf -- "     Cipher Suite Name (RFC)"
+          outln
+          printf -- "%s--------------------------------------------------------------------------"
+          [[ "$DISPLAY_CIPHERNAMES" != "openssl-only" ]] && printf -- "---------------------------------------------------"
+          outln
+     fi
 }
 
 
@@ -2300,10 +2312,16 @@ neat_list(){
 
      echo "$export" | grep -iq export && strength="$strength,exp"
 
-     [[ -n "$ADD_RFC_STR" ]] && tls_cipher="$(show_rfc_style "$hexcode")"
+     [[ "$DISPLAY_CIPHERNAMES" != "openssl-only" ]] && tls_cipher="$(show_rfc_style "$hexcode")"
 
      if [[ "$5" == "false" ]]; then
-          line="$(printf -- " %-7s %-33s %-10s %-12s%-8s${ADD_RFC_STR:+ %-49s}${SHOW_EACH_C:+  %-0s}" "$hexcode" "$ossl_cipher" "$kx" "$enc" "$strength" "$tls_cipher")"
+          if [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]]; then
+               line="$(printf -- " %-7s %-49s %-10s %-12s%-8s" "$hexcode" "$tls_cipher" "$kx" "$enc" "$strength")"
+               [[ "$DISPLAY_CIPHERNAMES" != "rfc-only" ]] && line+="$(printf -- " %-33s${SHOW_EACH_C:+  %-0s}" "$ossl_cipher")"
+          else
+               line="$(printf -- " %-7s %-33s %-10s %-12s%-8s" "$hexcode" "$ossl_cipher" "$kx" "$enc" "$strength")"
+               [[ "$DISPLAY_CIPHERNAMES" != "openssl-only" ]] && line+="$(printf -- " %-49s${SHOW_EACH_C:+  %-0s}" "$tls_cipher")"
+          fi
           pr_deemphasize "$line"
           return 0
      fi
@@ -2320,7 +2338,13 @@ neat_list(){
           done
      fi
      #echo "${#kx}"                            # should be always 20 / 13
-     printf -- " %-7s %-33s %-10s %-12s%-8s${ADD_RFC_STR:+ %-49s}${SHOW_EACH_C:+  %-0s}" "$hexcode" "$ossl_cipher" "$kx" "$enc" "$strength" "$tls_cipher"
+     if [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]]; then
+          printf -- " %-7s %-49s %-10s %-12s%-8s" "$hexcode" "$tls_cipher" "$kx" "$enc" "$strength"
+          [[ "$DISPLAY_CIPHERNAMES" != "rfc-only" ]] && printf -- " %-33s${SHOW_EACH_C:+  %-0s}" "$ossl_cipher"
+     else
+          printf -- " %-7s %-33s %-10s %-12s%-8s" "$hexcode" "$ossl_cipher" "$kx" "$enc" "$strength"
+          [[ "$DISPLAY_CIPHERNAMES" != "openssl-only" ]] && printf -- " %-49s${SHOW_EACH_C:+  %-0s}" "$tls_cipher"
+     fi
 }
 
 test_just_one(){
@@ -4178,10 +4202,10 @@ run_client_simulation() {
                fi
                #FiXME: awk
                cipher=$(grep -wa Cipher $TMPFILE | egrep -avw "New|is" | sed -e 's/ //g' -e 's/^Cipher://')
-               if [[ -z "$SHOW_RFC" ]] && ( [[ "$cipher" == TLS_* ]] || [[ "$cipher" == SSL_* ]] ); then
+               if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && ( [[ "$cipher" == TLS_* ]] || [[ "$cipher" == SSL_* ]] ); then
                     cipher="$(rfc2openssl "$cipher")"
                     [[ -z "$cipher" ]] && cipher=$(grep -wa Cipher $TMPFILE | egrep -avw "New|is" | sed -e 's/ //g' -e 's/^Cipher://')
-               elif [[ -n "$SHOW_RFC" ]] && [[ "$cipher" != TLS_* ]] && [[ "$cipher" != SSL_* ]]; then
+               elif [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]] && [[ "$cipher" != TLS_* ]] && [[ "$cipher" != SSL_* ]]; then
                     cipher="$(openssl2rfc "$cipher")"
                     [[ -z "$cipher" ]] && cipher=$(grep -wa Cipher $TMPFILE | egrep -avw "New|is" | sed -e 's/ //g' -e 's/^Cipher://')
                fi
@@ -4944,7 +4968,7 @@ run_server_preference() {
 
           pr_bold " Negotiated cipher            "
           default_cipher_ossl=$(grep -aw "Cipher" $TMPFILE | egrep -avw "New|is" | sed -e 's/^.*Cipher.*://' -e 's/ //g')
-          if [[ -z "$SHOW_RFC" ]]; then
+          if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]]; then
                default_cipher="$default_cipher_ossl"
           else
                default_cipher="$(openssl2rfc "$default_cipher_ossl")"
@@ -5003,7 +5027,7 @@ run_server_preference() {
                                              cipher1="${TLS_CIPHER_HEXCODE[j]}"
                                              cipher1="$(tolower "x${cipher1:2:2}${cipher1:7:2}${cipher1:12:2}")"
                                              if [[ "$supported_sslv2_ciphers" =~ "$cipher1" ]]; then
-                                                  if ( [[ -z "$SHOW_RFC" ]] && [[ "${TLS_CIPHER_OSSL_NAME[j]}" != "-" ]] ) || [[ "${TLS_CIPHER_RFC_NAME[j]}" == "-" ]]; then
+                                                  if ( [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && [[ "${TLS_CIPHER_OSSL_NAME[j]}" != "-" ]] ) || [[ "${TLS_CIPHER_RFC_NAME[j]}" == "-" ]]; then
                                                        cipher[i]="${TLS_CIPHER_OSSL_NAME[j]}"
                                                   else
                                                        cipher[i]="${TLS_CIPHER_RFC_NAME[j]}"
@@ -5028,7 +5052,7 @@ run_server_preference() {
                                    proto[i]="SSLv3"
                                    cipher[i]=""
                                    cipher1=$(awk '/Cipher *:/ { print $3 }' "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt")
-                                   if [[ -z "$SHOW_RFC" ]] && [[ $TLS_NR_CIPHERS -ne 0 ]]; then
+                                   if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && [[ $TLS_NR_CIPHERS -ne 0 ]]; then
                                         cipher[i]="$(rfc2openssl "$cipher1")"
                                         [[ -z "${cipher[i]}" ]] && cipher[i]="$cipher1"
                                    fi
@@ -5045,7 +5069,7 @@ run_server_preference() {
                               proto[i]=$(grep -aw "Protocol" $TMPFILE | sed -e 's/^.*Protocol.*://' -e 's/ //g')
                               cipher[i]=$(grep -aw "Cipher" $TMPFILE | egrep -avw "New|is" | sed -e 's/^.*Cipher.*://' -e 's/ //g')
                               [[ ${cipher[i]} == "0000" ]] && cipher[i]=""                     # Hack!
-                              if [[ -n "$SHOW_RFC" ]] && [[ -n "${cipher[i]}" ]]; then
+                              if [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]] && [[ -n "${cipher[i]}" ]]; then
                                    cipher[i]="$(openssl2rfc "${cipher[i]}")"
                                    [[ -z "${cipher[i]}" ]] && cipher[i]=$(grep -aw "Cipher" $TMPFILE | egrep -avw "New|is" | sed -e 's/^.*Cipher.*://' -e 's/ //g')
                               fi
@@ -5069,7 +5093,7 @@ run_server_preference() {
                               cipher[i]=""
                          else
                               cipher[i]=$(grep -aw "Cipher" $TMPFILE | egrep -avw "New|is" | sed -e 's/^.*Cipher.*://' -e 's/ //g')
-                              if [[ -n "$SHOW_RFC" ]] && [[ -n "${cipher[i]}" ]]; then
+                              if [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]] && [[ -n "${cipher[i]}" ]]; then
                                    cipher[i]="$(openssl2rfc "${cipher[i]}")"
                                    [[ -z "${cipher[i]}" ]] && cipher[i]=$(grep -aw "Cipher" $TMPFILE | egrep -avw "New|is" | sed -e 's/^.*Cipher.*://' -e 's/ //g')
                               fi
@@ -5084,7 +5108,7 @@ run_server_preference() {
                     if [[ -n "${cipher[i]}" ]]; then                                      # cipher not empty
                           if [[ -z "${cipher[i-1]}" ]]; then                              # previous one empty
                               #outln
-                              if [[ -z "$SHOW_RFC" ]]; then
+                              if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]]; then
                                    printf -- "     %-30s %s" "${cipher[i]}:" "${proto[i]}"     # print out both
                               else
                                    printf -- "     %-51s %s" "${cipher[i]}:" "${proto[i]}"     # print out both
@@ -5094,7 +5118,7 @@ run_server_preference() {
                                    out ", ${proto[i]}"                                    # same cipher --> only print out protocol behind it
                               else
                                    outln
-                                   if [[ -z "$SHOW_RFC" ]]; then
+                                   if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]]; then
                                         printf -- "     %-30s %s" "${cipher[i]}:" "${proto[i]}"     # print out both
                                    else
                                         printf -- "     %-51s %s" "${cipher[i]}:" "${proto[i]}"     # print out both
@@ -5355,14 +5379,14 @@ cipher_pref_check() {
                     for (( i=0; i < nr_ciphers; i++ )); do
                          [[ "$cipher" == "${rfc_ciph[i]}" ]] && ciphers_found2[i]=true && break
                     done
-                    if [[ -z "$SHOW_RFC" ]] && [[ $TLS_NR_CIPHERS -ne 0 ]]; then
+                    if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && [[ $TLS_NR_CIPHERS -ne 0 ]]; then
                          cipher="$(rfc2openssl "$cipher")"
                          # If there is no OpenSSL name for the cipher, then use the RFC name
                          [[ -z "$cipher" ]] && cipher=$(awk '/Cipher *:/ { print $3 }' "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt")
                     fi
                     order+="$cipher "
                done
-          elif [[ -n "$order" ]] && [[ -n "$SHOW_RFC" ]]; then
+          elif [[ -n "$order" ]] && [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]]; then
                rfc_order=""
                while read -d " " cipher; do
                     rfc_ciph="$(openssl2rfc "$cipher")"
@@ -5404,7 +5428,7 @@ cipher_pref_check() {
                          order+="$cipher "
                     done
                fi
-               if [[ -n "$order" ]] && [[ -n "$SHOW_RFC" ]]; then
+               if [[ -n "$order" ]] && [[ "$DISPLAY_CIPHERNAMES" =~ "rfc" ]]; then
                     rfc_order=""
                     while read -d " " cipher; do
                          rfc_ciph="$(openssl2rfc "$cipher")"
@@ -6946,7 +6970,7 @@ run_pfs() {
           for (( i=0; i < nr_supported_ciphers; i++ )); do
                ! "${ciphers_found[i]}" && ! "$SHOW_EACH_C" && continue
                if "${ciphers_found[i]}"; then
-                    if ( [[ -z "$SHOW_RFC" ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
+                    if ( [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
                          pfs_cipher="${ciph[i]}"
                     else
                          pfs_cipher="${rfc_ciph[i]}"
@@ -10535,7 +10559,7 @@ run_beast(){
                     [[ "$cbc_cipher" == "${ciph[i]}" ]] && break
                done
                ciphers_found[i]=true
-               if [[ -z "$SHOW_RFC" ]] || [[ "${rfc_ciph[i]}" == "-" ]]; then
+               if [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] || [[ "${rfc_ciph[i]}" == "-" ]]; then
                     detected_cbc_ciphers+="${ciph[i]} "
                else
                     detected_cbc_ciphers+="${rfc_ciph[i]} "
@@ -10566,7 +10590,7 @@ run_beast(){
                          [[ "$cbc_cipher" == "${rfc_ciph[i]}" ]] && break
                     done
                     ciphers_found[i]=true
-                    if ( [[ -z "$SHOW_RFC" ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
+                    if ( [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
                          detected_cbc_ciphers+=" ${ciph[i]}"
                     else
                          detected_cbc_ciphers+=" ${rfc_ciph[i]}"
@@ -10943,7 +10967,7 @@ run_rc4() {
                     outln "${sigalg[i]}"
                fi
                if "${ciphers_found[i]}"; then
-                    if ( [[ -z "$SHOW_RFC" ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
+                    if ( [[ "$DISPLAY_CIPHERNAMES" =~ "openssl" ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
                          rc4_detected+="${ciph[i]} "
                     else
                          rc4_detected+="${rfc_ciph[i]} "
@@ -11038,8 +11062,7 @@ get_install_dir() {
      fi
 
      if [[ ! -r "$CIPHERS_BY_STRENGTH_FILE" ]]; then
-          unset ADD_RFC_STR
-          unset SHOW_RFC
+          DISPLAY_CIPHERNAMES="no-rfc"
           debugme echo "$CIPHERS_BY_STRENGTH_FILE"
           pr_warningln "\nATTENTION: No cipher mapping file found!"
           outln "Please note from 2.9dev on $PROG_NAME needs files in \"\$TESTSSL_INSTALL_DIR/etc/\" to function correctly."
@@ -11295,7 +11318,9 @@ output options (can also be preset via environment variables):
      --quiet                       don't output the banner. By doing this you acknowledge usage terms normally appearing in the banner
      --wide                        wide output for tests like RC4, BEAST. PFS also with hexcode, kx, strength, RFC name
      --show-each                   for wide outputs: display all ciphers tested -- not only succeeded ones
-     --mapping <rfc|no-rfc>        (rfc: display the RFC Cipher Suite name instead of the OpenSSL name;
+     --mapping <openssl|rfc|       (openssl: use the OpenSSL Cipher suite name as the primary name cipher suite name form (default);
+                no-openssl|no-rfc>  rfc: use the RFC Cipher suite name as the primary name cipher suite name form;
+                                    no-openssl: don't display the OpenSSL Cipher Suite Name;
                                     no-rfc: don't display the RFC Cipher Suite Name)
      --color <0|1|2>               0: no escape or other codes,  1: b/w escape codes,  2: color (default)
      --colorblind                  swap green and blue in the output
@@ -12737,9 +12762,11 @@ parse_cmd_line() {
                     cipher_mapping=$(parse_opt_equal_sign "$1" "$2")
                     [[ $? -eq 0 ]] && shift
                     case "$cipher_mapping" in
-                         no-rfc) unset ADD_RFC_STR; unset SHOW_RFC;;
-                         rfc) SHOW_RFC="rfc" ;;
-                         *)   pr_magentaln "\nmapping can only be \"rfc\" or \"no-rfc\""
+                         no-openssl) DISPLAY_CIPHERNAMES="rfc-only" ;;
+                         no-rfc) DISPLAY_CIPHERNAMES="openssl-only" ;;
+                         openssl) DISPLAY_CIPHERNAMES="openssl" ;;
+                         rfc) DISPLAY_CIPHERNAMES="rfc" ;;
+                         *)   pr_magentaln "\nmapping can only be \"no-openssl\", \"no-rfc\", \"openssl\", or \"rfc\""
                               help 1 ;;
                     esac
                     ;;


### PR DESCRIPTION
This PR attempts to address #631. It allows four choices for the `--mapping` option. "openssl" (default), "rfc", "no-openssl", and "no-rfc".

* "openssl" is the current default

* "no-rfc" shows only the OpenSSL names (just as it currently does)

* "rfc" shows the RFC name rather than the OpenSSL name for things that are not in wide now (just as it currently does). But now, in wide mode, it shows the RFC name first (further to the left) and the OpenSSL name second.

* "rfc-only" shows only the RFC name.

If the `--mapping` option is not provided, this is the same as "openssl". If the "cipher-mapping.txt" file cannot be found, then testssl.sh runs as if "no-rfc" had been requested.