### PR TITLE
non-HTTP cRLDistributionPoints

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1431,6 +1431,8 @@ check_revocation_crl() {
      local tmpfile=""
 
      "$PHONE_OUT" || return 0
+     # The code for obtaining CRLs only supports HTTP and HTTPS URLs.
+     [[ "$(tolower "${crl:0:4}")" == "http" ]] || return 0
      tmpfile=$TEMPDIR/${NODE}-${NODEIP}.${crl##*\/} || exit $ERR_FCREATE
 
      http_get "$crl" "$tmpfile"


### PR DESCRIPTION
At the moment the code for downloading a CRL seems to only work if the URL is an HTTP or HTTPS URL. It fails if the URL is an LDAP URL. The `wget` command does not support LDAP and when `curl` retrieves data from an LDAP URL it stores the result in LDIF format, which `http_get()` cannot currently convert into a PEM-encoded CRL.

This PR addresses the issue by skipping the revocation check for any URL that does not begin with "http".