### PR TITLE
Use $TESTSSL_INSTALL_DIR instead of $RUN_DIR in find_openssl_binary() - Second Try

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10697,9 +10697,9 @@ find_openssl_binary() {
      elif [[ -e "/mnt/c/Windows/System32/bash.exe" ]] && test_openssl_suffix "$(dirname "$(which openssl)")"; then
           # 2. otherwise, only if on Bash on Windows, use system binaries only.
           SYSTEM2="WSL"
-     elif test_openssl_suffix "$RUN_DIR"; then
+     elif test_openssl_suffix "$TESTSSL_INSTALL_DIR"; then
           :    # 3. otherwise try openssl in path of testssl.sh
-     elif test_openssl_suffix "$RUN_DIR/bin"; then
+     elif test_openssl_suffix "$TESTSSL_INSTALL_DIR/bin"; then
           :    # 4. otherwise here, this is supposed to be the standard --platform independed path in the future!!!
      elif test_openssl_suffix "$(dirname "$(which openssl)")"; then
           :    # 5. we tried hard and failed, so now we use the system binaries


### PR DESCRIPTION
find_openssl_binary() should use $TESTSSL_INSTALL_DIR instead of $RUN_DIR once get_install_dir() has discovered it, especially since $TESTSSL_INSTALL_DIR is set to $RUN_DIR if it is correct.

I have a symlink in /usr/local/bin pointing to testssl.sh so I can run it from anywhere. Before making this change, it was looking for openssl in /usr/local/bin, failing, using the default system openssl, and complaining about GOST support.