### PR TITLE
Use $TESTSSL_INSTALL_DIR instead of $RUN_DIR in find_openssl_binary()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -957,17 +957,17 @@ hex2ascii() {
 count_lines() {
      #echo "${$(wc -l <<< "$1")// /}"
      # ^^ bad substitution under bash, zsh ok. For some reason this does the trick:
-     echo $(wc -l <<< "$1")
+     wc -l <<< "$1"
 }
 
 count_words() {
      #echo "${$(wc -w <<< "$1")// /}"
      # ^^ bad substitution under bash, zsh ok. For some reason this does the trick:
-     echo $(wc -w <<< "$1")
+     wc -w <<< "$1"
 }
 
 count_ciphers() {
-     echo $(wc -w <<< "${1//:/ }")
+     wc -w <<< "${1//:/ }"
 }
 
 actually_supported_ciphers() {
@@ -5193,7 +5193,7 @@ get_cn_from_cert() {
      # for e.g. russian sites -esc_msb,utf8 works in an UTF8 terminal -- any way to check platform indepedent?
      # see x509(1ssl):
      subject="$($OPENSSL x509 -in $1 -noout -subject -nameopt multiline,-align,sname,-esc_msb,utf8,-space_eq 2>>$ERRFILE)"
-     echo "$(awk -F'=' '/CN=/ { print $2 }' <<< "$subject")"
+     awk -F'=' '/CN=/ { print $2 }' <<< "$subject"
      return $?
 }
 
@@ -6146,9 +6146,9 @@ get_session_ticket_lifetime_from_serverhello() {
 }
 
 get_san_dns_from_cert() {
-     echo "$($OPENSSL x509 -in "$1" -noout -text 2>>$ERRFILE | \
+     $OPENSSL x509 -in "$1" -noout -text 2>>$ERRFILE | \
           grep -A2 "Subject Alternative Name" | tr ',' '\n' | grep "DNS:" | \
-          sed -e 's/DNS://g' -e 's/ //g' | tr '\n' ' ')"
+          sed -e 's/DNS://g' -e 's/ //g' | tr '\n' ' '
 }
 
 
@@ -9473,7 +9473,7 @@ run_freak() {
                done
                tmln_out
           else
-               echo $(actually_supported_ciphers $exportrsa_cipher_list)
+               actually_supported_ciphers $exportrsa_cipher_list
           fi
      fi
      debugme echo $nr_supported_ciphers

--- a/testssl.sh
+++ b/testssl.sh
@@ -762,7 +762,8 @@ fileout() {
      local hint="$6"
 
      if ( "$do_pretty_json" && [[ "$1" == "service" ]] ) || show_finding "$severity"; then
-         local finding=$(strip_lf "$(newline_to_spaces "$(strip_quote "$3")")")
+         local finding
+         finding=$(strip_lf "$(newline_to_spaces "$(strip_quote "$3")")")
          [[ -f "$JSONFILE" ]] && (fileout_json_finding "$1" "$severity" "$finding" "$cve" "$cwe" "$hint")
          "$do_csv" && \
               echo -e \""$1\"",\"$NODE/$NODEIP\",\"$PORT"\",\""$severity"\",\""$finding"\",\""$cve"\",\""$cwe"\",\""$hint"\"" >> "$CSVFILE"

--- a/testssl.sh
+++ b/testssl.sh
@@ -10466,9 +10466,9 @@ find_openssl_binary() {
      elif [[ -e "/mnt/c/Windows/System32/bash.exe" ]] && test_openssl_suffix "$(dirname "$(which openssl)")"; then
           # 2. otherwise, only if on Bash on Windows, use system binaries only.
           SYSTEM2="WSL"
-     elif test_openssl_suffix "$RUN_DIR"; then
+     elif test_openssl_suffix "$TESTSSL_INSTALL_DIR"; then
           :    # 3. otherwise try openssl in path of testssl.sh
-     elif test_openssl_suffix "$RUN_DIR/bin"; then
+     elif test_openssl_suffix "$TESTSSL_INSTALL_DIR/bin"; then
           :    # 4. otherwise here, this is supposed to be the standard --platform independed path in the future!!!
      elif test_openssl_suffix "$(dirname "$(which openssl)")"; then
           :    # 5. we tried hard and failed, so now we use the system binaries

--- a/testssl.sh
+++ b/testssl.sh
@@ -5328,7 +5328,7 @@ must_staple() {
      # Note this function is only looking for status_request (5) and not
      # status_request_v2 (17), since OpenSSL seems to only include status_request (5)
      # in its ClientHello when the "-status" option is used.
-     
+
      # OpenSSL 1.1.0 supports pretty-printing the "TLS Feature extension." For any
      # previous versions of OpenSSL, OpenSSL can only show if the extension OID is present.
      if $OPENSSL x509 -in "$HOSTCERT" -noout -text 2>>$ERRFILE | grep -A 1 "TLS Feature:" | grep -q "status_request"; then
@@ -10847,7 +10847,7 @@ mybanner() {
      bb1=$(cat <<EOF
 
 ###########################################################
-    $PROG_NAME       $VERSION from 
+    $PROG_NAME       $VERSION from
 EOF
 )
      bb2=$(cat <<EOF
@@ -12605,4 +12605,3 @@ lets_roll() {
 
 #main
 exit $?
-


### PR DESCRIPTION
find_openssl_binary() should use $TESTSSL_INSTALL_DIR instead of $RUN_DIR once get_install_dir() has discovered it, especially since $TESTSSL_INSTALL_DIR is set to $RUN_DIR if it is correct.  

I have a symlink in /usr/local/bin pointing to testssl.sh so I can run it from anywhere.  Before making this change, it was looking for openssl in /usr/local/bin, failing, using the default system openssl, and complaining about GOST support.  