### PR TITLE
Fix problem with LibreSSL encryption names

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2686,6 +2686,11 @@ neat_list(){
 
      kx="${3//Kx=/}"
      enc="${4//Enc=/}"
+     # In two cases LibreSSL uses very long names for encryption algorithms
+     # and doesn't include the number of bits.
+     [[ "$enc" == "ChaCha20-Poly1305" ]] && enc="CHACHA20(256)"
+     [[ "$enc" == "GOST-28178-89-CNT" ]] && enc="GOST(256)"
+
      strength="${enc//\)/}"             # retrieve (). first remove traling ")"
      strength="${strength#*\(}"         # exfiltrate (VAL
      enc="${enc%%\(*}"


### PR DESCRIPTION
For ciphers that use the ChaCha20-Poly1305 cipher, LibreSSL shows "Enc=ChaCha20-Poly1305" in the `openssl ciphers -V` command rather than "Enc=ChaCha20(256)" and for some GOST ciphers it shows "Enc=GOST-28178-89-CNT" rather than "Enc=GOST(256)". This causes a problem for `neat_list()` if information is being obtained from `$OPENSSL ciphers -V` rather than from the cipher-mapping.txt file.