### PR TITLE
Fix #1015

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6270,12 +6270,12 @@ is_wildcard()
 
      # Remove part of name preceding '*' or '.'. If no "*" appears in the
      # left-most label, then it is not a wildcard name (RFC 6125, Section 6.4.3).
-     basename="$(echo -n "$certname" | sed 's/^[a-zA-Z0-9\-]*//')"
+     basename="$(echo -n "$certname" | sed 's/^[_a-zA-Z0-9\-]*//')"
      [[ "${basename:0:1}" != "*" ]] && return 1 # not a wildcard name
 
      # Check that there are no additional wildcard ('*') characters or any
      # other characters that do not belong in a DNS name.
-     [[ -n $(echo -n "${basename:1}" | sed 's/^[\.a-zA-Z0-9\-]*//') ]] && return 1
+     [[ -n $(echo -n "${basename:1}" | sed 's/^[_\.a-zA-Z0-9\-]*//') ]] && return 1
      return 0
 }
 
@@ -6305,7 +6305,7 @@ wildcard_match()
      servername="$(toupper "$servername")"
 
      # Extract part of name that comes after the "*"
-     basename="$(echo -n "$certname" | sed 's/^[A-Z0-9\-]*\*//')"
+     basename="$(echo -n "$certname" | sed 's/^[_A-Z0-9\-]*\*//')"
      len_basename=${#basename}
      len_part1=$len_certname-$len_basename-1
      len_wildcard=$len_servername-$len_certname+1
@@ -6318,7 +6318,7 @@ wildcard_match()
 
      # Check that part of $servername that matches "*" is all part of a single
      # domain label.
-     [[ -n $(echo -n "${servername:len_part1:len_wildcard}" | sed 's/^[A-Z0-9\-]*//') ]] && return 1
+     [[ -n $(echo -n "${servername:len_part1:len_wildcard}" | sed 's/^[_A-Z0-9\-]*//') ]] && return 1
 
      return 0
 }


### PR DESCRIPTION
This PR fixes #1015 by adding underscore ('_') to the list of characters that may appear in a domain name label. https://github.com/drwetter/testssl.sh/commit/a178f3e1838f0698e193337e10f0c32eb8c5f34a already addressed this for the check of whether the Common Name field in a certificate is a DNS name. This PR fixes it for checks of whether a domain name is a wildcard name and whether the server's host name is a wildcard match against a name in a certificate.