### PR TITLE
Use exit $ret at the end of the script

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -12990,5 +12990,5 @@ lets_roll() {
 #}
 
 #main
-exit $?
+exit $ret
 


### PR DESCRIPTION
$? has an exitcode of the previous if then fi statement, and because of that it's always 0; we need to use exit $ret here to correctly pickup what returned by `lets_roll` function.

It seems like an relict of `main()` function that existed before to me.