### PR TITLE
 Remove extra space in BEAST output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -13722,9 +13722,9 @@ run_beast(){
                     done
                     ciphers_found[i]=true
                     if ( [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]] && [[ "${ciph[i]}" != "-" ]] ) || [[ "${rfc_ciph[i]}" == "-" ]]; then
-                         detected_cbc_ciphers+=" ${ciph[i]}"
+                         detected_cbc_ciphers+="${ciph[i]} "
                     else
-                         detected_cbc_ciphers+=" ${rfc_ciph[i]}"
+                         detected_cbc_ciphers+="${rfc_ciph[i]} "
                     fi
                     vuln_beast=true
                     if "$WIDE" && ( [[ ${kx[i]} == "Kx=ECDH" ]] || [[ ${kx[i]} == "Kx=DH" ]] || [[ ${kx[i]} == "Kx=EDH" ]] ); then


### PR DESCRIPTION
testssl.sh was inserting two spaces between the CBC ciphers detected by OpenSSL and those detected to `tls_sockets()`. This PR fixes the problem.

This issue was previously fixed by #838 (https://github.com/drwetter/testssl.sh/commit/87fe0c15da90e60ce999f6711c40e9faa0a1a3a2), but that fix was accidentally removed by the next commit: https://github.com/drwetter/testssl.sh/commit/f3dc53f554f02bf8a74f1970e4c035a012fe0be7.