### PR TITLE
Remove extra line break in debugging output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7686,7 +7686,7 @@ parse_tls_serverhello() {
 
           if [[ $DEBUG -ge 3 ]]; then
                echo  "     protocol (rec. layer):  0x$tls_protocol"
-               echo  "     tls_content_type:       0x$tls_content_type"
+               echo -n "     tls_content_type:       0x$tls_content_type"
                case $tls_content_type in
                     15) tmln_out " (alert)" ;;
                     16) tmln_out " (handshake)" ;;


### PR DESCRIPTION
A [commit](https://github.com/drwetter/testssl.sh/commit/e8b5a82c7e9c082396e2d016b870d4beae352427) that was made on May 15 replaced a `tm_out` with `echo` rather than `echo -n` resulting in an extra line break.