### PR TITLE
Add check for the Expect-CT header

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2315,7 +2315,7 @@ run_cookie_flags() {     # ARG1: Path
 
 
 run_more_flags() {
-     local good_flags2test="X-Frame-Options X-XSS-Protection X-Content-Type-Options Content-Security-Policy X-Content-Security-Policy X-WebKit-CSP Content-Security-Policy-Report-Only"
+     local good_flags2test="X-Frame-Options X-XSS-Protection X-Content-Type-Options Content-Security-Policy X-Content-Security-Policy X-WebKit-CSP Content-Security-Policy-Report-Only Expect-CT"
      local other_flags2test="Access-Control-Allow-Origin Upgrade X-Served-By X-UA-Compatible Referrer-Policy X-UA-Compatible"
      local f2t line
      local first=true


### PR DESCRIPTION
This PR adds a check for the Expect-CT header to `run_more_flags()`.

I was forwarded an [announcement](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ) this morning that support for public-key pinning is being deprecated in Chrome. The [announcement](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ) included a recommendation for web developers to use the Expect-CT header. The Expect-CT header is mentioned in an [announcement](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/tgn5R-58iek) about Chrome and in an IETF Internet Draft, [draft-ietf-httpbis-expect-ct](https://datatracker.ietf.org/doc/draft-ietf-httpbis-expect-ct).

This PR just causes testssl.sh to print the contents of the Expect-CT header if it is present. It doesn't check the contents of the header nor does it check whether the site's operations are consistent with the header (i.e., whether the site provide CT information if the header is present and indicates that users should expect to find CT information).