### PR TITLE
proxy support: update HTTP CONNECT to conform RFC2616

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6973,7 +6973,7 @@ fd_socket() {
                pr_magenta "$PROG_NAME: unable to open a socket to proxy $PROXYIP:$PROXYPORT"
                return 6
           fi
-          echo "CONNECT $nodeip:$PORT" >&5
+          echo -en "CONNECT $NODE:$PORT HTTP/1.1\r\nHost: $NODE:$PORT\r\n\r\n" >&5
           while true ; do
                read proyxline <&5
                if [[ "${proyxline%/*}" == "HTTP" ]]; then


### PR DESCRIPTION
When connecting to the proxy we should include the Host-header into the
request. This is required by RFC2616 section 14.23: "A client MUST
include a Host header field in all HTTP/1.1 request messages".

While without this change some proxies reject connections, no such
problems appear with this patch applied.

This patcht furhter puts the $NODE into the URI rather than the $nodeip so
the DNS lookup is performed by the proxy. This fixes problems when scanning hosts
that can not be resolved by the local machine but can be resolved by the proxy.

Signed-off-by: Thomas Niederprüm <thomas.niederpruem@optimabit.com>