### PR TITLE
Fix client simulations

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3953,8 +3953,10 @@ client_simulation_sockets() {
 
      if [[ "${1:0:4}" == "1603" ]]; then
           clienthello="$(create_client_simulation_tls_clienthello "$1")"
+          TLS_CLIENT_HELLO="${clienthello:10}"
      else
           clienthello="$1"
+          TLS_CLIENT_HELLO=""
      fi
      len=${#clienthello}
      for (( i=0; i < len; i=i+2 )); do


### PR DESCRIPTION
`parse_tls_serverhello()` checks `$TLS_CLIENT_HELLO` for a supported_versions extension, and if it contains one, checks that the negotiated version is listed in that extension. However, while `$TLS_CLIENT_HELLO` is always set in `socksend_tls_clienthello()` it is not set by `client_simulation_sockets()` (or any of the functions that `client_simulation_sockets()` calls). As a result, when the server's response to a client simulation is parsed, `parse_tls_serverhello()` may compare the negotiated version against the supported_versions extension from a ClientHello message from a previous test.

This PR fixes the problem by having `client_simulation_sockets()` set `$TLS_CLIENT_HELLO`.