### PR TITLE
has_server_protocol() fixes

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2418,7 +2418,7 @@ std_cipherlists() {
                sclient_success=$?
                [[ $sclient_success -eq 2 ]] && sclient_success=0
           fi
-          if [[ $sclient_success -ne 0 ]] && [[ 0 -eq $(has_server_protocol ssl2) ]]; then
+          if [[ $sclient_success -ne 0 ]] && [[ 1 -ne $(has_server_protocol ssl2) ]]; then
                if ( [[ -z "$6" ]] || "$FAST" ) && "$HAS_SSL2" && listciphers "$1" -ssl2; then
                     $OPENSSL s_client -cipher "$1" $BUGS $STARTTLS -connect $NODEIP:$PORT $PROXY -ssl2 2>$ERRFILE >$TMPFILE </dev/null
                     sclient_connect_successful $? $TMPFILE
@@ -10743,7 +10743,7 @@ run_beast(){
      local hexc dash cbc_cipher sslvers auth mac export sni
      local -a ciph hexcode normalized_hexcode kx enc export2
      local proto proto_hex
-     local -i i nr_ciphers=0 sclient_success=0
+     local -i i ret nr_ciphers=0 sclient_success=0
      local detected_cbc_ciphers="" ciphers_to_test
      local higher_proto_supported=""
      local vuln_beast=false
@@ -10810,12 +10810,13 @@ run_beast(){
 
      # first determine whether it's mitigated by higher protocols
      for proto in tls1_1 tls1_2; do
-          if [[ $(has_server_protocol "$proto") -eq 0 ]]; then
+          ret=$(has_server_protocol "$proto")
+          if [[ $ret -eq 0 ]]; then
                case $proto in
                     tls1_1) higher_proto_supported+=" TLSv1.1" ;;
                     tls1_2) higher_proto_supported+=" TLSv1.2" ;;
                esac
-          else
+          elif [[ $ret -eq 2 ]]; then
                $OPENSSL s_client -state -"$proto" $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI 2>>$ERRFILE >$TMPFILE </dev/null
                if sclient_connect_successful $? $TMPFILE; then
                     higher_proto_supported+=" $(get_protocol $TMPFILE)"
@@ -10831,8 +10832,11 @@ run_beast(){
                continue
           fi
           [[ ! "$proto" =~ ssl ]] && sni="$SNI" || sni=""
-          if [[ $(has_server_protocol "$proto") -eq 0 ]]; then
+          ret=$(has_server_protocol "$proto")
+          if [[ $ret -eq 0 ]]; then
                sclient_success=0
+          elif [[ $ret -eq 1 ]]; then
+               sclient_success=1
           elif [[ "$proto" != "ssl3" ]] || "$HAS_SSL3"; then
                $OPENSSL s_client -"$proto" $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $sni >$TMPFILE 2>>$ERRFILE </dev/null
                sclient_connect_successful $? $TMPFILE


### PR DESCRIPTION
This PR fixes the use of `has_server_protocol()` in two places.

Currently `std_ciphersuites()` only tries SSLv2 if the server is known to support SSLv2. This changes it to try SSLv2 unless the server is known to not support SSLv2.

In `run_beast()`, tests against the server are run to determine support for TLSv1.2, TLSv1.1, TLSv1, and SSLv3 unless the server is known to support that protocol (i.e., even if `has_server_protocol()` reports that the server does not support the protocol). This changes it so that a test is only performed against the server if `has_server_protocol()` reports that it doesn't know whether the protocol is supported.