### PR TITLE
Reduce read timeout for MySQL back to 1 second

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -204,7 +204,7 @@ HEADER_MAXSLEEP=${HEADER_MAXSLEEP:-5}   # we wait this long before killing the p
 MAX_WAITSOCK=${MAX_WAITSOCK:-10}        # waiting at max 10 seconds for socket reply. There shouldn't be any reason to change this.
 CCS_MAX_WAITSOCK=${CCS_MAX_WAITSOCK:-5} # for the two CCS payload (each). There shouldn't be any reason to change this.
 HEARTBLEED_MAX_WAITSOCK=${HEARTBLEED_MAX_WAITSOCK:-8}      # for the heartbleed payload. There shouldn't be any reason to change this.
-STARTTLS_SLEEP=${STARTTLS_SLEEP:-10}    # max time to wait on a socket replay for STARTTLS
+STARTTLS_SLEEP=${STARTTLS_SLEEP:-10}    # max time to wait on a socket reply for STARTTLS
 FAST_STARTTLS=${FAST_STARTTLS:-true}    # at the cost of reliabilty decrease the handshakes for STARTTLS
 USLEEP_SND=${USLEEP_SND:-0.1}           # sleep time for general socket send
 USLEEP_REC=${USLEEP_REC:-0.2}           # sleep time for general socket receive
@@ -7759,14 +7759,16 @@ starttls_just_send2(){
      echo -ne "$1" >&5
 }
 
+# arg1: (optional): wait time
 starttls_just_read(){
+     [[ -z "$1" ]] && waitsleep=$STARTTLS_SLEEP || waitsleep=$1
      debugme echo "=== just read banner ==="
      if [[ "$DEBUG" -ge 2 ]]; then
           cat <&5 &
-          wait_kill $! $STARTTLS_SLEEP
+          wait_kill $! $waitsleep
      else
           dd of=/dev/null count=8 <&5 2>/dev/null &
-          wait_kill $! $STARTTLS_SLEEP
+          wait_kill $! $waitsleep
      fi
 
      return 0
@@ -7895,7 +7897,7 @@ starttls_mysql_dialog() {
      00, 00, 00, 00, 00, 00, 00, 00,
      00, 00, 00, 00, 00, 00, 00"
      code2network "${login_request}"
-     starttls_just_read                     && debugme echo -e "\nreceived server greeting" &&
+     starttls_just_read 1                   && debugme echo -e "\nreceived server greeting" &&
      starttls_just_send2 "$NW_STR"          && debugme echo "initiated STARTTLS"
      # TODO: We could detect if the server supports STARTTLS via the "Server Capabilities"
      # bit field, but we'd need to parse the binary stream, with greater precision than regex.


### PR DESCRIPTION
The default STARTTLS_SLEEP timeout was increased to 10 seconds in
d1e7498. This caused MySQL connections to timeout. Quick fix is to
parameterize the timeout and pass in 1 again.

Better future fix is to read MySQL as binary packets, parsing the fixed
sized header, to then read the variable sized payload. Doing this will
also greatly speed up testing.

This fixes issue #914.