### PR TITLE
Don't read tls_data.txt inside function

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10385,8 +10385,6 @@ get_install_dir() {
           outln
           ignore_no_or_lame "Type \"yes\" to ignore this warning and proceed at your own risk" "yes"
           [[ $? -ne 0 ]] && exit -2
-     else
-          . $TLS_DATA_FILE
      fi
 }
 
@@ -12451,6 +12449,7 @@ lets_roll() {
      json_header
      csv_header
      get_install_dir
+     [[ -r "$TLS_DATA_FILE" ]] && . $TLS_DATA_FILE
      set_color_functions
      maketempf
      find_openssl_binary


### PR DESCRIPTION
I was doing some testing on my extended_tls_sockets branch and discovered that it was not fully working since the `TLS13_KEY_SHARES` array was empty. According to https://lists.gnu.org/archive/html/bug-bash/2012-06/msg00068.html, there is an issue when trying to initialize a global array inside a function. (The current code initializes `TLS12_CIPHER`, `TLS_CIPHER`, and `TLS13_KEY_SHARES` within `get_install_dir()`, since tls_data.txt is read in that function.) In fact, according to http://stackoverflow.com/questions/10806357/associative-arrays-are-local-by-default, in order to initialize a global variable in a function, one needs to provide the `-g` option, which was only added in Bash 4.2.

This PR seems to fix the problem by moving the reading of tls_data.txt to the main body of the code rather than reading it within the `get_install_dir()` function.