### PR TITLE
Fix mass testing

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -145,7 +145,7 @@ HNAME="${HNAME%%.*}"
 
 declare CMDLINE
 declare -r -a CMDLINE_ARRAY=("$@")                # When performing mass testing, the child processes need to be sent the
-declare -r -a MASS_TESTING_CMDLINE                # command line in the form of an array (see #702 and http://mywiki.wooledge.org/BashFAQ/050).
+declare -a MASS_TESTING_CMDLINE                   # command line in the form of an array (see #702 and http://mywiki.wooledge.org/BashFAQ/050).
 
 
 ########### Some predefinitions: date, sed (we always use test and not try to determine


### PR DESCRIPTION
https://github.com/drwetter/testssl.sh/commit/b2be380b5465bcf8a8fc028d943a2687df10c8f8 inadvertently changed `MASS_TESTING_CMDLINE` to be a read-only variable. This causes mass testing to fail, since in mass testing the value of `MASS_TESTING_CMDLINE` is set to the command line for each child test.