### PR TITLE
Certificate-based auth host scanning produces invalid JSON output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1472,7 +1472,7 @@ service_detection() {
           *)   if "$CLIENT_AUTH"; then
                     out " certificate-based authentication => skipping all HTTP checks"
                     echo "certificate-based authentication => skipping all HTTP checks" >$TMPFILE
-                    fileout "client_auth" "INFO" "certificate-based authentication => skipping all HTTP checks"
+                    fileout "service" "INFO" "certificate-based authentication => skipping all HTTP checks"
                else
                     out " Couldn't determine what's running on port $PORT"
                     if "$ASSUME_HTTP"; then


### PR DESCRIPTION
When we scan a service with certificate-based authentication enabled with the `--json-pretty` output, the file generated is invalid:
```
"scanResult"  : [
                           {
                               "id"           : "client_auth",
                               "severity"     : "INFO",
                               "finding"      : "certificate-based authentication => skipping all HTTP checks"
                          }                    "protocols"         : [
                           {
                               "id"           : "sslv2",
                               "severity"     : "OK",
                               "finding"      : "SSLv2 is not offered"
```

