### PR TITLE
Fix CCS Injection detection for MySQL (yaSSL)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9162,7 +9162,7 @@ run_ccs_injection(){
           fi
           ret=0
      elif [[ "$byte6" == "15" ]] && [[ "${tls_hello_ascii:0:4}" == "1503" ]]; then
-          # decyption failed received
+          # decryption failed received
           pr_svrty_critical "VULNERABLE (NOT ok)"
           fileout "ccs" "CRITICAL" "CCS: VULNERABLE" "$cve" "$cwe" "$hint"
           ret=1
@@ -9174,6 +9174,11 @@ run_ccs_injection(){
                out " - alert description type: $byte6"
                fileout "ccs" "WARN" "CCS: probably not vulnerable but received 0x${byte6} instead of 0x15" "$cve" "$cwe" "$hint"
           fi
+     elif [[ $STARTTLS_PROTOCOL == "mysql" ]] && [[ "${tls_hello_ascii:14:12}" == "233038533031" ]]; then
+          # MySQL community edition (yaSSL) returns a MySQL error instead of a TLS Alert
+          # Error: #08S01 Bad handshake
+          pr_done_best "not vulnerable (OK)"
+          fileout "ccs" "OK" "CCS: not vulnerable" "$cve" "$cwe"
      elif [[ "$byte6" == [0-9a-f][0-9a-f] ]] && [[ "${tls_hello_ascii:2:2}" != "03" ]]; then
           pr_warning "test failed"
           out ", probably read buffer too small (${tls_hello_ascii:0:14})"


### PR DESCRIPTION
Another yaSSL server incompatibility. MySQL protects against CCS
Injection by erroring if it sees two CCS requests before the handshake
completes. But instead of returning a TLS alert, it seems to error up
the stack to MySQL which returns its own error message.

Debug output looks like:

```
sending client hello,
reading server hello

1st reply:

sending payload #2 with TLS version x03, x02:
tls_content_type: 16 | tls_protocol: 0000 | byte6: 04

2nd reply:
00000000  16 00 00 02 ff 13 04 23  30 38 53 30 31 42 61 64  |.......#08S01Bad|
00000010  20 68 61 6e 64 73 68 61  6b 65                    | handshake|
0000001a

test failed, probably read buffer too small (16000002FF1304)
```

This patch adds a custom check for this MySQL specific error, as far
down in the error check path as I can.