### PR TITLE
Fixed file output error in case of insecure redirect

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1416,7 +1416,7 @@ run_http_header() {
                out ", redirecting to \""; pr_url "$redirect"; out "\""
                if [[ $redirect == "http://"* ]]; then
                     pr_svrty_high " -- Redirect to insecure URL (NOT ok)"
-                    fileout "HTTP_STATUS_CODE" "HIGH" \, "Redirect to insecure URL. Url: \"$redirect\""
+                    fileout "insecure_redirect" "HIGH" "Redirect to insecure URL. Url: \"$redirect\""
                fi
                fileout "HTTP_STATUS_CODE" "INFO" \
                     "Testing HTTP header response @ \"$URL_PATH\", $HTTP_STATUS_CODE$msg_thereafter, redirecting to \"$redirect\""


### PR DESCRIPTION
In case of an insecure redirect a duplicate finding would be logged.

First finding would be HTTP_STATUS_CODE with severity HIGH and content ','.
Second finding would be HTTP_STATUS_CODE with severity INFO with the correct status code.

Now two findings will be created. 
1) insecure_redirect severity high with redirect URL
2) http_status_code with severity info and the redirect message