### PR TITLE
Label elliptic curve public keys as "EC"

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6522,7 +6522,7 @@ certificate_info() {
           case $cert_key_algo in
                *RSA*|*rsa*)             out "RSA ";;
                *DSA*|*dsa*)             out "DSA ";;
-               *ecdsa*|*ecPublicKey)    out "ECDSA ";;
+               *ecdsa*|*ecPublicKey)    out "EC ";;
                *GOST*|*gost*)           out "GOST ";;
                *dh*|*DH*)               out "DH " ;;
                *)                       pr_fixme "don't know $cert_key_algo " ;;


### PR DESCRIPTION
In the output created by `certificate_info()`, the "Server key size" line labels an elliptic curve key as "ECDSA." This PR changes the label to "EC." I believe this a more correct label since ECDSA is a signature algorithm, not a key type. Also, while unlikely, an elliptic curve key in a certificate may be used for ECDH (e.g, in TLS_ECDH_RSA_WITH_AES_128_CBC_SHA) rather than ECDSA.

Note that this change does not impact the JSON or CSV output, since the corresponding `fileout` command already uses `"$cert_keysize EC bits"`.