### PR TITLE
Bugfix for extra extensions

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10965,7 +10965,7 @@ socksend_tls_clienthello() {
           # the provided values for those extensions.
           extra_extensions="$(tolower "$4")"
           code2network "$extra_extensions"
-          len_all=${#extra_extensions}
+          len_all=${#NW_STR}
           for (( i=0; i < len_all; i=i+16+4*0x$len_extension_hex )); do
                part2=$i+4
                extn_type="${NW_STR:i:2}${NW_STR:part2:2}"


### PR DESCRIPTION
If extra extensions are provided to `socksend_tls_clienthello()`, then `socksend_tls_clienthello()` needs to determine what extensions were provided so that it doesn't add any of these extensions a second time. The code that was looping through the extra extensions to get the extension IDs was using the wrong value for the length of the string. This PR fixes the error.