### PR TITLE
Fix #1053

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3900,7 +3900,7 @@ run_cipher_per_proto() {
                          done
                          success=1
                          if [[ -n "$ciphers_to_test" ]] || [[ -n "$tls13_ciphers_to_test" ]]; then
-                              OPENSSL s_client $(s_client_options "-cipher "\'${ciphers_to_test:1}\'" -ciphersuites "\'${tls13_ciphers_to_test:1}\'" $proto $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE </dev/null
+                              $OPENSSL s_client $(s_client_options "-cipher "\'${ciphers_to_test:1}\'" -ciphersuites "\'${tls13_ciphers_to_test:1}\'" $proto $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE </dev/null
                               sclient_connect_successful $? "$TMPFILE"
                               if [[ $? -eq 0 ]]; then
                                    cipher=$(get_cipher $TMPFILE)


### PR DESCRIPTION
It appears that #1053 was caused by a typo that was introduced by https://github.com/drwetter/testssl.sh/commit/39647d17034ab773a6f9878fe5cc0bec93c37300.