### PR TITLE
Revert "small performance improvement for prepare_arrays() by replaci…

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11417,7 +11417,7 @@ prepare_arrays() {
                     if [[ $OSSL_VER_MAJOR -lt 1 ]]; then
                          [[ ":${ossl_supported_tls}:" =~ ":${TLS_CIPHER_OSSL_NAME[i]}:" ]] && TLS_CIPHER_OSSL_SUPPORTED[i]=true
                     else
-                         ossl_ciph="$(awk '/\<'"$hexc"'\>/ { print $3 }' <<< "$ossl_supported_tls")"
+                         ossl_ciph="$(grep -w "$hexc" <<< "$ossl_supported_tls" | awk '{ print $3 }')"
                          if [[ -n "$ossl_ciph" ]]; then
                               TLS_CIPHER_OSSL_SUPPORTED[i]=true
                               [[ "$ossl_ciph" != "${TLS_CIPHER_OSSL_NAME[i]}" ]] && TLS_CIPHER_OSSL_NAME[i]="$ossl_ciph"


### PR DESCRIPTION
...ng grep + awk by awk only"

This reverts commit 3b1638f60309b1c4e9636c6f5b62c71b22ff4cd1.

I'm not sure what went wrong here, but these commands are not equivalent.

```
$ export hexc=0x00,0x05 && openssl ciphers -tls2 -V 'ALL:COMPLEMENTOFALL:@STRENGTH' | grep -w "$hexc" -
          0x00,0x05 - RC4-SHA                 SSLv3 Kx=RSA      Au=RSA Enc=RC4(128)  Mac=SHA1
$ export hexc=0x00,0x05 && openssl ciphers -tls2 -V 'ALL:COMPLEMENTOFALL:@STRENGTH' | grep -w "$hexc" - | awk '{ print $3 }'
RC4-SHA
$ export hexc=0x00,0x05 && openssl ciphers -tls2 -V 'ALL:COMPLEMENTOFALL:@STRENGTH' | awk '/\<'"$hexc"'\>/ { print $3 }'
$
```

The old command finds my RC4-SHA cipher, the new one does not.