### PR TITLE
run_server_preference() bug fix

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4957,8 +4957,8 @@ run_server_preference() {
                          tls_sockets "00" "$TLS_CIPHER"
                          if [[ $? -eq 0 ]]; then
                               proto[i]="SSLv3"
-                              cipher[i]=""
                               cipher1=$(awk '/Cipher *:/ { print $3 }' "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt")
+                              cipher[i]="$cipher1"
                               if [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]] && [[ $TLS_NR_CIPHERS -ne 0 ]]; then
                                    cipher[i]="$(rfc2openssl "$cipher1")"
                                    [[ -z "${cipher[i]}" ]] && cipher[i]="$cipher1"


### PR DESCRIPTION
If `run_server_preference()` is performed:
* against a server that supports SSLv3 and that does not have a cipher order; and
* using a version of OpenSSL that does not support SSLv3; and
* with the `--mapping` option set to "rfc" or "no-openssl"

then the "Negotiated cipher per proto" will not show the SSLv3 cipher since `cipher[i]` will be empty.