### PR TITLE
Add TLSv1.3 support for run_server_preference()

### DIFF
--- a/etc/tls_data.txt
+++ b/etc/tls_data.txt
@@ -3,6 +3,10 @@
 # see #807 and #806 (especially
 # https://github.com/drwetter/testssl.sh/issues/806#issuecomment-318686374)
 
+# All 5 ciphers defined for TLS 1.3
+readonly TLS13_CIPHER="
+13,01, 13,02, 13,03, 13,04, 13,05"
+
 # 123 standard cipher + 4x GOST for TLS 1.2 and SPDY/NPN HTTP2/ALPN
 readonly TLS12_CIPHER="
 c0,30, c0,2c, c0,28, c0,24, c0,14, c0,0a, 00,9f, 00,6b,


### PR DESCRIPTION
This PR adds support for TLSv1.3 to `run_server_preference()`. It only provides partial support, as it only works if the server supports an earlier TLS protocol (in order to determine whether the server has a cipher order). It also will only show TLSv1.3 as the "Negotiated protocol" if `$OPENSSL` supports TLSv1.3. (Note that PR #826 and #827 are needed in order for `run_server_preference()` to work with an `$OPENSSL` that supports TLSv1.3).

This PR also fixes a bug in which the variable "proto" was defined and used as both a regular variable and as an array.