### PR TITLE
Define extract_certificates() function

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5976,14 +5976,49 @@ determine_tls_extensions() {
      return $success
 }
 
+extract_certificates() {
+     local version="$1"
+     local savedir
+     local -i success nrsaved=0
+
+     # Place the server's certificate in $HOSTCERT and any intermediate
+     # certificates that were provided in $TEMPDIR/intermediatecerts.pem
+     savedir=$(pwd); cd $TEMPDIR
+     # http://backreference.org/2010/05/09/ocsp-verification-with-openssl/
+     if [[ "$version" == "ssl2" ]]; then
+          awk -v n=-1 '/Server certificate/ {start=1}
+               /-----BEGIN CERTIFICATE-----/{ if (start) {inc=1; n++} }
+               inc { print > ("level" n ".crt") }
+               /---END CERTIFICATE-----/{ inc=0 }' $TMPFILE
+     else
+          awk -v n=-1 '/Certificate chain/ {start=1}
+               /-----BEGIN CERTIFICATE-----/{ if (start) {inc=1; n++} }
+               inc { print > ("level" n ".crt") }
+               /---END CERTIFICATE-----/{ inc=0 }' $TMPFILE
+     fi
+     [[ -s level0.crt ]] && nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
+     if [[ $nrsaved -eq 0 ]]; then
+         success=1
+     else
+         success=0
+         mv level0.crt $HOSTCERT
+         if [[ $nrsaved -eq 1 ]]; then
+             echo "" > $TEMPDIR/intermediatecerts.pem
+         else
+             cat level?.crt > $TEMPDIR/intermediatecerts.pem
+             rm level?.crt
+         fi
+     fi
+     cd "$savedir"
+     return $success
+}
+
 # arg1 is "-cipher <OpenSSL cipher>" or empty
 # arg2 is a list of protocols to try (tls1_2, tls1_1, tls1, ssl3) or empty (if all should be tried)
 get_server_certificate() {
      local protocols_to_try proto
      local success
      local npn_params="" line
-     local savedir
-     local nrsaved=0
 
      "$HAS_SPDY" && [[ -z "$STARTTLS" ]] && npn_params="-nextprotoneg \"$NPN_PROTOs\""
 
@@ -6000,28 +6035,8 @@ get_server_certificate() {
           $OPENSSL s_client $STARTTLS $BUGS $1 -showcerts -connect $NODEIP:$PORT $PROXY -ssl2 </dev/null 2>$ERRFILE >$TMPFILE
           sclient_connect_successful $? $TMPFILE && success=0
           if [[ $success -eq 0 ]]; then
-               # Place the server's certificate in $HOSTCERT and any intermediate
-               # certificates that were provided in $TEMPDIR/intermediatecerts.pem
-               savedir=$(pwd); cd $TEMPDIR
-               # http://backreference.org/2010/05/09/ocsp-verification-with-openssl/
-               awk -v n=-1 '/Server certificate/ {start=1}
-                  /-----BEGIN CERTIFICATE-----/{ if (start) {inc=1; n++} }
-                  inc { print > ("level" n ".crt") }
-                  /---END CERTIFICATE-----/{ inc=0 }' $TMPFILE
-               [[ -s level0.crt ]] && nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
-               if [[ $nrsaved -eq 0 ]]; then
-                    success=1
-               else
-                    success=0
-                    mv level0.crt $HOSTCERT
-                    if [[ $nrsaved -eq 1 ]]; then
-                         echo "" > $TEMPDIR/intermediatecerts.pem
-                    else
-                         cat level?.crt > $TEMPDIR/intermediatecerts.pem
-                         rm level?.crt
-                    fi
-               fi
-               cd "$savedir"
+               extract_certificates "ssl2"
+               success=$?
           fi
           tmpfile_handle $FUNCNAME.txt
           return $success
@@ -6063,29 +6078,8 @@ get_server_certificate() {
           "ssl3") DETECTED_TLS_VERSION="0300" ;;
      esac
      extract_new_tls_extensions $TMPFILE
-
-     # Place the server's certificate in $HOSTCERT and any intermediate
-     # certificates that were provided in $TEMPDIR/intermediatecerts.pem
-     savedir=$(pwd); cd $TEMPDIR
-     # http://backreference.org/2010/05/09/ocsp-verification-with-openssl/
-     awk -v n=-1 '/Certificate chain/ {start=1}
-             /-----BEGIN CERTIFICATE-----/{ if (start) {inc=1; n++} }
-             inc { print > ("level" n ".crt") }
-             /---END CERTIFICATE-----/{ inc=0 }' $TMPFILE
-     [[ -s level0.crt ]] && nrsaved=$(count_words "$(echo level?.crt 2>/dev/null)")
-     if [[ $nrsaved -eq 0 ]]; then
-         success=1
-     else
-         success=0
-         mv level0.crt $HOSTCERT
-         if [[ $nrsaved -eq 1 ]]; then
-             echo "" > $TEMPDIR/intermediatecerts.pem
-         else
-             cat level?.crt > $TEMPDIR/intermediatecerts.pem
-             rm level?.crt
-         fi
-     fi
-     cd "$savedir"
+     extract_certificates "$proto"
+     success=$?
 
      tmpfile_handle $FUNCNAME.txt
      return $success


### PR DESCRIPTION
This PR defines an `extract_certificates()` function in order to remove some redundant code from `get_server_certificate()`. Currently, nearly identical code appears in two places in `get_server_certificate()` to extract certificates from the output of `$OPENSSL sclient`, in one place for SSLv2 responses and in another for SSLv3 through TLSv1.2. The code to get the certificates used with TLSv1.3 (see https://github.com/dcooper16/testssl.sh/tree/extended_tls_sockets) would have added a third place where this same code would be needed. This PR allows the code to be written once and used in all three places.