### PR TITLE
Prevent broken pipe error

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11484,7 +11484,7 @@ prepare_logging() {
      tmln_out "## at $HNAME:$OPENSSL_LOCATION" >>"$LOGFILE"
      tmln_out "## version testssl: $VERSION ${GIT_REL_SHORT:-$CVS_REL_SHORT} from $REL_DATE" >>"$LOGFILE"
      tmln_out "## version openssl: \"$OSSL_VER\" from \"$OSSL_BUILD_DATE\")\n" >>"$LOGFILE"
-     exec > >(tee -a "$LOGFILE")
+     exec > >(tee -a -i "$LOGFILE")
 }
 
 


### PR DESCRIPTION
When the `--log`, `--logging`, or `--logfile <logfile>` option is being used and testssl.sh is stopped, a "printf: write error: Broken pipe" message tends to appear (at least on my Linux desktop). From what I can tell, this is a result of the `tee` process being killed before the `cleanup ()` function completes. At the moment, `cleanup ()` doesn't write very much to `stdout`, but if parallel mass testing is performed, then `cleanup ()` may try to write the results of several previously completed tests.

This PR fixes the problem by adding the `-i` option ("ignore interrupt signals") to `tee`.

Note that I have tested this on a Linux desktop and an OS X laptop and it seems to work OK on both, but don't have a MS Windows computer on which to test this change.