### PR TITLE
Add support for MongoDB service detection

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1398,6 +1398,8 @@ service_detection() {
           [[ -z "$SERVICE" ]] && head $TMPFILE | grep -aq FTP && SERVICE=FTP
           [[ -z "$SERVICE" ]] && head $TMPFILE | egrep -aqi "jabber|xmpp" && SERVICE=XMPP
           [[ -z "$SERVICE" ]] && head $TMPFILE | egrep -aqw "Jive News|InterNetNews|NNRP|INN" && SERVICE=NNTP
+          # MongoDB port 27017 will respond to a GET request with a mocked HTTP response
+          [[ "$SERVICE" == HTTP ]] && head $TMPFILE | egrep -aqw "MongoDB" && SERVICE=MongoDB
           debugme head -50 $TMPFILE | sed -e '/<HTML>/,$d' -e '/<html>/,$d' -e '/<XML/,$d' -e '/<xml/,$d' -e '/<\?XML/,$d' -e '/<\?xml/,$d' -e '/<\!DOCTYPE/,$d' -e '/<\!doctype/,$d'
      fi
 
@@ -1408,7 +1410,7 @@ service_detection() {
                fileout "service" "INFO" "Service detected: $SERVICE"
                ret=0
                ;;
-          IMAP|POP|SMTP|NNTP)
+          IMAP|POP|SMTP|NNTP|MongoDB)
                out " $SERVICE, thus skipping HTTP specific checks"
                fileout "service" "INFO" "Service detected: $SERVICE, thus skipping HTTP specific checks"
                ret=0


### PR DESCRIPTION
MongoDB listens on port 27017 and will respond to a direct TLS
ClientHello without the need for STARTTLS. Thus, testssl.sh already
mostly works to scan a MongoDB server.

The problem is that MongoDB will also reply to an HTTP GET request with
a mocked up HTTP response, which was tricking the tool into believing it
was dealing with an HTTP server. The response looks like this:

```
HTTP/1.0 200 OK
Connection: close
Content-Type: text/plain
Content-Length: 84

It looks like you are trying to access MongoDB over HTTP on the native
driver port.
```

Thus, the detection algorith must first look for HTTP, then dig deeper
into the body looking for "MongoDB".

The tool output now says:

Service detected:       MongoDB, thus skipping HTTP specific checks