### PR TITLE
HTTP-related checks and certificate based client authentication

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3945,14 +3945,14 @@ run_client_simulation() {
 
      if [[ $SERVICE != "" ]];  then
           client_service="$SERVICE"
-     else
+     elif [[ -n "$STARTTLS_PROTOCOL" ]]; then
           # Can we take the service from STARTTLS?
-           if [[ -n "$STARTTLS_PROTOCOL" ]]; then
-               client_service=$(toupper "${STARTTLS_PROTOCOL%s}")    # strip trailing 's' in ftp(s), smtp(s), pop3(s), etc
-          else
-               outln "Could not determine the protocol, only simulating generic clients."
-               client_service="undetermined"
-          fi
+          client_service=$(toupper "${STARTTLS_PROTOCOL%s}")    # strip trailing 's' in ftp(s), smtp(s), pop3(s), etc
+     elif "$ASSUME_HTTP"; then
+          client_service="HTTP"
+     else
+          outln "Could not determine the protocol, only simulating generic clients."
+          client_service="undetermined"
      fi
 
      outln
@@ -6237,7 +6237,7 @@ certificate_transparency() {
           fi
      fi
 
-     if [[ $SERVICE != "HTTP" ]]; then
+     if [[ $SERVICE != "HTTP" ]] && ! "$CLIENT_AUTH"; then
           # At the moment Certificate Transparency only applies to HTTPS.
           tm_out "N/A"
      else
@@ -6299,7 +6299,7 @@ certificate_info() {
      case $cert_sig_algo in
           sha1WithRSAEncryption)
                pr_svrty_medium "SHA1 with RSA"
-               if [[ "$SERVICE" == HTTP ]]; then
+               if [[ "$SERVICE" == HTTP ]] || "$ASSUME_HTTP"; then
                     out " -- besides: users will receive a "; pr_svrty_high "strong browser WARNING"
                fi
                outln
@@ -6547,7 +6547,7 @@ certificate_info() {
           prln_italic "$(out_row_aligned_max_width "$all_san" "$indent                              " $TERM_WIDTH)"
           fileout "${json_prefix}san" "INFO" "subjectAltName (SAN) : $all_san"
      else
-          if [[ $SERVICE == "HTTP" ]]; then
+          if [[ $SERVICE == "HTTP" ]] || "$ASSUME_HTTP"; then
                pr_svrty_high "missing (NOT ok)"; outln " -- Browsers are complaining"
                fileout "${json_prefix}san" "HIGH" "subjectAltName (SAN) : -- Browsers are complaining"
           else
@@ -6639,7 +6639,7 @@ certificate_info() {
           pr_svrty_high "$trustfinding"
           trust_sni_finding="HIGH"
      elif ( [[ $trust_sni -eq 4 ]] || [[ $trust_sni -eq 8 ]] ); then
-          if [[ $SERVICE == "HTTP" ]]; then
+          if [[ $SERVICE == "HTTP" ]] || "$ASSUME_HTTP"; then
                # https://bugs.chromium.org/p/chromium/issues/detail?id=308330
                # https://bugzilla.mozilla.org/show_bug.cgi?id=1245280
                # https://www.chromestatus.com/feature/4981025180483584
@@ -6704,7 +6704,7 @@ certificate_info() {
      fi
      if [[ -n "$sni_used" ]] || [[ $trust_nosni -eq 0 ]] || ( [[ $trust_nosni -ne 4 ]] && [[ $trust_nosni -ne 8 ]] ); then
           outln "$trustfinding_nosni"
-     elif [[ $SERVICE == "HTTP" ]]; then
+     elif [[ $SERVICE == "HTTP" ]] || "$ASSUME_HTTP"; then
           prln_svrty_high "$trustfinding_nosni"
      else
           prln_svrty_medium "$trustfinding_nosni"
@@ -11041,7 +11041,7 @@ run_crime() {
           fi
           ret=0
      else
-          if [[ $SERVICE == "HTTP" ]]; then
+          if [[ $SERVICE == "HTTP" ]] || "$CLIENT_AUTH"; then
                pr_svrty_high "VULNERABLE (NOT ok)"
                fileout "crime" "HIGH" "CRIME, TLS: VULNERABLE" "$cve" "$cwe" "$hint"
           else


### PR DESCRIPTION
If certificate-based client authentication is required by the server, then most HTTP-related checks are skipped, even if the "--assume-http" flag is used. If `$CLIENT_AUTH` is true, then `$ASSUME_HTTP` is ignored.

In some cases the checks are appropriately skipped, since the tests cannot be performed. In other places, the value of `$CLIENT_AUTH` is used as a hint as to whether HTTP is being used. For example, in `run_tickbleed()`:
```
     if [[ "$SERVICE" != HTTP ]] && ! "$CLIENT_AUTH"; then
          outln "--   (applicable only for HTTPS)"
          fileout "ticketbleed" "INFO" "Ticketbleed: not applicable, not HTTP" "$cve" "$cwe"
          return 0
     fi
```
There are some places, however, where tests are just skipped if both `$CLIENT_AUTH` and `$ASSUME_HTTP` are true, even though the test could be performed. For example, `run_client_simulation()` only simulates generic clients in this case.

This PR attempts to address this:
* In `run_client_simulation()` it runs all of the tests if `$ASSUME_HTTP` is true.
* In `certificate_transparency()` it only says that the lack of CT information is "N/A" it can verify that HTTP is not being used (if `$SERVICE` is not HTTP and `$CLIENT_AUTH` is false). Otherwise it just says "no" without flagging it as an issue.
* In `certificate_info()` it displays additional warnings (about use of SHA-1 or subjectAltName matching) only if it can verify that HTTP is being used (`$SERVICE` is HTTP or `$ASSUME_HTTP` is true).
* In `run_crime()`, if compression is used, it only says " but not using HTTP" only if it can verify that HTTP is not being used (if `$SERVICE` is not HTTP and `$CLIENT_AUTH` is false).