### PR TITLE
Missing HTML banner

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1075,7 +1075,7 @@ html_header() {
 }
 
 html_banner() {
-     if ! "$APPEND" && "$HTMLHEADER"; then
+     if "$APPEND" && "$HTMLHEADER"; then
           html_out "## Scan started as: \"$PROG_NAME $CMDLINE\"\n"
           html_out "## at $HNAME:$OPENSSL_LOCATION\n"
           html_out "## version testssl: $VERSION ${GIT_REL_SHORT:-$CVS_REL_SHORT} from $REL_DATE\n"


### PR DESCRIPTION
With the commit made on March 26, "partly (1/2) fixing #653," an HTML banner isn't added to the HTML files anymore.  A banner should be added to the top of the HTML file if mass testing is being performed and a separate HTML file is being created for each test.

The `$APPEND` flag being `true` is an indicator that mass testing is being performed and that this is one of the individual tests being run. Given that `$APPEND` is `true`, `$HTMLHEADER` being `true` indicates that testssl.sh is creating the file name for the HTML output. So, it is when both flags are `true` that the HTML banner should be created.