### PR TITLE
Dockerfile for testssl.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM debian:latest
 
 RUN apt-get update && apt-get install -y git bsdmainutils dnsutils ldnsutils host
 
-#ADD ./ /testssl/
-
 RUN git clone https://github.com/drwetter/testssl.sh.git /testssl.sh/
 
 RUN ln -s /testssl.sh/testssl.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM debian:latest
 
 RUN apt-get update && apt-get install -y git bsdmainutils dnsutils ldnsutils host
 
-RUN git clone https://github.com/drwetter/testssl.sh.git /testssl.sh/
+RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git /testssl.sh/
 
 RUN ln -s /testssl.sh/testssl.sh /usr/local/bin/
 
 WORKDIR /testssl.sh/
 
 ENTRYPOINT ["testssl.sh","--openssl","/testssl.sh/bin/openssl.Linux.x86_64"]
+
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:latest
+
+RUN apt-get update && apt-get install -y git bsdmainutils dnsutils ldnsutils host
+
+#ADD ./ /testssl/
+
+RUN git clone https://github.com/drwetter/testssl.sh.git /testssl.sh/
+
+RUN ln -s /testssl.sh/testssl.sh /usr/local/bin/
+
+WORKDIR /testssl.sh/
+
+ENTRYPOINT ["testssl.sh","--openssl","/testssl.sh/bin/openssl.Linux.x86_64"]

--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -1,0 +1,9 @@
+## Usage:
+```
+docker run -t testssl.sh example.com
+```
+
+Ability to pull image from docker hub:
+```
+docker run -t dr4y/testssl.sh example.com
+```


### PR DESCRIPTION
Added a Dockerfile for using testssl.sh with docker.

Usage:
docker run -t testssl.sh example.com

Ability to pull image from docker hub:
docker run -t dr4y/testssl.sh example.com