### PR TITLE
Fix run_heartbleed()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10157,7 +10157,7 @@ run_heartbleed(){
      debugme echo "using protocol $tls_hexcode"
 
      heartbleed_payload=", x18, $tls_hexcode, x00, x03, x01, x40, x00"
-     tls_sockets "${tls_hexcode:6:2}" "" "" "" "" "false"
+     tls_sockets "${tls_hexcode:6:2}" "" "ephemeralkey" "" "" "false"
 
      [[ $DEBUG -ge 4 ]] && tmln_out "\nsending payload with TLS version $tls_hexcode:"
      socksend "$heartbleed_payload" 1


### PR DESCRIPTION
When the server's response to the ClientHello message (i.e., the ServerHello, Certificate, ServerHelloDone) is split across more than one packet, the current call to `tls_sockets()` in `run_heartbleed()` only retrieves the first packet. As a result, sometimes when `run_heartbleed()` believes that it is reading the response to the Heartbleed payload it is actually reading the continuation of the response to the ClientHello message.

This PR fixes the problem by indicating in the call to `tls_sockets()` that the ephemeral key is needed. This causes `tls_sockets()` to continue requesting additional packets until it receives the ServerHelloDone.