### PR TITLE
Fix extraction of certificate validity dates

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7451,8 +7451,10 @@ certificate_info() {
      out "$indent"; pr_bold " Certificate Validity (UTC)   "
 
      # FreeBSD + OSX can't swallow the leading blank:
-     enddate="$(strip_leading_space "$(awk -F':' '/Not After/ { print $2":"$3":"$4 }' <<< "$cert_txt")")"       # in GMT
-     startdate="$(strip_leading_space "$(awk -F':' '/Not Before/ { print $2":"$3":"$4 }' <<< "$cert_txt")")"
+     enddate="${cert_txt#*Validity*Not Before: *Not After : }"
+     enddate="${enddate%%GMT*}GMT"
+     startdate="${cert_txt#*Validity*Not Before: }"
+     startdate="${startdate%%GMT*}GMT"
      enddate="$(parse_date "$enddate" +"%F %H:%M" "%b %d %T %Y %Z")"
      startdate="$(parse_date "$startdate" +"%F %H:%M" "%b %d %T %Y %Z")"
 


### PR DESCRIPTION
The current code for extracting the validity dates for certificates assumes that the strings "Not Before" and "Not After" will appear exactly once in the pretty-print of the certificate. In most cases that works. However, there are a few server certificates that include the private key usage period extension, which also includes "Not Before" and "Not After" lines. The result is that the current code does not correctly extract the start date and end date from any certificates that have private key usage period extensions.

This PR fixes the problem and also speeds up extraction of the dates by only using Bash internal functions.

The pretty-print of a certificate begins as follows:
```
   Certificate:
       Data:
           Version: 3 (0x2)
           Serial Number: ...
       Signature Algorithm: ...
           Issuer: ...
           Validity
               Not Before: ... GMT
               Not After : ... GMT
           ...
```
The code in this PR extracts the start date by first removing from the certificate everything that comes before "Not Before: ". It looks for the shortest string that includes ""Not Before: " in order to ensure it is not getting the date from the private key usage period extension. After that, the longest string that begins with "GMT" is removed so that only the notBefore date remains. 

The part that removes the string up to "Not Before: " actually looks for the first instance of "Not Before: " that comes after the "Validity". This is to protect against the unlikely possibility that the string "Not Before: " appears somewhere in the issuer's name.

The extraction of the notAfter date works similarly. It first looks for the first instance of "Not After :" that appears after both "Validity" and "Not Before: " and then takes the date string that appears immediately afterwards, with the assumption that the date string ends in "GMT".