### PR TITLE
Remove extra space in BEAST output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10874,9 +10874,9 @@ run_beast(){
                     done
                     ciphers_found[i]=true
                     if ( [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
-                         detected_cbc_ciphers+=" ${ciph[i]}"
+                         detected_cbc_ciphers+="${ciph[i]} "
                     else
-                         detected_cbc_ciphers+=" ${rfc_ciph[i]}"
+                         detected_cbc_ciphers+="${rfc_ciph[i]} "
                     fi
                     vuln_beast=true
                     if "$WIDE" && ( [[ ${kx[i]} == "Kx=ECDH" ]] || [[ ${kx[i]} == "Kx=DH" ]] || [[ ${kx[i]} == "Kx=EDH" ]] ); then


### PR DESCRIPTION
testssl.sh was inserting two spaces between the CBC ciphers detected by OpenSSL and those detected to `tls_sockets()`. This PR fixes the problem.