### PR TITLE
Check for TLSv1.3 in OpenSSL

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5597,6 +5597,10 @@ cipher_pref_check() {
                out "\n    SSLv3:     "; pr_local_problem "$OPENSSL doesn't support \"s_client -ssl3\"";
                continue
           fi
+          if [[ $p == tls1_3 ]] && ! "$HAS_TLS13" && ! "$using_sockets"; then
+               out "\n    TLSv1.3    "; pr_local_problem "$OPENSSL doesn't support \"s_client -tls1_3\"";
+               continue
+          fi
 
           [[ $(has_server_protocol "$p") -eq 1 ]] && continue
 


### PR DESCRIPTION
This PR adds a missing check for local TLSv1.3 support in cipher_pref_check(). If the "--ssl-native" mode is being used and $OPENSSL does not support TLSv1.3, then a warning should be displayed indicating that TLSv1.3 cannot be checked rather than displaying the same results as if the server did not support TLSv1.3.