### PR TITLE
Consider 2048-bit DH primes as acceptable

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -13477,7 +13477,7 @@ run_freak() {
 }
 
 
-# see https://weakdh.org/upported_ciphers/ogjam.html
+# see https://weakdh.org/logjam.html
 run_logjam() {
      local -i sclient_success=0
      local exportdh_cipher_list="EXP1024-DHE-DSS-DES-CBC-SHA:EXP1024-DHE-DSS-RC4-SHA:EXP-EDH-RSA-DES-CBC-SHA:EXP-EDH-DSS-DES-CBC-SHA"
@@ -13630,7 +13630,7 @@ run_logjam() {
                elif [[ $len_dh_p -le 1536 ]]; then
                     pr_svrty_medium "common prime with $len_dh_p bits detected: "; pr_italic "$comment"
                     fileout "$jsonID2" "MEDIUM" "$comment" "$cve" "$cwe"
-               elif [[ $len_dh_p -le 2048 ]]; then
+               elif [[ $len_dh_p -lt 2048 ]]; then
                     pr_svrty_low "common prime with $len_dh_p bits detected: "; pr_italic "$comment"
                     fileout "$jsonID2" "LOW" "$comment" "$cve" "$cwe"
                else
@@ -13655,7 +13655,7 @@ run_logjam() {
                elif [[ $len_dh_p -le 1536 ]]; then
                     pr_svrty_medium "Common prime with $len_dh_p bits detected: "; pr_italic "$comment"
                     fileout "$jsonID2" "MEDIUM" "$comment" "$cve" "$cwe"
-               elif [[ $len_dh_p -le 2048 ]]; then
+               elif [[ $len_dh_p -lt 2048 ]]; then
                     pr_svrty_low "Common prime with $len_dh_p bits detected: "; pr_italic "$comment"
                     fileout "$jsonID2" "LOW" "$comment" "$cve" "$cwe"
                else


### PR DESCRIPTION
This PR changes `run_logjam()` so that it does not warn about the use of 2048-bit DH primes, even if the selected prime is a common prime.

This PR leaves two issues unaddressed. First, it does not detect servers that are vulnerable to Attack IV in https://weakdh.org/logjam.html. These are servers that use DH primes that are of sufficient length, but that are poorly generated, and so are still vulnerable to attack.

Second, it does not address the potential problem that use of a common prime could leak information about what server product is being used, even if this information is not leaked through other means (e.g., HTTP headers). This should not be an issue with common primes from an RFC (2409, 3526, 5114, 7919), but would be an issue with product-specific common primes.