### PR TITLE
yaSSL and client simulation

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3446,12 +3446,18 @@ client_simulation_sockets() {
      for (( i=0; i < len; i=i+2 )); do
           data+=", ${clienthello:i:2}"
      done
-     # Extact list of cipher suites
-     sid_len=4*$(hex2dec "${data:174:2}")
-     offset1=178+$sid_len
-     offset2=182+$sid_len
-     len=4*$(hex2dec "${data:offset1:2}${data:offset2:2}")-2
-     offset1=186+$sid_len
+     if [[ "${1:0:4}" == "1603" ]]; then
+          # Extact list of cipher suites from SSLv3 or later ClientHello
+          sid_len=4*$(hex2dec "${data:174:2}")
+          offset1=178+$sid_len
+          offset2=182+$sid_len
+          len=4*$(hex2dec "${data:offset1:2}${data:offset2:2}")-2
+          offset1=186+$sid_len
+     else
+          # Extact list of cipher suites from SSLv2 ClientHello
+          offset1=46
+          len=4*$(hex2dec "${data:26:2}")-2
+     fi
      code2network "$(tolower "${data:offset1:len}")"   # convert CIPHER_SUITES to a "standardized" format
      cipher_list_2send="$NW_STR"
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -3435,6 +3435,7 @@ client_simulation_sockets() {
      local cipher_list_2send
      local sock_reply_file2 sock_reply_file3
      local tls_hello_ascii next_packet hello_done=0
+     local -i sid_len offset1 offset2
 
      if [[ "${1:0:4}" == "1603" ]]; then
           clienthello="$(create_client_simulation_tls_clienthello "$1")"
@@ -3445,6 +3446,15 @@ client_simulation_sockets() {
      for (( i=0; i < len; i=i+2 )); do
           data+=", ${clienthello:i:2}"
      done
+     # Extact list of cipher suites
+     sid_len=4*$(hex2dec "${data:174:2}")
+     offset1=178+$sid_len
+     offset2=182+$sid_len
+     len=4*$(hex2dec "${data:offset1:2}${data:offset2:2}")-2
+     offset1=186+$sid_len
+     code2network "$(tolower "${data:offset1:len}")"   # convert CIPHER_SUITES to a "standardized" format
+     cipher_list_2send="$NW_STR"
+
      debugme echo "sending client hello..."
      code2network "${data}"
      data="$NW_STR"
@@ -3496,7 +3506,7 @@ client_simulation_sockets() {
           echo
      fi
 
-     parse_tls_serverhello "$tls_hello_ascii" "ephemeralkey"
+     parse_tls_serverhello "$tls_hello_ascii" "ephemeralkey" "$cipher_list_2send"
      save=$?
 
      if [[ $save -eq 0 ]]; then


### PR DESCRIPTION
This PR adds the same additional check to `client_simulation_sockets()` as was previously added to `tls_sockets()`. It extracts the list of cipher suites offered from each ClientHello and passes the list to `parse_tls_serverhello()` so that `parse_tls_serverhello()` can check that the cipher offered in the ServerHello was included in the ClientHello.

This assumes that a real client would abort the connection if it was presented with a cipher in the ServerHello that it didn't offer in its ClientHello.