### PR TITLE
Fix #981

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6235,26 +6235,27 @@ compare_server_name_to_cert()
 
      # Check whether any of the DNS names in the certificate match the servername
      dns_sans="$(get_san_dns_from_cert "$cert")"
-     for san in $dns_sans; do
-          [[ $(toupper "$san") == "$servername" ]] && ret=1 && break
-     done
+     while read san; do
+          [[ -n "$san" ]] && [[ $(toupper "$san") == "$servername" ]] && ret=1 && break
+     done <<< "$dns_sans"
 
      if [[ $ret -eq 0 ]]; then
           # Check whether any of the IP addresses in the certificate match the servername
           ip_sans=$($OPENSSL x509 -in "$cert" -noout -text 2>>$ERRFILE | grep -A2 "Subject Alternative Name" | \
                   tr ',' '\n' | grep "IP Address:" | sed -e 's/IP Address://g' -e 's/ //g')
-          for san in $ip_sans; do
-               [[ "$san" == "$servername" ]] && ret=1 && break
-          done
+          while read san; do
+               [[ -n "$san" ]] && [[ "$san" == "$servername" ]] && ret=1 && break
+          done <<< "$ip_sans"
      fi
 
      # Check whether any of the DNS names in the certificate are wildcard names
      # that match the servername
      if [[ $ret -eq 0 ]]; then
-          for san in $dns_sans; do
+          while read san; do
+               [[ -n "$san" ]] || continue
                wildcard_match "$servername" "$san"
                [[ $? -eq 0 ]] && ret=2 && break
-          done
+          done <<< "$dns_sans"
      fi
 
      cn="$(get_cn_from_cert "$cert")"
@@ -7250,9 +7251,9 @@ run_server_defaults() {
                                    if [[ "$sans_nosni" == "$sans_sni" ]]; then
                                         success[n]=0
                                    else
-                                        for san in $sans_nosni; do
-                                             [[ " $sans_sni " =~ " $san " ]] && success[n]=0 && break
-                                        done
+                                        while read san; do
+                                             [[ -n "$san" ]] && [[ " $sans_sni " =~ " $san " ]] && success[n]=0 && break
+                                        done <<< "$sans_nosni"
                                    fi
                               fi
                          fi
@@ -7457,7 +7458,7 @@ get_session_ticket_lifetime_from_serverhello() {
 get_san_dns_from_cert() {
      echo "$($OPENSSL x509 -in "$1" -noout -text 2>>$ERRFILE | \
           grep -A2 "Subject Alternative Name" | tr ',' '\n' | grep "DNS:" | \
-          sed -e 's/DNS://g' -e 's/ //g' | tr '\n' ' ')"
+          sed -e 's/DNS://g' -e 's/ //g')"
 }
 
 


### PR DESCRIPTION
This PR fixes #981. It changes `get_san_dns_from_cert()` to place each DNS name in single quotes (') so that when the resulting string is used in a for loop, Bash does not try to perform wildcard completion. `compare_server_name_to_cert()` removes the single quotes (') from each name before comparing it against the presented name. `run_server_defaults()` does not need to remove the  single quotes ('), since all checks in that function continue to work with the quotes added.

An on-line search suggested that the best way to deal with Bash attempting to perform wildcard expansion in cases like this is to create an array, but placing the entries in quotes seems to work, and it is a much easier fix.