### PR TITLE
Test for vulnerability to Bleichenbacher attack

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -15,6 +15,7 @@
   - numerous fixes
   - better error msg suppression (not fully installed openssl
   - GREASE support
+  - Bleichenbacher vulnerability test
   - TLS 1.3 support
 
 ##### Credits also to

--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,7 @@ Update notification here or @ [twitter](https://twitter.com/drwetter).
 * Better formatting of output (indentation)
 * Choice showing the RFC naming scheme only
 * LUCKY13 and SWEET32 checks
+* Check for vulnerability to Bleichenbacher attacks
 * Ticketbleed check
 * Decoding of unencrypted BIG IP cookies
 * LOGJAM: now checking also for known DH parameters

--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -260,6 +260,9 @@ Security headers (X\-Frame\-Options, X\-XSS\-Protection, \.\.\., CSP headers)
 \fB\-T, \-\-ticketbleed\fR Checks for Ticketbleed memory leakage in BigIP loadbalancers\.
 .
 .P
+\fB\-BB, \-\-robot\fR Checks for vulnerability to Bleichenbacher attacks\.
+.
+.P
 \fB\-R, \-\-renegotiation\fR Tests renegotiation vulnerabilities\. Currently there\'s a check for "Secure Renegotiation" and for "Secure Client\-Initiated Renegotiation"\. Please be aware that vulnerable servers to the latter can likely be DoSed very easily (HTTP)\. A check for "Insecure Client\-Initiated Renegotiation" is not yet implemented\.
 .
 .P

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -176,6 +176,8 @@ If the server provides no matching record in Subject Alternative Name (SAN) but 
 
 `-T, --ticketbleed`		Checks for Ticketbleed memory leakage in BigIP loadbalancers.
 
+`-BB, --robot`		Checks for vulnerability to Bleichenbacher attacks.
+
 `-R, --renegotiation`           Tests renegotiation vulnerabilities. Currently there's a check for "Secure Renegotiation" and for "Secure Client-Initiated Renegotiation". Please be aware that vulnerable servers to the latter can likely be DoSed very easily (HTTP). A check for "Insecure Client-Initiated Renegotiation" is not yet implemented.
 
 `-C, --compression, --crime`    Checks for CRIME ("Compression Ratio Info-leak Made Easy") vulnerability in TLS. CRIME in SPDY is not yet being checked for.


### PR DESCRIPTION
This PR adds a test to check whether a server that supports ciphers suites that use RSA key transport (TLS_RSA) are vulnerable to Bleichenbacher attacks (see http://archiv.infsec.ethz.ch/education/fs08/secsem/bleichenbacher98.pdf).