### PR TITLE
Stop parent if child encounters parsing error

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -101,6 +101,7 @@ fi
 
 # make sure that temporary files are cleaned up after use in ANY case
 trap "cleanup" QUIT EXIT
+trap "child_error" USR1
 
 readonly VERSION="2.9dev"
 readonly SWCONTACT="dirk aet testssl dot sh"
@@ -11175,6 +11176,7 @@ URI always needs to be the last parameter.
 
 EOF
      #' Fix syntax highlight on sublime
+     "$CHILD_MASS_TESTING" && kill -s USR1 $PPID
      exit $1
 }
 
@@ -11384,6 +11386,11 @@ cleanup () {
      fileout_footer
      # debugging off, see above
      grep -q xtrace <<< "$SHELLOPTS" && ! "$DEBUG_ALLINONE" && exec 2>&42 42>&-
+}
+
+child_error() {
+     cleanup
+     exit 1
 }
 
 fatal() {


### PR DESCRIPTION
This PR implements the suggestion from #753 for a child process in mass testing to send a signal to the parent to exit if the child encounters an error parsing its command line. At the moment, the child only sends the signal if it encounters an error that results in the `help()` function being called, but that could easily be changed (e.g., to also send a signal if `fatal()` is called in the child process).

In the case of parallel mass testing, the cleanup function needs to call `get_next_message_testing_parallel_result()` for the child that sent the signal, since otherwise the child's error message would not be displayed. Since I cannot tell which child sent the signal, I just call `cleanup()`, which displays the output of all completed child processes. Since the child process will send the signal almost immediately after starting, it can be assumed the that process that send the signal will be the last one that completed, and so its output will be displayed last (so it isn't hidden from the user).

Note that PR #753 is still needed, since there are still scenarios in which a child would not produce any JSON output, but the parent testssl.sh would not exit (e.g., the child process cannot open a socket to the server it is supposed to test). In additional, PR #754 would still be useful, since it would be more user friendly to catch the error in the mass testing file immediately (when possible) rather that partway through a potentially time-consuming testing process.