### PR TITLE
Fix HTML

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2493,7 +2493,8 @@ std_cipherlists() {
                     ;;
           esac
           tmpfile_handle $FUNCNAME.$debugname.txt
-          [[ $DEBUG -ge 1 ]] && tmln_out " -- $1" || tmln_out
+          [[ $DEBUG -ge 1 ]] && tm_out " -- $1"
+          outln
      else
           singlespaces=$(sed -e 's/ \+/ /g' -e 's/^ //' -e 's/ $//g' -e 's/  //g' <<< "$2")
           if [[ "$OPTIMAL_PROTO" == "-ssl2" ]]; then
@@ -12498,6 +12499,7 @@ ip=""
 lets_roll init
 initialize_globals
 parse_cmd_line "$@"
+html_header
 get_install_dir
 set_color_functions
 maketempf
@@ -12510,7 +12512,6 @@ check4openssl_oldfarts
 check_bsd_mount
 json_header
 csv_header
-html_header
 
 if "$do_display_only"; then
      prettyprint_local "$PATTERN2SHOW"


### PR DESCRIPTION
This PR fixes two issues with HTML generation that were introduced by a commit on March 31, 2016, "[count_ciphers is now un-sed'ed, minor improvements](https://github.com/drwetter/testssl.sh/commit/a480e5f699983207651aa0a8717dc395d13e6e52)."

The first is that in `std_cipherlists()`,
```
     [[ $DEBUG -ge 1 ]] && outln " -- $1" || outln  #FIXME: should be in standard output at some time
```
was changed to
```
     [[ $DEBUG -ge 1 ]] && tmln_out " -- $1" || tmln_out
```
The result being that in the HTML output all of the tests from `run_std_cipherlists()` appear on the same line. This PR changes the line to:
```
          [[ $DEBUG -ge 1 ]] && tm_out " -- $1"
          outln
```
so that the line break is added to the HTML output, but the debugging information is not.
[Note: I had previously included the `" -- $1"` in the HTML output if `$DEBUG -ge 1` based on the "FIXME."]

The second problem is that the commit on March 31 moved the call in main to `html_header()` until after the calls to `get_install_dir()`, `find_openssl_binary()`, `mybanner()`, `check4openssl_oldfarts()`, and `check_bsd_mount()`. The problem is that each of these functions may call an output function that will call `html_out()`.

If `html_out()` is called before `html_header()` and the command line contains `--htmlfile <htmlfile>`, then "htmlfile" will be written to before `html_header()` is called and then `html_header()` will warn that "htmlfile" already exists and exit the program.

If `html_out()` is called before `html_header()` and the command line contains `--html`, then anything sent to `html_out()` before `html_header()` is called (such as the banner) will not appear in the HTML file.