### PR TITLE
Don't check expired certificates

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7445,8 +7445,10 @@ certificate_info() {
      else
           if [[ $(count_lines "$crl") -eq 1 ]]; then
                out "$crl"
-               check_revocation_crl "$crl" "cert_CRLrevoked_${json_postfix}"
-               ret=$((ret +$?))
+               if [[ "$expfinding" != "expired" ]]; then
+                    check_revocation_crl "$crl" "cert_CRLrevoked_${json_postfix}"
+                    ret=$((ret +$?))
+               fi
                outln
           else # more than one CRL
                first_crl=true
@@ -7457,8 +7459,10 @@ certificate_info() {
                          out "$spaces"
                     fi
                     out "$line"
-                    check_revocation_crl "$line" "cert_CRLrevoked_${json_postfix}"
-                    ret=$((ret +$?))
+                    if [[ "$expfinding" != "expired" ]]; then
+                         check_revocation_crl "$line" "cert_CRLrevoked_${json_postfix}"
+                         ret=$((ret +$?))
+                    fi
                     outln
                done <<< "$crl"
           fi


### PR DESCRIPTION
In general, a CA only needs to keep the status information for a certificate until it expires. So, once a certificate has expired, the information provided about it in a CRL or OCSP response may no longer be reliable. The certificate may no longer be listed as revoked, even it had been revoked at some point before it expired.

So, this PR changes `certificate_info()` to only check CRLs for revocation status if the certificate has not expired.