### PR TITLE
TLS 1.3 clients in update_client_sim_data.pl

### DIFF
--- a/utils/update_client_sim_data.pl
+++ b/utils/update_client_sim_data.pl
@@ -184,7 +184,17 @@ foreach my $client ( @$ssllabs ) {
 		$sim->{protos} = "protos+=(\"" . (join " ", reverse @proto_flags) . "\")";
 		$sim->{tlsvers} = "tlsvers+=(\"" . (join " ", reverse @tls_flags) . "\")";
 		$sim->{lowestProtocol} = sprintf("lowest_protocol+=(\"0x%04x\")", $client->{lowestProtocol});
-		$sim->{highestProtocol} = sprintf("highest_protocol+=(\"0x%04x\")", $client->{highestProtocol});
+		# https://api.dev.ssllabs.com/api/v3/getClients incorrectly indicates
+		# a highestProtocol of TLS 1.2 for clients that support TLS 1.3, which
+		# can lead to client simulation reporting "no connection" if the connection
+		# is made using TLS 1.3. In order to avoid this problem, assume that any
+		# client with a highestProtocol of TLS 1.2 that supports any TLS 1.3
+		# ciphers really supports TLS 1.3.
+		if ( $client->{highestProtocol} != 771 || scalar(@ciphersuites) == 0 ) {
+			$sim->{highestProtocol} = sprintf("highest_protocol+=(\"0x%04x\")", $client->{highestProtocol});
+		} else {
+			$sim->{highestProtocol} = sprintf("highest_protocol+=(\"0x0304\")", $client->{highestProtocol});
+		}
 
 		if ( lc($client->{name}) eq "java" || lc($client->{name}) eq "openssl" ) {
 			# Java and OpenSSL are generic clients


### PR DESCRIPTION
https://api.dev.ssllabs.com/api/v3/getClients incorrectly indicates a highestProtocol of 771 (TLS 1.2) for clients that support TLS 1.3, which leads `run_client_simulation()` to incorrectly report "No connection" if the client would have actually connected using TLS 1.3.

This has been addressed by manually editing etc/client-simulation.txt to set the highest_protocol to 0x0304 for the clients that support TLS 1.3.

This PR modifies update_client_sim_data.pl to automatically apply the fix for clients that support TLS 1.3 in order to avoid a possible regression when etc/client-simulation.txt is updated.