### PR TITLE
Cleanup extraction of TLS extensions

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5091,7 +5091,7 @@ extract_new_tls_extensions() {
           # check to see if any new TLS extensions were returned and add any new ones to TLS_EXTENSIONS
           while read -d "\"" -r line; do
                if [[ $line != "" ]] && [[ ! "$TLS_EXTENSIONS" =~ "$line" ]]; then
-  #FIXME: This is a string of quoted strings, so this seems to deterime the output format already. Better e.g. would be an array         
+#FIXME: This is a string of quoted strings, so this seems to determine the output format already. Better e.g. would be an array         
                     TLS_EXTENSIONS+=" \"${line}\""
                fi
           done <<<$tls_extensions


### PR DESCRIPTION
Currently there is code to extract TLS extensions in three places, in `get_server_certificate()` and two places in `determine_tls_extensions()`. This PR replaces them with one new function, `extract_new_tls_extensions()`.

In order for the new function to work correctly whether OpenSSL or `tls_sockets()` is being used, this PR also changes `parse_tls_serverhello()` so that extensions are formatted in the file it creates in the same way as they are formatted by OpenSSL.