### PR TITLE
Avoid false-positives when testing for CVE-2011-1473 / maximum of 3 renegotiation attempts

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -12803,8 +12803,10 @@ run_renego() {
                fileout "$jsonID" "OK" "likely not vulnerable (timed out)" "$cve" "$cwe"
                sec_client_renego=1
           else
-               # second try in the foreground as we are sure now it won't hang
-               echo R | $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -msg -connect $NODEIP:$PORT $SNI $PROXY") >$TMPFILE 2>>$ERRFILE
+               # Second try in the foreground as we are sure now it won't hang.
+               # Probe for a max renegotiation limit to avoid false positives. Some servers (e.g. Node.js)
+               # mitigate the DoS threat by restricting the number of allowed client renegotiations.
+               (for i in $(seq 4); do echo R; sleep 1; done) | $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -msg -connect $NODEIP:$PORT $SNI $PROXY") >$TMPFILE 2>>$ERRFILE
                sec_client_renego=$?                                                  # 0=client is renegotiating & doesn't return an error --> vuln!
                case "$sec_client_renego" in
                     0)   if [[ $SERVICE == "HTTP" ]]; then


### PR DESCRIPTION
Hi,

testssl.sh may report that a server is vulnerable to CVE-2011-1473 (possible DoS due to client-side renegotiation) even if it only allows a limited number of renegotiation attempts. It concludes that after attempting only one renegotiation.

Contrary to other implementations, Node.js and apparently lighttpd, mitigate the issue by allowing a maximum of 3 renegotiation attempts. See [here](https://github.com/nodejs/node-v0.x-archive/issues/2726) for more details.

We propose this patch to handle this scenario. The limit of renegotiation attempts (4) was obtained empirically according to Node.js's behaviour.

João