### PR TITLE
Fix false positive in std_cipherlists()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2449,7 +2449,7 @@ listciphers() {
 # argv[5]: non-SSLv2 cipher list to test (hexcodes), if using sockets
 # argv[6]: SSLv2 cipher list to test (hexcodes), if using sockets
 std_cipherlists() {
-     local -i i len sclient_success
+     local -i i len sclient_success=1
      local cipherlist sslv2_cipherlist detected_ssl2_ciphers
      local singlespaces
      local proto=""


### PR DESCRIPTION
This PR fixes a false positive in `std_cipherlists()`. Currently, `sclient_success` is not initialized (so it initially set to 0). If a server is being tested that only supports TLSv1.3, the `--ssl-native` option is not used, and `run_protocols()` is run before `run_std_cipherlists()`, then for many of the calls to `std_cipherlists()` no tests are run and so `sclient_success` remains at its initial value (0), which is treated as success (i.e., the server supports at least one of the ciphers in the list).

The reason this happens is that in the testing loop, the TLSv1.3 test is skipped if the list of ciphers doesn't include any TLSv1.3 ciphers (and only the "Strong encryption" test includes TLSv1.3 ciphers) and the tests for each of lower versions of SSL/TLS is skipped since it was already determined in `run_protocols()` that those versions weren't supported.