### PR TITLE
Send fewer key shares

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11505,6 +11505,7 @@ generate_key_share_extension() {
      local -i i len supported_groups_len group
      local extn_len list_len
      local key_share key_shares=""
+     local -i nr_key_shares=0
 
      supported_groups="${1//\\x/}"
      [[ "${supported_groups:0:4}" != "000a" ]] && return 1
@@ -11548,6 +11549,9 @@ generate_key_share_extension() {
           key_share="${TLS13_PUBLIC_KEY_SHARES[group]}"
           if [[ ${#key_share} -gt 4 ]]; then
                key_shares+=",$key_share"
+               nr_key_shares+=1
+               # Don't include more than two keys, so that the extension isn't too large.
+               [[ $nr_key_shares -ge 2 ]] && break
           fi
      done
      [[ -z "$key_shares" ]] && tm_out "" && return 0


### PR DESCRIPTION
This PR reduces the number of public keys that are included in the key_share extension for a TLS 1.3 ClientHello.

When creating the key_share extension for a TLS 1.3 ClientHello, `generate_key_share_extension()` generally omits the public keys for larger finite-field groups (ffdhe3072, ffdhe4096, ffdhe6144, and ffdhe8192) so that the extension will not be overly large.  However, the extension that it creates is still much larger than what is created by other software.

For a generic TLS 1.3 ClientHello, `socksend_tls_clienthello()` offers 7 groups in the supported_groups extension (P-256, P-384, P-521, X25519, X448, ffdhe2048, ffdhe3072) and 6 public keys in the key_share extension (P-256, P-384, P-521, X25519, X448, ffdhe2048). While the largest public key is omitted, this still creates a 665 byte key_share extension.

By contrast, Firefox offers 6 groups in the supported_groups extension (X25519, P-256, P-384, P-521, ffdhe2028, ffdhe3072), but only includes two public keys in the key_share extension (X25519, P-256). OpenSSL 1.1.1 offers 5 groups in the supported_groups extension (X25519, P-256, P-384, P-521, X448) and only includes one key in the key_share extension (X25519). Chrome offers 3 groups in the supported_groups extension (X25519, P-256, P-384) and only includes one key in the key_share extension (X25519).

Following the examples of OpenSSL, Firefox, and Chrome, this PR changes `generate_key_share_extension()` to include at most two public keys in the key_share extension. In general it will offer the public keys for the first two groups that appear in the supported_groups extension. However, it will still exclude the public key for any ffdhe group larger than ffdhe2048 unless that group appears first in the supported_groups extension.

In most cases this change will simply result in the ClientHello message being smaller. In some unusual cases, this change will force a second round-trip, with the server sending a HelloRetryRequest in order to ask for the key_share that it needs, but this will not affect the results of the testing.