### PR TITLE
Fix typo

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -85,7 +85,7 @@ readonly PS4='|${LINENO}> \011${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 DEBUGTIME=${DEBUGTIME:-false}
 DEBUG_ALLINONE=${DEBUG_ALLINONE:-false}           # true: do debugging in one sceen (old behaviour for testssl.sh and bash3's default
                                                   # false: needed for performance analysis or useful for just having an extra file
-DEBUG_ALLINONE=${SETX=-false}                     # SETX as a shortcut for old style debugging, overriding DEBUG_ALLINONE
+DEBUG_ALLINONE=${SETX:-false}                     # SETX as a shortcut for old style debugging, overriding DEBUG_ALLINONE
 
 
 if grep -q xtrace <<< "$SHELLOPTS"; then


### PR DESCRIPTION
I believe there is a typo in the second definition of `DEBUG_ALLINONE`. If I run testssl.sh using the `-x` option for bash I get the following error:
```
     testssl.sh: line 12714: -false: command not found
```