### PR TITLE
Extracting OpenSSL version information

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14489,6 +14489,7 @@ find_openssl_binary() {
      local s_client_has=$TEMPDIR/s_client_has.txt
      local s_client_starttls_has=$TEMPDIR/s_client_starttls_has.txt
      local openssl_location cwd=""
+     local ossl_wo_dev_info
 
      # 0. check environment variable whether it's executable
      if [[ -n "$OPENSSL" ]] && [[ ! -x "$OPENSSL" ]]; then
@@ -14516,9 +14517,11 @@ find_openssl_binary() {
      # http://www.openssl.org/news/openssl-notes.html
      OSSL_NAME=$($OPENSSL version 2>/dev/null | awk '{ print $1 }')
      OSSL_VER=$($OPENSSL version 2>/dev/null | awk -F' ' '{ print $2 }')
-     OSSL_VER_MAJOR=$(sed 's/\..*$//' <<< "$OSSL_VER")
-     OSSL_VER_MINOR=$(sed -e 's/^.\.//' <<< "$OSSL_VER" | tr -d '[a-zA-Z]-')
-     OSSL_VER_APPENDIX=$(tr -d '0-9.' <<< "$OSSL_VER")
+     OSSL_VER_MAJOR="${OSSL_VER%%\.*}"
+     ossl_wo_dev_info="${OSSL_VER%%-*}"
+     OSSL_VER_MINOR="${ossl_wo_dev_info#$OSSL_VER_MAJOR\.}"
+     OSSL_VER_MINOR="${OSSL_VER_MINOR%%[a-zA-Z]*}"
+     OSSL_VER_APPENDIX="${ossl_wo_dev_info#$OSSL_VER_MAJOR\.$OSSL_VER_MINOR}"
      OSSL_VER_PLATFORM=$($OPENSSL version -p 2>/dev/null | sed 's/^platform: //')
      OSSL_BUILD_DATE=$($OPENSSL version -a 2>/dev/null | grep '^built' | sed -e 's/built on//' -e 's/: ... //' -e 's/: //' -e 's/ UTC//' -e 's/ +0000//' -e 's/.000000000//')
 


### PR DESCRIPTION
When using testssl.sh with the current development branch of OpenSSL 1.1.1, `determine_trust()` incorrectly reports that "openssl <= 1.0.2 might be too unreliable to determine trust." The problem is that `find_openssl_binary()` is not correctly extracting the version information. The version is "1.1.1-pre3-dev," but `find_openssl_binary()` extracts:
```
   OSSL_VER_MAJOR: 1
   OSSL_VER_MINOR: 1.13
   OSSL_VER_APPENDIX: -pre-dev
```
This PR fixes the problem and also eliminates the use of external functions in extracting version information for $OSSL_VER.

Note that this code makes a change from the current code. Currently, $OSSL_VER_APPENDIX is intended to contain anything from $OSSL_VER that comes after $OSSL_VER_MAJOR.$OSSL_VER_MINOR. For example, if $OSSL_VER is 1.1.0-dev, then  $OSSL_VER_APPENDIX is "-dev". In this PR, the "-dev" is dropped and so does not appear in $OSSL_VER_MAJOR, $OSSL_VER_MINOR, or $OSSL_VER_APPENDIX. The reason for this is that testssl.sh is only using $OSSL_VER_APPENDIX in cases in which $OSSL_VER_MAJOR.$OSSL_VER_MINOR is 0.9.8 to determine whether 0.9.8a - 0.9.8l or 0.9.8m - 0.9.8z. So, it seems that testssl.sh isn't interested in things such as "-dev" or "-pre3-dev".

If desired, this PR could be changed to that $OSSL_VER_APPENDIX contains everything in $OSSL_VER that appears after $OSSL_VER_MAJOR.$OSSL_VER_MINOR.