### PR TITLE
Populate OPENSSL_LOCATION in find_openssl_binary

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10544,6 +10544,7 @@ test_openssl_suffix() {
 find_openssl_binary() {
      local s_client_has=$TEMPDIR/s_client_has.txt
      local s_client_starttls_has=$TEMPDIR/s_client_starttls_has.txt
+     local openssl_location cwd=""
 
      # 0. check environment variable whether it's executable
      if [[ -n "$OPENSSL" ]] && [[ ! -x "$OPENSSL" ]]; then
@@ -10589,6 +10590,18 @@ find_openssl_binary() {
      fi
 
      initialize_engine
+
+     openssl_location="$(which $OPENSSL)"
+     [[ -n "$GIT_REL" ]] && \
+          cwd=$(/bin/pwd) || \
+          cwd=$RUN_DIR
+     if [[ "$openssl_location" =~ $(/bin/pwd)/bin ]]; then
+          OPENSSL_LOCATION="\$PWD/bin/$(basename "$openssl_location")"
+     elif [[ "$openssl_location" =~ $cwd ]] && [[ "$cwd" != '.' ]]; then
+          OPENSSL_LOCATION="${openssl_location%%$cwd}"
+     else
+         OPENSSL_LOCATION="$openssl_location"
+     fi
 
      OPENSSL_NR_CIPHERS=$(count_ciphers "$($OPENSSL ciphers 'ALL:COMPLEMENTOFALL:@STRENGTH' 2>/dev/null)")
 
@@ -10923,8 +10936,6 @@ prepare_arrays() {
 mybanner() {
      local idtag
      local bb1 bb2 bb3
-     local openssl_location="$(which $OPENSSL)"
-     local cwd=""
 
      $QUIET && return
      OPENSSL_NR_CIPHERS=$(count_ciphers "$($OPENSSL ciphers 'ALL:COMPLEMENTOFALL:@STRENGTH' 2>/dev/null)")
@@ -10962,17 +10973,6 @@ EOF
      outln "\n"
      outln " Using \"$($OPENSSL version 2>/dev/null)\" [~$OPENSSL_NR_CIPHERS ciphers]"
      out " on $HNAME:"
-
-     [[ -n "$GIT_REL" ]] && \
-          cwd=$(/bin/pwd) || \
-          cwd=$RUN_DIR
-     if [[ "$openssl_location" =~ $(/bin/pwd)/bin ]]; then
-          OPENSSL_LOCATION="\$PWD/bin/$(basename "$openssl_location")"
-     elif [[ "$openssl_location" =~ $cwd ]] && [[ "$cwd" != '.' ]]; then
-          OPENSSL_LOCATION="${openssl_location%%$cwd}"
-     else
-         OPENSSL_LOCATION="$openssl_location"
-     fi
      outln "$OPENSSL_LOCATION"
      outln " (built: \"$OSSL_BUILD_DATE\", platform: \"$OSSL_VER_PLATFORM\")\n"
 }

--- a/testssl.sh
+++ b/testssl.sh
@@ -10484,8 +10484,8 @@ find_openssl_binary() {
 
      openssl_location="$(which $OPENSSL)"
      [[ -n "$GIT_REL" ]] && \
-          cwd=$(/bin/pwd) || \
-          cwd=$RUN_DIR
+          cwd="$(/bin/pwd)" || \
+          cwd="$RUN_DIR"
      if [[ "$openssl_location" =~ $(/bin/pwd)/bin ]]; then
           OPENSSL_LOCATION="\$PWD/bin/$(basename "$openssl_location")"
      elif [[ "$openssl_location" =~ $cwd ]] && [[ "$cwd" != '.' ]]; then


### PR DESCRIPTION
`$OPENSSL_LOCATION` is used in `fileout_pretty_json_banner()`, `html_banner()`, `mybanner()`, and `prepare_logging()`, but the value of `$OPENSSL_LOCATION` is populated in `mybanner()`. This is usually okay, since `mybanner()` is always called before the other three functions are called. However, if `$QUIET` is `true`, then `mybanner()` returns immediately, without populating `$OPENSSL_LOCATION`, even though the value of `$OPENSSL_LOCATION` may be needed by one or more of the other functions.

This PR addresses this problem by populating `$OPENSSL_LOCATION` in `find_openssl_binary()` rather than `mybanner()`.