### PR TITLE
Fix check for whether certificates were found

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5950,7 +5950,7 @@ get_server_certificate() {
      local success
      local npn_params="" line
      local savedir
-     local nrsaved
+     local nrsaved=0
 
      "$HAS_SPDY" && [[ -z "$STARTTLS" ]] && npn_params="-nextprotoneg \"$NPN_PROTOs\""
 
@@ -5975,7 +5975,7 @@ get_server_certificate() {
                   /-----BEGIN CERTIFICATE-----/{ if (start) {inc=1; n++} }
                   inc { print > ("level" n ".crt") }
                   /---END CERTIFICATE-----/{ inc=0 }' $TMPFILE
-               nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
+               [[ -s level0.crt ]] && nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
                if [[ $nrsaved -eq 0 ]]; then
                     success=1
                else
@@ -6039,7 +6039,7 @@ get_server_certificate() {
              /-----BEGIN CERTIFICATE-----/{ if (start) {inc=1; n++} }
              inc { print > ("level" n ".crt") }
              /---END CERTIFICATE-----/{ inc=0 }' $TMPFILE
-     nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
+     [[ -s level0.crt ]] && nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
      if [[ $nrsaved -eq 0 ]]; then
          success=1
      else


### PR DESCRIPTION
`get_server_certificate()` uses an `awk` script to extract the certificates from the output of `$OPENSSL s_client` and it then uses the following line to determine how many certificates were found:
```
nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
```
If `$nrsaved` is 0, then `get_server_certificate()` returns 1 (indicating failure); otherwise it returns 0 (indicating success).

However, the check for the number of certificates returned doesn't work if no certificates were found, as `$nrsaved` will be set to 1 if no certificates were found:
```
> touch level0.crt
> echo level?.crt
level0.crt
> touch level1.crt
> echo level?.crt
level0.crt level1.crt
> rm level0.crt level1.crt
> echo level?.crt
level?.crt
```
This PR fixes the problem by first checking that level0.crt exists (`-s` is used instead of `-e`, since an empty file wouldn't have a certificate).

Note that I discovered this problem using a version of OpenSSL older than 1.0. `$OPENSSL s_client` returned 0 even though it wasn't successful (#520) so `get_server_certificate()` tried to extract the protocol version and certificate.