### PR TITLE
Fix determine_trust() for OpenSSL 1.1.1

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5779,13 +5779,13 @@ determine_trust() {
           fi
           debugme printf -- " %-12s" "${certificate_file[i]}"
           # set SSL_CERT_DIR to /dev/null so that $OPENSSL verify will only use certificates in $bundle_fname
-          (export SSL_CERT_DIR="/dev/null; export SSL_CERT_FILE=/dev/null"
+          (export SSL_CERT_DIR="/dev/null"; export SSL_CERT_FILE="/dev/null"
           if [[ $certificates_provided -ge 2 ]]; then
                $OPENSSL verify -purpose sslserver -CAfile "$bundle_fname" -untrusted $TEMPDIR/intermediatecerts.pem $HOSTCERT >$TEMPDIR/${certificate_file[i]}.1 2>$TEMPDIR/${certificate_file[i]}.2
           else
                $OPENSSL verify -purpose sslserver -CAfile "$bundle_fname" $HOSTCERT >$TEMPDIR/${certificate_file[i]}.1 2>$TEMPDIR/${certificate_file[i]}.2
           fi)
-          verify_retcode[i]=$(awk '/error [1-9][0-9]? at [0-9]+ depth lookup:/ { if (!found) {print $2; found=1} }' $TEMPDIR/${certificate_file[i]}.1)
+          verify_retcode[i]=$(awk '/error [1-9][0-9]? at [0-9]+ depth lookup:/ { if (!found) {print $2; found=1} }' $TEMPDIR/${certificate_file[i]}.1 $TEMPDIR/${certificate_file[i]}.2)
           [[ -z "${verify_retcode[i]}" ]] && verify_retcode[i]=0
           if [[ ${verify_retcode[i]} -eq 0 ]]; then
                trust[i]=true


### PR DESCRIPTION
`determine_trust()` uses the output of `$OPENSSL verify` to determine whether OpenSSL can construct a valid certification path for the server's certificate. If it does not find a string of the form "error [1-9][0-9]? at [0-9]+ depth lookup:" in the output, then it assumes that validation was successful. In current versions of OpenSSL, when this error is created it is printed to stdout, but in OpenSSL 1.1.1 is it printed to stderr. Since testssl.sh only checks the output sent to stdout, it incorrectly treats all certificates as valid if OpenSSL 1.1.1 is used.

This PR fixes the problem by checking the text that is sent to both stdout and stderr.

This PR also fixes a typo in the call to `$OPENSSL verify` which resulted in the environment variables SSL_CERT_DIR and SSL_CERT_FILE not being set to "/dev/null".