### PR TITLE
JSOn output is broken by the JSON footer in combination with mass mode

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14534,6 +14534,7 @@ run_mass_testing() {
                "$first" || fileout_separator                         # this is needed for appended output, see #687
                first=false
                cat "$TEMPDIR/jsonfile_child.json" >> "$JSONFILE"
+               FIRST_FINDING=false
           fi
      done < "${FNAME}"
      return $?

--- a/testssl.sh
+++ b/testssl.sh
@@ -14556,6 +14556,7 @@ get_next_message_testing_parallel_result() {
                # produced some JSON output.
                "$FIRST_JSON_OUTPUT" || fileout_separator                     # this is needed for appended output, see #687
                FIRST_JSON_OUTPUT=false
+               FIRST_FINDING=false
                cat "$TEMPDIR/jsonfile_$(printf "%08d" $NEXT_PARALLEL_TEST_TO_FINISH).json" >> "$JSONFILE"
           fi
           "$CSVHEADER" && cat "$TEMPDIR/csvfile_$(printf "%08d" $NEXT_PARALLEL_TEST_TO_FINISH).csv" >> "$CSVFILE"


### PR DESCRIPTION
The comma was missing in front of the last finding that is inserted as part of the JSOn footer. THis corrects it and once merged my unit tests should work again.