### PR TITLE
update_client_sim_data.pl and GREASE ciphers

### DIFF
--- a/utils/update_client_sim_data.pl
+++ b/utils/update_client_sim_data.pl
@@ -95,7 +95,12 @@ foreach my $client ( @$ssllabs ) {
 				push @ciphers, "TLS13-AES-128-CCM-SHA256"; }
 			elsif ( $suite == "4869" ) {
 				push @ciphers, "TLS13-AES-128-CCM-8-SHA256"; }
-			elsif ( $suite == "14906" ) {
+			elsif ( $suite == "2570" || $suite == "6682" || $suite == "10794" ||
+				   $suite == "14906" || $suite == "19018" || $suite == "23130" ||
+				   $suite == "27242" || $suite == "31354" || $suite == "35466" ||
+				   $suite == "39578" || $suite == "43690" || $suite == "47802" ||
+				   $suite == "51914" || $suite == "56026" || $suite == "60138" ||
+				   $suite == "64250" ) {
 				if ( $has_matched ) {
 					print " \"$shortname\": ";
 					$has_matched = 0;


### PR DESCRIPTION
Two GREASE ciphers currently appear in https://api.dev.ssllabs.com/api/v3/getClients: 0x3A3A for Chrome 57 and 0xAAAA for Chrome 65.

update_client_sim_data.pl currently only recognizes 0x3A3A as a GREASE cipher and so prints a "FIXME" for 0xAAAA. This PR fixes the problem by adding all 16 ciphers from https://tools.ietf.org/html/draft-ietf-tls-grease-00 to update_client_sim_data.pl.