### PR TITLE
Revert change to read_sigalg_from_file()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5066,10 +5066,7 @@ read_dhtype_from_file() {
 
 # arg1: certificate file
 read_sigalg_from_file() {
-     local hostcert_txt="${1//pem/txt}"
-
-     [[ -r "$hostcert_txt" ]] || $OPENSSL x509 -noout -text -in "$1" 2>/dev/null >$hostcert_txt
-     awk -F':' '/Signature Algorithm/ { print $2; exit; }' $hostcert_txt
+     $OPENSSL x509 -noout -text -in "$1" 2>/dev/null | awk -F':' '/Signature Algorithm/ { print $2; exit; }'
 }
 
 


### PR DESCRIPTION
The implementation of `read_sigalg_from_file()` was changed on January 29 in https://github.com/drwetter/testssl.sh/commit/88cd5528e72a923b26386666d5e76b69849f387b. The new implementation does not work correctly in cases in which `read_sigalg_from_file()` is called with `$TMPFILE` as as parameter.

The current implementation of the function is:
```
read_sigalg_from_file() {
     local hostcert_txt="${1//pem/txt}"

     [[ -r "$hostcert_txt" ]] || $OPENSSL x509 -noout -text -in "$1" 2>/dev/null >$hostcert_txt
     awk -F':' '/Signature Algorithm/ { print $2; exit; }' $hostcert_txt
}
```

When called using `$TMPFILE` (`/tmp/testssl.XXXXXX/tempfile.txt`), `hostcert_txt` is set to `$TMPFILE`, and since this file exists and is readable, the next line does nothing and the final line tries to read the signature algorithm from `$TMPFILE` rather than from a parsed version of the certificate.

This PR reverts `read_sigalg_from_file()` to its previous implementation, at least as a temporary solution.