### PR TITLE
Yet another fix for OpenSSL 1.1.1

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6192,6 +6192,7 @@ certificate_info() {
      fi
 
      cert_sig_algo=$($OPENSSL x509 -in $HOSTCERT -noout -text 2>>$ERRFILE | grep "Signature Algorithm" | sed 's/^.*Signature Algorithm: //' | sort -u )
+     cert_sig_algo="${cert_sig_algo%% *}"
      cert_key_algo=$($OPENSSL x509 -in $HOSTCERT -noout -text 2>>$ERRFILE | awk -F':' '/Public Key Algorithm:/ { print $2 }' | sort -u )
 
      out "$indent" ; pr_bold " Signature Algorithm          "


### PR DESCRIPTION
When the certificate signature algorithm is RSA-PSS and OpenSSL 1.1.1 is used `$cert_sign_algo` contains some trailing space characters, which causes the algorithm not to be recognized in the case statement. This PR fixes the problem by removing any trailing space characters from `$cert_sign_algo`.

I came across this problem as a result of noticing a new [commit](https://github.com/openssl/openssl/commit/e6cccb5f0523f5a61f5d963ca1708d02e3e83ccc) to the OpenSSL master branch, which changes the [indentation of the Signature Algorithm line](https://github.com/openssl/openssl/commit/d1453d60a58b3e5de24a71d6fa65938629c144c8) when printing a certificate.

I did a comparison of the output of OpenSSL 1.0.2-chacha and the current master branch of OpenSSL and discovered that there are other differences in the output. Below is a diff for GitHub's certificate. The first "Signature Algorithm" line is intended more, spaces have been added to the Issuer and Subject lines (before and after '='), the word "RSA" is added before "Public-Key", and the printout of the version number within the CT Precertificate SCTs extension has changed.

So far I have not discovered any problems other than the one addressed by this PR that the changes in OpenSSL 1.1.1 cause. However, there are places where testssl.sh relies on the exact amount of certain lines in the certificate printout, so changes like this are a potential source of trouble.
```
6,7c6,7
<     Signature Algorithm: sha256WithRSAEncryption
<         Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 Extended Validation Server CA
---
>         Signature Algorithm: sha256WithRSAEncryption
>         Issuer: C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert SHA2 Extended Validation Server CA
11c11
<         Subject: businessCategory=Private Organization/jurisdictionC=US/jurisdictionST=Delaware/serialNumber=5157550/street=88 Colin P Kelly, Jr Street/postalCode=94107, C=US, ST=California, L=San Francisco, O=GitHub, Inc., CN=github.com
---
>         Subject: businessCategory = Private Organization, jurisdictionC = US, jurisdictionST = Delaware, serialNumber = 5157550, street = "88 Colin P Kelly, Jr Street", postalCode = 94107, C = US, ST = California, L = San Francisco, O = "GitHub, Inc.", CN = github.com
14c14
<                 Public-Key: (2048 bit)
---
>                 RSA Public-Key: (2048 bit)
68c68
<                     Version   : v1(0)
---
>                     Version   : v1 (0x0)
80c80
<                     Version   : v1(0)
---
>                     Version   : v1 (0x0)
92c92
<                     Version   : v1(0)
---
>                     Version   : v1 (0x0)
```