### PR TITLE
HTTP URLs with multiple components in path

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1504,7 +1504,7 @@ check_revocation_ocsp() {
      "$PHONE_OUT" || return 0
      tmpfile=$TEMPDIR/${NODE}-${NODEIP}.${uri##*\/} || exit $ERR_FCREATE
      host_header=${uri##http://}
-     host_header=${host_header%/*}
+     host_header=${host_header%%/*}
      $OPENSSL ocsp -no_nonce -header Host ${host_header} -url "$uri" \
           -issuer $TEMPDIR/hostcert_issuer.pem -verify_other $TEMPDIR/intermediatecerts.pem \
           -CAfile $TEMPDIR/intermediatecerts.pem -cert $HOSTCERT -text &> "$tmpfile"


### PR DESCRIPTION
In some cases the OCSP URI contains multiple components in the path (e.g., http://www.example.com/OCSP/myOCSPresponder).

This PR changes `check_revocation_ocsp()` to remove all components in the path, rather than just the final component, when extracting the host name from the URI for the host header.