### PR TITLE
Client simulation and SSLv2 servers

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3483,8 +3483,10 @@ client_simulation_sockets() {
      tls_hello_ascii=$(hexdump -v -e '16/1 "%02X"' "$SOCK_REPLY_FILE")
      tls_hello_ascii="${tls_hello_ascii%%[!0-9A-F]*}"
 
-     check_tls_serverhellodone "$tls_hello_ascii"
-     hello_done=$?
+     if [[ "${tls_hello_ascii:0:1}" != "8" ]]; then
+          check_tls_serverhellodone "$tls_hello_ascii"
+          hello_done=$?
+     fi
 
      for(( 1 ; hello_done==1; 1 )); do
           sock_reply_file2=${SOCK_REPLY_FILE}.2
@@ -3522,29 +3524,40 @@ client_simulation_sockets() {
           echo
      fi
 
-     parse_tls_serverhello "$tls_hello_ascii" "ephemeralkey" "$cipher_list_2send"
-     save=$?
-
-     if [[ $save -eq 0 ]]; then
-          debugme echo "sending close_notify..."
-          if [[ "$DETECTED_TLS_VERSION" == "0300" ]]; then
-               socksend ",x15, x03, x00, x00, x02, x02, x00" 0
+     if [[ "${tls_hello_ascii:0:1}" == "8" ]]; then
+          parse_sslv2_serverhello "$SOCK_REPLY_FILE" "false"
+          if [[ $? -eq 3 ]] && [[ "$V2_HELLO_CIPHERSPEC_LENGTH" -ne 0 ]]; then
+               echo "Protocol  : SSLv2" > "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt"
+               DETECTED_TLS_VERSION="0200"
+               ret=0
           else
-               socksend ",x15, x03, x01, x00, x02, x02, x00" 0
+               ret=1
           fi
-     fi
-
-     # see https://secure.wand.net.nz/trac/libprotoident/wiki/SSL
-     lines=$(count_lines "$(hexdump -C "$SOCK_REPLY_FILE" 2>$ERRFILE)")
-     debugme tm_out "  (returned $lines lines)  "
-
-     # determine the return value for higher level, so that they can tell what the result is
-     if [[ $save -eq 1 ]] || [[ $lines -eq 1 ]]; then
-          ret=1          # NOT available
      else
-          ret=0
+          parse_tls_serverhello "$tls_hello_ascii" "ephemeralkey" "$cipher_list_2send"
+          save=$?
+
+          if [[ $save -eq 0 ]]; then
+               debugme echo "sending close_notify..."
+               if [[ "$DETECTED_TLS_VERSION" == "0300" ]]; then
+                    socksend ",x15, x03, x00, x00, x02, x02, x00" 0
+               else
+                    socksend ",x15, x03, x01, x00, x02, x02, x00" 0
+               fi
+          fi
+
+          # see https://secure.wand.net.nz/trac/libprotoident/wiki/SSL
+          lines=$(count_lines "$(hexdump -C "$SOCK_REPLY_FILE" 2>$ERRFILE)")
+          debugme tm_out "  (returned $lines lines)  "
+
+          # determine the return value for higher level, so that they can tell what the result is
+          if [[ $save -eq 1 ]] || [[ $lines -eq 1 ]]; then
+               ret=1          # NOT available
+          else
+               ret=0
+          fi
+          debugme tmln_out
      fi
-     debugme tmln_out
 
      close_socket
      TMPFILE=$SOCK_REPLY_FILE


### PR DESCRIPTION
The data for `run_client_simulation()` currently includes two clients that send version 2.0 CLIENT-HELLO messages (see Appendix E.2 of RFC 5246). Each of the CLIENT-HELLO messages advertises support for newer protocol versions (SSLv3 in the case of IE6XP and TLSv1.0 in the case of Java 6u45). A server may reject one of these version 2.0 CLIENT-HELLO messages, or it may respond with an SSLv2, SSLv3, or TLSv1.0 ServerHello.

The current code in `client_simulation_sockets()` assumes that the server's response with be an SSLv3 or later ServerHello. So, it can support cases in which servers respond with an SSLv3 or TLSv1.0 ServerHello (once PR #800 is accepted to undo the mistake in PR #797), but not cases in which servers response with an SSLv2 ServerHello.

This PR adds code to `client_simulation_sockets()` to check if the server's response is an SSLv2 ServerHello, so that it can process such responses with `parse_sslv2_serverhello()` rather than `parse_tls_serverhello()`.

When a connection is made using SSLv3 or later, `run_client_simulation()` will show to the protocol and cipher selected for the connection. With this PR, if the connection is made using SSLv2, `run_client_simulation()` will just show "SSLv2." In the case of SSLv2, the ServerHello contains a list of all ciphers that the server and client have in common, and it is up to the client to choose one. So, if the client and server have more than one cipher in common, more information about the client would be needed to know which cipher it would choose.