### PR TITLE
Fix socksend() debugging output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2604,7 +2604,7 @@ socksend() {
      else
           data=$(sed -e 's/# .*$//g' -e 's/ //g' <<< "$1" | sed -r 's/^[[:space:]]+//; s/[[:space:]]+$//; /^$/d' | sed 's/,/\\/g' | tr -d '\n')
      fi
-     [[ $DEBUG -ge 4 ]] && echo -e "\n\"$data\""
+     [[ $DEBUG -ge 4 ]] && echo "" && echo "\"$data\""
      printf -- "$data" >&5 2>/dev/null &
      sleep $2
 }


### PR DESCRIPTION
For debug levels 4 and above, `socksend()` is supposed to print the data that is being sent to the terminal. It currently uses `echo -e` for this so that a newline character can be written before the data. However, the `-e` option causes every byte of `$data`, written as "\xHH" to be interpreted as an escape sequence rather than just being printed as plain text.

This PR fixes the problem by removing the `-e` option and using a separate call to `echo` to create the preceding newline character.