### PR TITLE
JSON and CSV output problem with mass testing

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -867,8 +867,8 @@ fileout() {
 
      if ( "$do_pretty_json" && [[ "$1" == "service" ]] ) || show_finding "$severity"; then
          local finding=$(strip_lf "$(newline_to_spaces "$(strip_quote "$3")")")
-         [[ -e "$JSONFILE" ]] && (fileout_json_finding "$1" "$severity" "$finding" "$cve" "$cwe" "$hint")
-         "$do_csv" && \
+         [[ -e "$JSONFILE" ]] && [[ ! -d "$JSONFILE" ]] && (fileout_json_finding "$1" "$severity" "$finding" "$cve" "$cwe" "$hint")
+         "$do_csv" && [[ -n "$CSVFILE" ]] && [[ ! -d "$CSVFILE" ]] && \
               echo -e \""$1\"",\"$NODE/$NODEIP\",\"$PORT"\",\""$severity"\",\""$finding"\",\""$cve"\",\""$cwe"\",\""$hint"\"" >> "$CSVFILE"
      "$FIRST_FINDING" && FIRST_FINDING=false
      fi


### PR DESCRIPTION
There is currently a problem if mass testing is being performed, JSON and/or CSV output is to be produced, the parent process calls `fileout()`, and each child process have its own output file for the JSON and/or CSV output. The can be seen, for example, with the following:
```
testssl.sh --openssl=openssl_1.1.1 --file test_servers.txt --csvfile output_dir --jsonfile output_dir
```
A call will be made in the parent process to report that openssl_1.1.1 has "No engine or GOST support via engine." `fileout()` will try to write to output_dir, which will result in an error.

This PR fixes the problem by checking that the file to be written to is not a directory (as is already done in `html_out()` for HTML output).

NOTE: At some point, a change should be made so that all of these checks are performed once (probably in `html_header()`,`csv_header()`, and `json_header()`), with the results being stored in a variable, so that these file operations do not need to be performed each time output is to be written to one of these files.