### PR TITLE
Avoid unnecessary '0a' characters in ClientHello

### DIFF
--- a/etc/tls_data.txt
+++ b/etc/tls_data.txt
@@ -74,9 +74,9 @@ kKeLdXY4eWKxUw==
 BggqhkjOPQMBBw==
 -----END EC PARAMETERS-----
 -----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIHEhQsBkqt1i15mG1wluq/zLqDmjqNQegtgxyNBfRbZSoAoGCCqGSM49
-AwEHoUQDQgAEJP3GoZyVYrabOauJMWUZJxM0PEbtjTxW7K8V+JMDhJa+UyRQm8Tf
-2LDnzCAiuwzF8m0KhcloHEoptD2WBUmJlQ==
+MHcCAQEEIA6YyVcGYcFBFeH3RKz7d4WI9ylTcWYRY4XkzSa0kcmBoAoGCCqGSM49
+AwEHoUQDQgAEtCTvEZmcpOjOiCXDjnwMapTeM23/zRe3XGXb0VhGlWmAyLz85tki
+Obs/Y6s9XLrM6xqQG9R1/1jEAFhQIdCq5A==
 -----END EC PRIVATE KEY-----
 "
 "-----BEGIN EC PARAMETERS-----
@@ -101,12 +101,12 @@ bONJgO7LSp05PXa79CEi8sydmKYiH1pSLAzRiQnh
 -----END EC PRIVATE KEY-----
 " "1a" "1b" "1c"
 "-----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VuBCIEIACiKGKr1nm2eobXvsI3HrWNKR5wEVAIf7KaCmDPxsJR
+MC4CAQAwBQYDK2VuBCIEIDhCPq41ufKeHdfVAp6KeS7qo8E43pd+ee+npH0sOqxL
 -----END PRIVATE KEY-----
 "
 "-----BEGIN PRIVATE KEY-----
-MEYCAQAwBQYDK2VvBDoEOFxH7JJ8B4AopQls9SqDf5O+ATl/Cue6gnnUMfDMGdg/
-bcPkcJT4nX5fwbVjFKeoCdAYH6i6JJLJ
+MEYCAQAwBQYDK2VvBDoEONDoNojolTC5A5LwJmEfj/NqVrkG2PsagQ0IxZJcwyhC
+CrAkCbaEfSIdjRVr2ODIC8ByiHjIzqDu
 -----END PRIVATE KEY-----
 " "1f"
  "20" "21" "22" "23" "24" "25" "26" "27" "28" "29" "2a" "2b" "2c" "2d" "2e" "2f"
@@ -130,12 +130,12 @@ MIICJgIBADCCARcGCSqGSIb3DQEDATCCAQgCggEBAP//////////rfhUWKK7Spqv
 8VihNq3nNTCsyk9IOnl6vAqxgrMk+2HRCKlLssjj+7lq2rdg1/RoHU9Co945TfSu
 Vu3nY3K7GQsHp8juCm1wngL84c334uzANATNKDQvYZFy/pzphYP/jk8SMu7ygYPD
 /jsbTG+tczu1/LwuwiAFxY7xg30Wg7LG80omwbLv+ohrQjhhKFyX//////////8C
-AQIEggEEAoIBAHxYskjJGeKwSGdAf//JLxPmGRGP6Uylmt12QX5w1FfFXQVJdrsY
-unjdqhTwgV1vTZ1QApd0uZB//q8ZNNM8SZK0elY4ZJsHJAIdJ/ROmvPvkMCkU0fK
-S/uUHroP6tEDyKF+v7ooiBF2KXS5CkOYRTKhiOBaWGsdhiFIkd+O7oY6oyhPxPNT
-2zQEdhIu3ZgFG/ZcscdliMPMmZnKvt/dF4yV8RnCHl3MRDRdL/3McDAb4z89bWqR
-HRexppcgNa9lhOvR+nF/55NCzT3KwkFPQODQmMRH3bzmME+48HZrFcaaom3/DGt+
-EC+vidtEr4YW86tV6jvig5+uNR1mIKpE8N4=
+AQIEggEEAoIBAEcs/BWUPK4VleD+MgvCzy7mxgcH8Qi9SmKHN4wBCT/ZNbVGiBuu
+LNji/hl/TA/6WZT7HIiX+wXhc0AKbcbmvES59FQIzuMZpwyoxzps7X19Zjrbn/TG
+Al9MfhQ4KttyqkY6oT3JNKdB9Kk4VTekqHdVOtgV3jC83AfhA/2S0LpzlZ6V9IAN
+6xt+IvpNgcBRTeBTgNZxArdpS6IIaNBGk/5anyuKdDWzUBwKbaJQzm18j/66bqOr
+TernVJ3Hyiq/h3AMPY73sIVpYmjQOOwX059mEn6buNsdTFrSayiSxsfEeMrZH/Jk
+11Vit9Z8+i0zUUWxyPDDqo+ji9nbUKA/Sfc=
 -----END PRIVATE KEY-----
 "
 "-----BEGIN PRIVATE KEY-----
@@ -147,15 +147,15 @@ Vu3nY3K7GQsHp8juCm1wngL84c334uzANATNKDQvYZFy/pzphYP/jk8SMu7ygYPD
 /jsbTG+tczu1/LwuwiAFxY7xg30Wg7LG80omwbLv+ohrQjhhH8/c3jVbO2UZA1u8
 NPTe+ZwCOGG0b8nW5skHetkdJpH39+5ZjLD6wYbZHK7+EwmFE5JwtBMMk7xDeUT0
 /URS4tdN02Ty4h5x9Uv/XK6Cq5yd9p7obSvFIjY6DavFIZebDeraHb+aQtXESE4K
-vNBr+lPd7zwbIO4/1Z18JeQdK2bGLjf//////////wIBAgSCAYQCggGAV6hlUz0f
-RwpauhaumL+dFJQcZHgYghHX9JfNDZv1uMzkTiKxgVutrtFmfHoaTaYNgw+HEQSF
-ZRnGzyOXb14/ZoGWo727N4T5usOqINFcHIeAbPiRimo0mwS7ivYKxEFBaw4N7OyE
-zfNKAYWNQe0J+R2FLMKBSbJ+b1nGQ/cUSQDffDpKSUS94+XxwxcvNaCv9Ygtkvnl
-e/t61L/0eQu/nmi0o7PzR4brmyVTXGnj2LujG/KOtIB4pXQ1GqrvsYLB3pCUTDdA
-E0heXfpYGZJK10ByMkWmOuH3pCuI8C+7+Bh7JwQAXUtSpZ+hp1Bz7v1PKwY/3fG1
-2HcPXp85q5N9x9zYZv1vmwFAd0nTdoWdtMbiEJxhCdr6sRpi1+KPg6W3Kqtfcv2f
-ZZC6MwVFtxogjzIlXt68O7HRH7Adz+DGhEeZqdxIQpaQR50p4LF7gqQ/mzXq8oCe
-XKC3XxrfV5h3OrPEL/zNTd2pzh3LLQB349aOHNz1F+3YPyPlvwOsXkeT
+vNBr+lPd7zwbIO4/1Z18JeQdK2bGLjf//////////wIBAgSCAYQCggGAW1x+826N
+psCeb2tfDTDARYQV4fNRFXEAfMORDlYZKr/wcgO1HJ552W4dbmo/kKq/PFBgXZpx
+FqREmBywG5vIBGJO0lVxCc74HANS05/HiL1hC0c5n2vcVWlmlhuUwVRQjPRarAPa
+x3SevWA7zzbZQP2yfynf2Nn60GkoGbgRZ4wNW6Q378WaF6csgbkRr3BOZLX8uRa/
+NnxtxsoaPiWlBE27maDbPrw14HbvWUb+ft/BVPOtKg1JJ0UT8oFP+zLEpyfjeU7P
+m1vauWXb1k1iVTTeUNq+47JwQA1ZWm3fWympNoQWeohueZiraN0BerhsvdHWqBwC
+6cs6RVmgzY7eiAL38bjZ7swn32th3crbSveCypw8vHW7zOMPr8e6i7NI12a9rAdi
+UbU7PXSm1IekMCtWCFQsPdXAc0TIhJY0hElnmjTVAXwP4NPwDlhgtv6x1OE7rr9v
+BXvMHpw4dVscRWNimLWhoRnPwWDoNZSaz/rw5vVr06NIucC3Riq+bnOE
 -----END PRIVATE KEY-----
 "
 "-----BEGIN PRIVATE KEY-----
@@ -170,18 +170,18 @@ NPTe+ZwCOGG0b8nW5skHetkdJpH39+5ZjLD6wYbZHK7+EwmFE5JwtBMMk7xDeUT0
 vNBr+lPd7zwbIO4/1Z18JeQdK2aeHvFub1LDFk30+3kw6eTliFe2rH1fQtafbRh3
 Y88dVQNABIf1W6V+Mcx6cTXIhu+0MYrtah4BLZ5oMqkHYAqRgTDEbcd4+XGtADgJ
 KZmjM8uLehoduT1xQAA8Kk7OqfmNCswKgpHNzsl9z47JtVp/iKRrTbWoUfRBguHG
-igB+XmVfav//////////AgECBIICBAKCAgBKs8VkNMjroMib7Wuw71hVoHiB7lF9
-3FQsDwU3y//RgETN2CEx8gdarvb35ldNEkypxtiaYck+a5qKVkP8uW4/AUoGlH4V
-mIVz8R9e0Cewc4X8229+AgvyguaEhJHozp7EqIYEYlpLyn5GL53l2OYvBB3eH9Yi
-yjYKe5vCe16Jy88oJYrS6+ybYLXHcfJsLHIppMS17KuDdH/DUiCvy5HE5fA5ufD3
-ExQImgsDa3rm8nW6NUCix9Pl4X5OkWieYE7pXBePZ8Yk8BD4JpPbhsh/9husS4XL
-/IpSq+tzgXq44SKQv0o9hbkGaxR6xmTjTwOjRiqW1D/1pS/wHxZbH1qbgJSKq7Fx
-6VZZjH5Hyx9Zh5p3mksa7iZ4DQXVW/8ffz+8UdVRQolVUQxXWihcU5qfdtmDEPI0
-4dRR5mI/Pk1n7lAhdyE4H/Tz0TmqItfScZvNaj6RbPbk6KOapgHFKIX7dmtPxAOv
-oMMudOwsBg7md3CY08zH/XdE6O8lmVgCJQMjfwJ7QMayOKL1NYNMmUDPP0WIxOyz
-5UJj3GzmNrKgYftgr2o8blEwwDbETYN/hpgTPyWl8ieVxK2bn7SX8dFXXEwSdCAt
-Cg5c3H+YOc+ahx7VYXJtBDyAKuygUKnVqZ1ht6/xLUyJUxiSMZLbFKHBLkR3UuQa
-HyRwI92yYN4+Zg==
+igB+XmVfav//////////AgECBIICBAKCAgBchieVrkn2z0jDeaUn9AWgtHX5Lk58
+CeaLG58CvnxAqR/Sxn5farEICapmWmVBQuJPO+KyLCbZgB/NRb3Miw+1sgnAbZ5e
+vsLdnjjgKOvrrug9WpCjwv+/r2l9CfHxxyHiik1GwkE6O1SNZQySqnBi5fN1wg0c
+wzMf4U527OP+n0vrlrztjWftd6k/3/WX4LiSugPGXOYTiu4EnNpVbgtsH3Eaz264
+KbhxBaH4T9jWN4Mrg8ZL9mT1r1IajGfE8dLverTJ2ZEy3SWdhyEawPHOET78KSq2
+Rgj6ZGDMTYcSuRbWY83x6JG/fOnHytA/Er+R5+Z8icD3kOwujyoaO1/WJfMMzNWY
+BXQI8b6EZGK/DXrqOTpZbxwJizw9jURF9Bp8j+BJnjl0c9K/l6jEJJqKqS2mgwWl
+GRD3yk8OBnRNWbDx/xWgpMUTkFjm+PGpdHHRpg1qVxVHp6eMiu8OF5I3mMA2rv9K
+aRDGTTbsRp169Wdv41Ap+T6RVYf4oCIGkuSpBm5F8K0J3x/rkiTxqZFnDiQopRog
+fksgVds2zBZQ/ibGHFhjJQCMthiuDR8zDvCCVFrR/MVBP4ZoGzT2YPVAAqSRZ4yx
+2Ou8gqO6axcRsfygvjDK5LhvjCI7f/ruyu6jaM5ZyfMe7BxMkujpcVsNB56e63NH
+Gq1noDIjPnTehQ==
 -----END PRIVATE KEY-----
 "
 "-----BEGIN PRIVATE KEY-----
@@ -201,23 +201,23 @@ jowzTHAcOs2tBlf8z+xxmx9cPk5GBB84gUf7TP20d6UkcfepqWkQuFUyLttjQNig
 DvCSNQUR4wq+wf/546Juf7KfjBgwI8NYfjjaAHfZtHY+TkuUsrvBlMZlHnfK+ZLu
 qsAjKigb9rOnOcEiYRaCCujbWEemfL75yQkbRi1TjNcrA3Rq539eYiksMRViqEZQ
 XcgtuFQziuSfUjXJW5EXjM8t1crO9APsnRgQxicrBFs7cfnca4DWP91KjprbHmli
-ppUm1DFhwaQdVw15ONrUpA4ynNDkDmX//////////wIBAgSCAwQCggMAVvLSfpPC
-OJVhuOkMtOYtl6vcKtuP0RXXZYBfMFufb5gQJrEypjSIxS+kRyBjNMk3qSt9iBbG
-dpSe5fuu9RtI5O5eD/UXrDNBbI2/ldLNDarV3g+hcYklzKQE6kBSWEt1soktPXEq
-PIcvYFVrOtWrH3Nw0UT/brRLZ+Ea9mnRG6CCICM0K2UxMhyjDheGCVCpmZfYJycP
-mx0H1SA5RI9lP+GkDm096CgAEtXqk1eej8/9F4vsEn5r48HKobXlZEBp+HFcIq7s
-DqrNZkg6jRhMusGjVM7mpFuyt0D5LIshsDBHjwkULJUX9Zd7pcVizbHbst2rpi8u
-n7H908pdRFvdQYfvjBwvewl7DwZoFOsL+qA5Jo1MtfgpgegouKsS3jmyRSmY4wLp
-uOjv6S1//A1sctJNwXlMI7/3IcONT3bmOwNnyvUeFJE4+lnYeClEpAsrCegcljQa
-UNOeSKR1x9ctvzlWaBM5EP2daF0JiYdo3Ug/YISDX5dJFOW4gWz95W8Ii9//6zim
-8LgA2/NP5IJBs0DPQxVbEVUI0wRPYMI4aZBm2n5bQFQKI95FQfv8ncKSul/fuTtY
-du8INZR6ogMpWdDSz5UsIMwjLzXfg30ehcCyy9ebkDtiPDr8++HrwWKGVvuQaa4p
-rPiac3fF1+DCHVKwxRsqM1zgDzNtI59Y9wb85kyPRsHTuG5kR3KUMUUYWmbuuMG6
-3yMm7K3hJhlhfiO8hIWt+ZJJHCIEJOFK7FJbsZWmFbS6ukcl1uwlmQzote2aFfYA
-5fsL7VeUaXKkJPKY3p05rvHJkayUpxn+oamOA1qW4eVYzio/ZiRtaUNLbmOvb0pU
-Z1fyypnlaVzAVynoIF43LfbJ7cdpfnoz6hd//SVA742kuQMA4VeQoXLh6dX1/qZV
-8QF7gNjLxgJoqGssaOUwxdxcXqMl+9JUBL/LtvxYs1xcrzla/tj+26XcPT+/tIWR
-89TyyCWVPBvFLeWfG5+iIXT0X6g8zJP6d9QCL+2F3yStbJngWCZtFDFD
+ppUm1DFhwaQdVw15ONrUpA4ynNDkDmX//////////wIBAgSCAwQCggMAd1ECM2hF
+g6zHf/PHfDtO4uZ20GU4VSufPH+0HHMSbpF2NaMxsNiLvSiQTr6sfxqzr/GLe1ni
+jW8nt3xpi05vlkNaBDkzWJHkmQu+Y4uoOtK0Py1hj7VyrXq/+5R4fSGApXVZBjWV
+N2nfr279gnopCLBMh44y+lyKzcNa2Dlm6v/ToI9dAz9RP/1emAcbyoXGN3GdZHyy
+o4IH3iqjTFYIKAwEUHa9OerNvk4lD7/FzSJ6iyZo4kerDn0hiK1vR3Qwtwhj1gcY
+C5+zYPcntPqyYqhIejxEyfBhPNJS4v07q9w3Z6te6IjlP/NWpAd8DngrLsR/IJ0B
+sYCFxk7s2TthAG+PKLK+2CB9pKYOGXZ6dDGfAQQy4CqgNPR8soFJ2Dyi3+SIhKAw
+typEmhdEPmdza79D8lD3FcPnTF6+qFNknFNPAl/MFlvyrDYJ4dAG9f/ZNG6lVo3h
+IeoRiHJ4yXuzD4hC+A89YNccmR5fvhO9BbYRtkEEICgMd3vBPgmPEV7FQx3iAQn+
+TCxx/R+ayanuJZBJrMMq7tGVoGKBlY9ObDPQFB3BDieuJV36jWO3NuuRDjz8WrBZ
+96VPDygVNFUo3Ee9+QZAQciiZwRm7wmxHxs5GeUZstwDQHXp5s6qq3qsrbi2+wlx
+fzG/q6WwM4bF9jJzSZwzEvYRS91eM/mIG7QjFlYZNyEDvWDxHdOH/d7eLLkcgw0v
+i9xXakhYJ6kkaWUIl61LUvde0bZ63hmaH0auwLCrJVvj5f9HLJgyRBEAaAtNS1JK
+uFotFE+lbheDNSd8biGl59+y62SkLNfYrBLVPNF7VWFZ+gsFjN1WnZHKroAnx0/s
+xDC/e2HJ41V8cmObIQkb6En6isg7ELwhYZx0bnucjWHmX4T+6V5MrYDRIMDrvcIi
+kz00Zfodq4Jh3EbVkLgJ9PTxZxQqh17B/0aWszi7inC4krCjDajDVkVAJbTe4T5h
+eLLRNAcU8CqbKfueeE591Wee7AkjHff5+hFAbbNguxBcNO3I59tew8Ef
 -----END PRIVATE KEY-----
 "
 "-----BEGIN PRIVATE KEY-----
@@ -243,28 +243,28 @@ UErHi3WCgihGwLo1w19cWRYMwEb9glFUH8aMnIawIrtwmYdqRg50UaipMQlwP+4c
 IX5sOCblLFGqaR4OQjz8menjFlDBIXtiSBbNrZqV+dW4AZSI2cCgof4wdaV34jGD
 +B1KPy+kVx78jOC6ik/otoVd/nKwpm7e0vur++WKMPr6vhxdcah+L3Qe+MH+hv6m
 u/3lMGd/DZfRHUn3qEQ9CCLlBqn0YU4BHiqUg4/4jNaMi7fFxkJM//////////8C
-AQIEggQEAoIEAFBZTkIN/znN/euu0INkB365wc9kj/ibO/Hj3mHLa+NHoaKH4A33
-kd3WQCjRmLnLZHlodMbrgJ8vxHtKdeFiv4i1gefsv0aVv7zX9Sp3zpRJC/bhNJkz
-BsVJwwp9b+OPfc13d2vb3ZsVyqmfUO6NdMz1x9cEiR+wrpJjrMbWqByliAkByI5w
-Znlm/aLrwOWOZ0lkY2SzB5qDcNM/I9m7Uk9pW3Q0GugWC/PMzv/+VCMb/Q56pABX
-310qNm0AZov4cBWz5qtD8AQ+cZWBndX4ydL+jLT5n5SwrXR3z8biCBdJWpxpKeVJ
-3Dal4LC1UcuJDuwtxswlm+AzfVJI3eiKL5uwsSbIg0Ls7bk7FO1LWGHbGwbL+eof
-TijrETwUgsBNiLdmLeDtfWBTDAH3kZnBpZjRhCgIRuRUleTRevvnMtBXR9td5Lkj
-N4quHZbx0S9novQLV7EF6+mNW0fddbHxC6mK0C3vCGCTLUTjFoyW6DJMInUYrerO
-kTEyH0JCMrA/mIGmU4QR7dXuMPJiTwg+TS3jZYmwa4nL5hES7Ssf9PSaqdyV2ZzU
-/oVLTfIuvpFbcidZF7j2DFaObtV6ZjqegufOaNJmTItWJzNJ31s0ZUGwXLq5jygh
-HMAW+uzNVX5nv7ezvjOANrOAosSDN1zFVRrUBOilaKbvguwp1fym2bnqiCFD1tKw
-CMgtTOTwP8/j1XAMlD/Afu/VTJls3IY3r6ANoCX8hLTXK3ykcewV2irV4nB+8p09
-KhhWSr3zF0qj5Keo33oMUnEaN2eIeIUegXKxpp4WtT4JEUE0ritZF8SzZmoHkANw
-dgtDm8Ryx/SaZ+QwrqhVFOsSU8TgvIHc455j4M1o8DBAdUiTbXniYlSNslzbvfbK
-57uJbPwrw/Op3DzFvZPnOx5vfnDsR9qOmAknfNfgKtEFc0AAno5BiyaiIlHuBUte
-TS5AsCL7q4Q9ybS7WehGOWOwHzZEa7DlUJ1kqjFCxBXgYMEKSbwKF5vHpp6x2O3x
-0OPzODz1JGoRT5yYXY3UiboRlkldet4NPNufg4MoKW6XooLXq/bIVQNSZtg1gBO6
-ipWJlxpfmPhjOdljGlXsstvaazESsMaff5xG8dIIOb+yMFh6DC6GElU49GGzfnAe
-EB+RNHS/o8boRFQn4r6/KiVCODk0qGK3TvYStsjXo93vA+KfJwSsqtckwX+wcl5l
-mWWvMF+iHQ+gL4L1hz7hH/m7UZGy+o/7mi7lKDSPLvSlGwzzdWcvEQj4Hv4IHQQh
-eeSHdeSwhqaL1XjP6JXa+IEY/wXzwIMHohtw+epFwLZhg8NFxkzHUpCKLDZrEDc8
-Y9zPgF69gpA9VpStqLAqHxBvEm4BYFoFyfw=
+AQIEggQEAoIEAHS/7kGuCXfrpyvCcxeLd5jfcP3RHn8lE+EilYbyuQJqz8EL4npe
+TAt64jpvv69PB+zULeTk4UoDwFOymcmAX5OVruDh29y4I0+/UKFroqyLdemZ/27C
+DP90Hy5KCla56/228vYcL2YAXOo2iSUwqBeeL4t4w76U/0nTngh+JGI63GwS8Oql
+iX+JJ6PXyBjj/LU21Uv9OCAJjmbQM0qtI80ofrThy3lpU4vpuGB2eNTmhW7gFwys
+ypTn5px5nYawlau6XEJIhPU0KdmcjZK1wUHfymXF7tJ/2EnrcEqkNd8h+FvUDVsB
+as28va9BsonIGD3CHJ6xiTSJv9vpzOorUDo1vwSA11rff1VWqL0ki78275aSPWLr
+N27D5WW2oj4hWnHW4E+wG4/woTtFQn/lkdgrT0ip7h92RL4wxELz8kUOc1P7BCFi
+oho1GD7E6QAJx0Rz61ipLQHLANZRJv1lwx0rJVNOSkYE+UafZrwu0wPEXR6p4Aqw
+gxqG04PCj1j2ZyFMKF3/vT4NmEf1f0Mrt9LnjkSH9WWzur8Jep+2ysYcKhFBJX1F
+pGxk3MS8tB0eZH0Z2zmmDw32SzDdhrViQZfO7xigrLC95pW08lryZKRwLTrBA33R
+74/K2QkrwNq895X71FBgq8GrthdG4bkV5BXisrmjT7KS4tmZiCL/rFRTgQ/v8O/N
+WSaOM+sWHkDX+xX5zeGqLhsAAWXQuqOFfkyRfxyaX94z5yhucYY8HUAfng+KppzK
+RH3yb31QzUhWl9MOfJBn2ZaesJu4PCxcDjyJs2U2MEAkfmzZIvTp3ZFN9uC0oeRm
+Fslg2eVBQ+OaB8n11ll1kVYJ7Teq2JrCDGhIEeW3sNnZIVBDoeP6/yNtJIfqNcl0
+qqpyT23cZdfssuon0ehd15UC3NgWQ6HvM82qbBdys82ZHVfeGXmFXJj24ZgTKBLc
+hRWQOhW/7EsvgOMAnYack6Gc/v7LwS3rTFUH8HvC0WW+MlwXKukWCjllutKla7nk
+zAs82C+WKRdWhmpdqq9ay/yWkbQamVyGUCzd47q0v2XN9aN+B42LAONA1zbV73Ba
+MtckOChbFT9F1mWaFqguOj/BhUf744E96JAzvZEfHrEiR80d7Hzl/sm54jxQ1SJ4
+5XDVygSnlFzNDjpCEY7RRJWFhympdvaaeeDE7F8kKFFTQ6zE006JwYDjU3TK04l6
+fokq1G9AAniE9halfDT2VpFj7R2l0oFF1BH+VMLdA16Puu/s1i6TuvB6bR7U9Z6R
+lqlJqPTVC6RYUgoEqvmUwK0+bnhsE3xYXCjzKf77wSfXF1VKBivYQGc0Wq0BIKUI
+3V2dIgkNeXVF3JE975vjUf+yz1nrhVhdsD0=
 -----END PRIVATE KEY-----
 " "105" "106" "107" "108" "109" "10a" "10b" "10c" "10d" "10e" "10f" )
 
@@ -274,12 +274,12 @@ readonly -a TLS13_PUBLIC_KEY_SHARES=(
   "10" "11" "12" "13" "14"
  "00,15,00,39,04,76,b8,16,df,b9,b6,24,6f,45,24,6a,28,2c,89,c8,67,30,93,52,7d,e8,7c,34,1d,67,5c,c1,da,3a,45,bc,da,02,8b,c6,bc,9d,07,53,d9,7f,24,59,c2,19,14,90,a7,8b,75,76,38,79,62,b1,53"
  "16"
- "00,17,00,41,04,24,fd,c6,a1,9c,95,62,b6,9b,39,ab,89,31,65,19,27,13,34,3c,46,ed,8d,3c,56,ec,af,15,f8,93,03,84,96,be,53,24,50,9b,c4,df,d8,b0,e7,cc,20,22,bb,0c,c5,f2,6d,0a,85,c9,68,1c,4a,29,b4,3d,96,05,49,89,95"
+ "00,17,00,41,04,b4,24,ef,11,99,9c,a4,e8,ce,88,25,c3,8e,7c,0c,6a,94,de,33,6d,ff,cd,17,b7,5c,65,db,d1,58,46,95,69,80,c8,bc,fc,e6,d9,22,39,bb,3f,63,ab,3d,5c,ba,cc,eb,1a,90,1b,d4,75,ff,58,c4,00,58,50,21,d0,aa,e4"
  "00,18,00,61,04,ff,c7,bb,4d,f2,99,44,ea,06,c0,e8,3e,08,82,9d,da,b2,1e,44,bd,9c,6f,36,a7,46,43,9d,1f,70,3a,c8,72,8f,75,c9,b6,95,96,0d,ad,76,78,19,82,ea,d3,ce,d7,be,8e,fe,e4,76,46,2b,20,b5,26,2e,75,f1,01,41,a0,e1,df,3a,c9,2b,5f,71,96,88,ac,31,01,f0,77,3d,06,02,64,14,5a,0b,4a,c5,cc,54,22,9f,a0,4a,3b,ef,b9"
  "00,19,00,85,04,00,7b,81,9c,ca,50,fb,7d,25,9d,df,e0,5a,b1,f0,8c,ba,d7,43,e1,30,b7,16,33,32,34,83,91,f4,71,af,45,10,d1,8b,b3,0c,dc,ec,54,fd,1a,cf,29,42,d3,a0,54,95,c0,2f,56,08,97,fb,ad,41,89,46,a9,c3,ed,fb,10,e4,6e,01,a1,ce,96,86,f4,9e,86,e6,14,d0,fb,a5,e3,74,62,09,50,b8,17,92,76,a2,b7,71,b7,4f,fe,ef,63,7d,f1,ab,d8,7f,7d,6c,e3,49,80,ee,cb,4a,9d,39,3d,76,bb,f4,21,22,f2,cc,9d,98,a6,22,1f,5a,52,2c,0c,d1,89,09,e1"
  "1a" "1b" "1c"
- "00,1d,00,20,ad,da,32,b8,c8,41,c6,0a,a3,cd,37,92,f3,4f,a2,4a,97,84,b4,c9,2c,54,c5,70,ab,d1,10,ea,cd,7b,6b,42"
- "00,1e,00,38,c8,52,05,c1,be,84,4a,bb,0a,ce,52,1d,84,04,82,64,65,ba,32,39,da,8d,02,6b,86,d2,98,eb,c1,8d,f5,75,43,62,a6,b1,11,22,71,b4,07,83,68,c8,82,13,56,c9,18,ac,5f,97,15,00,86,a0"
+ "00,1d,00,20,4d,fa,57,44,b7,f7,48,b8,95,77,5a,c1,ff,86,bf,ae,f7,3a,33,69,54,de,6a,f5,2e,89,84,6c,f2,d8,b2,43"
+ "00,1e,00,38,6d,6d,67,a7,4e,3d,45,dd,ec,7e,a0,70,88,56,54,d8,c5,7c,4d,f3,8f,8b,f8,f2,14,06,1b,a0,4f,f7,ad,6b,3f,3a,90,42,41,8e,74,28,32,4a,a7,50,4a,7a,8e,42,55,eb,94,96,de,83,37,d6"
  "1f"
  "20" "21" "22" "23" "24" "25" "26" "27" "28" "29" "2a" "2b" "2c" "2d" "2e" "2f"
  "30" "31" "32" "33" "34" "35" "36" "37" "38" "39" "3a" "3b" "3c" "3d" "3e" "3f"
@@ -295,10 +295,10 @@ readonly -a TLS13_PUBLIC_KEY_SHARES=(
  "d0" "d1" "d2" "d3" "d4" "d5" "d6" "d7" "d8" "d9" "da" "db" "dc" "dd" "de" "df"
  "e0" "e1" "e2" "e3" "e4" "e5" "e6" "e7" "e8" "e9" "ea" "eb" "ec" "ed" "ee" "ef"
  "f0" "f1" "f2" "f3" "f4" "f5" "f6" "f7" "f8" "f9" "fa" "fb" "fc" "fd" "fe" "ff"
- "01,00,01,00,95,c2,02,1f,12,e4,c6,a6,d4,d1,20,89,fa,8e,f0,86,d7,b3,dc,a0,d9,40,41,92,03,0e,84,96,52,4f,6b,82,0b,9c,7d,83,05,6a,f3,9e,bb,78,6b,64,84,0d,c6,cf,0d,b0,f6,d7,df,f4,c7,34,6c,31,2f,32,11,53,8f,95,8b,9b,d1,1b,84,e9,fc,76,89,53,e7,5b,dc,b9,8d,ad,99,d6,e5,7a,eb,51,37,ec,20,18,53,e7,b3,b0,ab,06,94,c3,d9,0f,c0,45,9b,73,d2,aa,89,ff,00,03,f3,c0,4b,df,c5,f8,35,53,86,67,dd,c8,dc,11,a4,4c,08,98,56,30,f1,63,4a,05,2c,a0,9d,a2,80,9e,28,84,27,ad,ad,3f,90,c1,03,40,fe,12,0a,73,bf,50,44,2e,7f,0e,0c,56,7c,bd,37,2f,2f,52,1a,35,37,d7,c4,c8,22,04,b1,97,61,5f,9a,f7,87,4a,ff,c7,c7,ef,01,90,15,4c,2e,75,56,a5,e7,94,f3,a6,71,e0,14,bd,0b,2c,f7,b6,19,a8,f8,7d,d0,23,58,b5,21,62,3d,96,f8,58,2f,e4,8c,b3,f5,62,74,05,00,80,3e,e9,ed,18,1d,ec,db,08,1b,3f,69,29,dd,5e,fa,e3,71,47,26,c5,ad,a8,eb,75"
- "01,01,01,80,61,be,bc,aa,6f,e0,14,00,99,b8,4a,66,39,46,29,f8,2d,55,f9,c3,da,df,50,27,6b,b5,b7,a7,5a,b7,fa,71,72,99,d9,33,af,5e,5f,56,57,4a,4c,ff,43,5f,65,a5,29,ea,ed,87,55,38,23,06,66,6c,1b,d2,f8,dc,6d,c0,0e,d0,17,76,93,1b,e8,f8,b4,c3,52,e7,b4,a9,51,cd,fe,c8,62,b6,05,00,19,e2,f2,54,cd,a7,fd,38,5d,e6,a9,40,1b,a4,4d,08,b9,11,e0,65,22,5c,8a,88,48,44,6a,bb,51,a7,38,02,5b,69,7a,a3,8c,ce,44,82,59,ae,41,f8,e3,82,6c,db,6b,78,a3,38,67,3b,c4,b4,aa,f2,86,ab,a6,5e,96,d5,c4,8a,56,5c,38,4e,f8,35,10,8f,39,d0,39,7b,6c,d4,99,69,2e,78,2a,e7,90,0e,e0,09,e1,4a,ad,d5,0a,6f,41,d5,69,2a,ca,cd,84,9d,66,a1,28,d3,29,b4,ea,dd,5d,17,d5,e8,e4,48,9f,54,b3,ea,dd,e1,88,d9,2a,2d,08,ca,8f,a3,bd,93,64,b1,11,ce,13,60,a8,98,e8,8d,a7,2f,d4,0f,0d,cc,7d,28,be,68,1b,52,72,44,53,ca,f9,cc,da,e5,d2,79,59,91,52,8b,47,db,b2,12,8e,f8,26,3f,1d,ac,0f,fc,ef,c7,9c,c5,ad,7b,39,ba,49,99,bd,02,2a,88,bf,a6,c9,63,0e,e7,09,51,aa,94,b4,10,28,a3,ad,a1,4f,19,c0,f3,b2,68,a5,db,18,14,58,cb,88,86,73,8a,64,39,dc,f2,6f,83,7e,77,44,ef,c2,ba,95,f7,e3,65,a0,a3,ac,69,37,c2,a8,08,7c,e1,97,d8,b3,83,2b,db,1c,ec,51,88,aa,f8,e6,bb,31,d9,32,cd,08,1c,81,32,f8,e6,98,5b,e4,e2,16,25,eb,ac,bc,5a,23,b2,62,47,a2,93,e7,76,0f,a2"
- "01,02,02,00,99,9f,91,16,8d,be,05,71,c1,35,f8,35,d1,b0,8c,46,a3,b6,b1,99,1b,0a,49,29,aa,5b,26,b0,9e,67,91,60,fe,e8,fd,cb,87,a3,5d,01,55,c2,76,fd,c8,2e,80,67,71,17,5b,97,55,53,fe,84,d4,53,47,63,39,20,2c,ff,8e,e0,20,00,c5,86,c5,76,2e,7b,f0,85,5b,93,0e,44,f5,38,7a,d6,c0,3a,36,57,06,45,91,de,86,eb,f0,63,01,bc,23,c0,75,4e,42,f3,02,5a,76,52,8a,98,c6,6a,11,7e,08,6f,2b,67,b2,5e,35,05,22,cc,13,51,a2,37,b3,5c,82,24,12,10,9e,61,85,a4,0b,59,91,97,4f,c3,4b,28,fa,c2,02,c6,76,36,53,1a,93,cd,ff,1a,11,dd,02,da,ec,a0,8e,83,26,02,f8,37,cc,68,bc,1e,11,ea,90,dd,47,54,02,0f,6e,ed,d6,86,cd,33,ef,a5,b3,e9,5a,dc,b5,81,64,5c,ff,16,d3,b7,d3,7f,ec,47,4e,fd,5c,ca,a3,a0,8d,6d,05,69,80,6b,fc,e4,22,21,4f,3f,cb,46,ad,a6,f3,24,11,68,69,78,71,30,8d,10,06,60,9d,91,9a,3f,8a,f1,af,4d,b9,6c,9c,9a,ac,71,78,04,fb,8d,27,de,a9,da,ac,31,7a,b8,a6,92,47,50,eb,24,43,75,c9,40,58,6e,a6,bb,98,64,40,54,1c,f2,4a,16,79,5b,62,ec,5c,78,3d,b3,91,a3,3a,a8,41,de,08,03,15,6c,92,e6,dd,47,5e,16,c6,ea,37,86,94,57,be,16,c2,c3,ea,92,e9,e8,f3,39,7a,7b,53,a8,c5,37,ae,98,1a,75,b4,01,67,e8,f0,1d,b2,77,23,e7,04,85,45,69,f3,1b,1b,1a,08,8d,03,41,a0,e0,07,6a,df,66,ac,c4,f2,03,e9,68,da,8e,c4,2a,1d,60,2f,ae,d5,87,54,a9,5e,6a,a4,da,a9,78,10,cc,9e,86,08,af,9e,8a,f7,f8,dd,b7,62,35,e5,7d,18,5c,de,63,2c,e3,d8,a3,66,25,9f,18,cb,75,5a,2d,fa,37,6e,8a,b5,3e,25,cd,4d,9f,2c,09,bc,df,a9,02,5d,a9,da,a6,14,af,58,a5,11,1f,8b,6b,b7,85,b3,42,5a,6f,6c,ed,df,68,f5,47,3e,f1,ac,47,1a,43,13,2e,7f,f4,21,f9,45,9b,e0,8d,ed,4c,06,87,60,2a,2d,42,db,9f,00,ea,c3,48,94,05,04,1e,fe,71,3e,17,61,6f,23,59,4c,33,af,3c,02,de,af,68"
- "01,03,03,00,82,04,6b,a6,21,57,09,f0,84,a4,4f,1f,6d,02,70,8a,cc,ec,d9,f1,e3,59,1c,07,a0,58,88,8d,3a,86,dd,a9,34,9d,30,29,f3,a7,fa,c0,f0,79,de,6f,3f,61,a3,f8,49,3a,c5,89,fd,5e,5c,22,62,99,7c,02,c6,69,90,83,dc,c3,9f,c4,d3,8f,99,af,23,90,ba,54,fa,c2,97,8f,a0,e8,65,d2,e7,48,6d,55,2f,f4,80,d1,a6,82,2c,52,e7,a7,1e,34,99,8b,af,64,ef,e2,9e,53,12,98,28,6a,a8,22,01,34,9e,26,46,70,14,28,36,1d,c0,73,b7,cc,48,1f,a9,9c,50,e3,bf,46,c2,c8,29,e1,ab,20,2b,52,db,ec,7a,64,22,66,af,22,7c,77,ec,3d,16,00,8d,5a,0b,4c,03,52,dc,8f,61,8e,06,cc,b0,d2,48,c7,0e,4f,8a,0c,fd,6d,36,eb,a0,48,57,85,35,13,bd,c1,64,2f,d8,7a,7e,07,88,1c,e3,dd,f5,34,3c,8f,01,b0,35,df,cb,c3,b7,72,62,85,f9,74,59,e1,7f,13,17,3c,6b,06,77,30,61,1d,7d,4a,ab,9d,64,cc,ea,62,f1,22,57,dc,94,15,3e,89,61,75,14,4a,a0,de,68,07,47,f1,18,40,8e,bd,2a,c7,9d,4b,19,27,7c,67,89,af,a5,45,61,df,ef,a5,1a,79,12,6c,00,b0,91,2a,13,47,a8,24,02,a8,1e,e1,33,7a,95,b9,f5,26,86,b8,c0,46,cf,b9,18,2c,92,16,f1,3c,ca,9b,1b,be,a6,0c,ae,43,0a,80,f7,71,2d,41,ab,d6,98,98,f2,c7,f0,50,cd,34,a8,f7,6c,fe,2a,ef,ba,19,ec,5a,0d,df,c8,46,b3,ed,f6,0c,b1,66,12,6d,75,e1,7e,45,7f,67,07,f4,ee,1a,a0,5e,b5,b7,83,a6,d0,57,01,9c,be,11,91,7a,cd,13,92,8a,9c,34,0d,32,26,be,9a,9c,82,6f,80,84,da,01,cd,d8,74,9d,95,b2,25,8a,aa,60,7d,83,68,ba,d5,c9,23,b6,30,e4,6b,43,01,6b,41,64,d1,a1,69,53,65,8c,19,62,db,81,fe,27,2e,d3,b8,5c,a9,f6,50,95,c6,8b,61,4e,96,d2,14,a6,26,61,48,cc,5e,07,49,9a,14,89,12,18,1c,1b,12,7b,e8,59,16,62,25,29,a2,b6,5f,04,61,a8,f3,e0,f5,6c,8e,ee,c7,79,3a,8c,3b,05,54,db,47,c1,72,7c,ce,82,c1,af,94,fd,8d,67,b7,9d,c8,62,32,5e,3c,7e,61,36,77,6d,53,8b,74,f8,92,cf,ab,e3,3c,f6,56,79,81,14,a4,72,13,c8,b8,68,0d,d6,4f,0b,4e,f8,dd,ea,c9,16,be,7d,19,25,20,37,c4,b8,72,e5,46,7c,c8,7e,32,aa,5c,17,54,24,a7,00,2a,41,a4,96,c4,89,0b,fa,26,44,e2,a3,b0,48,2e,bc,bb,d6,99,11,aa,30,bc,78,9a,1f,76,71,23,e7,69,ba,c7,b0,0b,2d,fc,20,6d,b9,1d,b2,71,14,51,2f,f9,f9,d8,d7,43,58,aa,f7,03,00,e6,5f,99,4e,1f,6b,85,16,08,87,ca,e5,d3,ce,ab,ae,80,30,79,30,40,c0,68,06,ff,82,37,9b,b5,ed,53,a8,fe,36,48,10,ee,2d,d3,63,99,04,96,85,35,07,0e,58,ec,fa,b9,e0,df,0e,9c,8f,fc,ca,12,5b,99,42,dc,09,0a,97,37,c9,69,1e,7f,10,05,b3,47,b5,52,c7,bd,f6,ca,45,f6,8d,8b,3d,54,a3,de,a9,49,aa,b3,45,1b,7e,55,96,ef,48,3b,03,7e,06,62,46,45,df,c0,fe,ea,ea,b9,c3,d3,cb,89,0a,19,5a,9f,e6,e4,ef,42,52,cb,d6,a7,b3,b6,b7,d7,31,9c,66,6a,a9,58,46,ce,7c,50,e6"
- "01,04,04,00,d4,27,c9,4d,2e,03,97,86,9a,85,db,05,5c,76,5f,d0,99,0f,09,32,f1,ef,ac,c8,be,c9,05,95,0d,24,39,19,ad,be,36,51,a9,da,ef,d4,2e,76,9a,50,97,7a,40,62,5f,71,94,d4,d2,b9,b9,7d,cd,ac,d0,b5,17,15,de,1b,bc,86,f8,ed,f1,56,e2,fd,f0,fe,6a,7b,99,b5,64,3c,6b,29,05,ca,34,86,74,42,42,2c,5f,e1,9e,0f,99,9c,7d,b7,34,d5,8f,a5,df,01,d8,e8,bb,fa,f7,9c,ca,82,1e,d1,17,70,b3,2e,dc,ff,03,ba,ed,b5,6c,97,6b,61,e6,97,eb,34,3a,b7,9a,32,fe,fe,96,ed,84,75,33,15,58,5b,5d,1e,7b,c7,cb,87,cf,f9,59,c8,65,7b,d4,68,4f,2a,27,ca,e7,9f,9e,54,f8,49,8f,be,51,75,05,78,f3,ae,ac,ce,1e,e3,17,14,d7,68,ea,2f,54,ae,4a,aa,d3,5d,61,63,3d,e8,3d,ff,62,45,fa,e8,10,65,22,4e,f1,6a,98,f3,a7,45,04,4a,7d,4b,67,ff,ea,d7,f4,e0,b3,28,e6,b4,9c,87,79,24,28,f0,54,bf,98,7c,39,4e,44,6f,df,ae,4b,55,e3,af,c1,54,cc,86,a9,e2,77,0f,e4,6f,40,cd,fd,bb,d0,b1,99,82,5d,b0,db,38,13,c0,91,f6,de,d0,b1,4d,da,d2,b9,b1,db,36,78,31,00,a6,42,24,c7,d4,c3,af,8e,f5,69,63,57,4a,bd,5d,b4,16,93,53,6a,32,57,93,aa,c7,fc,d2,2c,35,68,74,af,39,c9,17,11,03,a1,dd,21,22,c7,a7,72,b5,c6,b4,9d,b9,bb,30,49,eb,eb,fc,01,7e,4b,a3,c3,7c,83,8c,cd,2d,77,55,a2,3b,92,24,ef,33,d5,ca,d7,54,f5,c6,46,ba,9a,97,14,cd,b9,c1,25,61,64,1c,ca,49,8c,76,1d,ca,bf,96,a0,1a,b5,73,ea,e2,f9,df,5e,76,f0,70,5b,91,f3,d3,84,20,22,6d,50,05,64,6c,92,32,71,72,9b,55,2e,0f,b5,f7,14,d3,a1,b0,0a,36,b1,cb,f7,38,df,82,5b,1a,63,b2,d5,17,de,20,d3,76,a3,e2,de,de,0b,bd,e8,43,62,6a,0b,f1,1f,e8,76,c6,a1,ab,cd,20,08,2c,86,30,75,3e,34,ae,66,0c,87,a0,1c,7a,3b,4b,63,1c,5c,96,56,0a,e3,7f,4e,c5,60,33,85,a6,58,f1,91,5c,24,e0,e2,8f,17,0d,51,6c,4f,e9,9f,4b,23,b0,4a,f6,3c,a4,ac,d0,73,ed,0c,e6,5c,d1,94,08,1a,1b,89,dc,b0,5b,3d,d5,72,24,90,6c,c2,ca,9d,41,be,a1,85,c7,ec,e5,42,1b,d1,9b,b3,73,7b,30,67,ec,90,93,6e,06,6f,07,7b,86,30,4e,4e,90,28,2a,50,75,41,24,4f,3f,1b,52,85,24,0b,54,31,c7,37,95,8d,a4,72,b7,0d,4b,0e,6c,bf,c9,5f,e1,98,a0,e4,dd,ca,22,b6,d0,7e,2f,3b,ca,ed,3f,ea,0e,26,f2,d8,48,1a,5c,62,4d,d3,34,25,59,60,3b,97,b0,96,b8,5e,35,0a,2e,1c,e4,a3,52,64,70,57,1f,2b,2e,70,ba,09,98,63,92,9c,d2,7f,9d,e3,30,5b,90,f5,ba,94,44,ee,7e,5c,18,f3,28,6f,93,38,51,da,04,c4,d0,1a,ba,c2,9b,62,4c,86,58,02,18,40,ac,01,84,51,4a,12,75,c4,96,70,1c,ca,9d,ca,8b,58,65,63,c0,06,88,b8,4a,9b,47,eb,46,3f,6d,42,8a,5d,30,7c,82,cd,b0,85,b9,68,7b,a0,82,78,15,dd,9a,98,ee,c8,01,81,1d,4e,90,e1,63,89,cc,87,66,71,44,a9,09,ac,91,90,ee,d6,fe,85,32,be,7c,65,34,75,50,99,e0,5d,bf,0d,2c,1f,67,78,21,5d,9d,b2,43,f3,5f,7b,b2,eb,df,c0,d2,00,53,26,ce,e9,56,a3,6b,97,ac,be,1d,69,2e,e0,62,13,2e,ac,df,6a,2c,aa,c2,80,2c,19,bb,20,e7,9e,55,1e,d5,e3,3f,fb,6f,d7,92,33,75,b9,d5,57,d2,7d,48,a8,8e,7b,cf,fe,ed,8d,4c,96,d6,c2,e5,9a,93,b2,38,d5,7f,3c,f5,ca,56,a6,2f,c6,ef,a4,e8,aa,52,78,d2,20,40,3c,43,17,14,30,94,f3,22,fe,81,4f,03,eb,36,1e,e4,ea,4a,39,aa,44,70,ab,66,ce,3d,6a,f6,6a,ea,dc,e9,de,52,8b,e0,d3,cc,79,19,c3,8d,f4,d2,80,d2,18,05,7c,48,05,f8,64,94,b0,b0,06,11,95,c4,e3,70,02,24,6e,e7,38,40,99,d4,89,7d,9a,cf,71,a1,6c,05,03,1f,4a,7b,47,23,77,a3,01,93,10,77,f8,53,08,52,8d,b6,de,e7,a5,89,25,9f,a8,7f,97,5f,f2,a0,fd,a5,bb,6b,0e,ca,44,85,97,3c,88,6f,f1,71,38,ae,30,26,1c,e4,b3,bd,1c,c0,f5,6e,08,0c,6b,bb,70,26,1a,e0,9f,f8,73,fb,54,e2,fe,ed,e8,56"
+ "01,00,01,00,e8,aa,94,5f,fb,d5,72,f6,1b,72,12,ea,6e,2c,77,9e,d6,e2,87,e3,b9,95,0d,99,76,d1,df,84,7a,4e,3a,d4,63,26,a6,02,51,28,74,2c,88,8c,75,ea,43,30,1a,4f,7a,a8,97,04,fc,01,9a,a8,ad,a0,04,56,03,ed,8d,e1,43,dc,57,73,73,2c,6c,4a,0b,64,8d,f9,9e,f1,a1,dd,6d,05,ce,48,d7,9d,b8,75,e6,f2,be,f5,cc,98,0f,37,05,06,5e,d9,1d,7a,69,5c,9c,79,36,86,2a,11,08,e5,b5,f3,f3,bd,14,83,c9,e5,04,ad,44,e6,ad,f7,4c,08,41,fe,b9,64,40,ae,ed,e6,96,e8,06,30,51,63,6f,99,09,38,a3,86,9f,70,65,05,e7,88,b7,80,bb,ce,84,7f,35,7e,51,c3,b9,19,a3,37,6d,c4,4d,ec,ea,11,f6,13,06,5f,e7,57,46,1c,da,72,f5,6f,bc,2c,2d,9c,fe,33,d4,f7,e2,ce,31,29,c4,d1,bf,f0,12,47,cc,cb,5f,d9,71,06,4b,ee,bd,f9,e7,d1,ac,8d,e5,1c,f1,4c,fa,3d,3a,72,57,7b,57,06,3b,94,00,16,24,f1,01,53,e0,34,89,2d,f8,b1,b5,6d,bc,f1,5a,ba,01,13,c3,9f,b7,d4"
+ "01,01,01,80,0b,55,f0,0b,cd,63,89,4f,97,ae,12,8f,ee,b9,58,54,27,ea,98,d5,86,d2,ce,f4,55,d9,89,e2,5b,2f,34,24,af,53,75,df,50,cd,de,6a,4f,8c,ed,fd,10,5a,95,b9,2f,fa,8b,b8,d3,fb,3d,e6,f0,6b,2b,55,e7,32,88,67,d2,c9,c2,ed,42,e4,85,51,65,7c,ee,ee,21,9d,6d,b0,28,58,17,94,30,f1,a0,20,76,ab,63,04,58,16,48,20,44,d2,7d,d8,b4,15,b3,6f,4a,b3,81,ae,f8,c5,09,c7,f2,35,1b,35,4f,1a,cb,bc,84,2b,ce,56,22,a6,f6,9f,ca,40,54,2a,65,8b,75,f6,36,9a,ab,40,ce,a7,0f,6d,d3,ef,a5,d0,6d,77,c2,98,84,dc,c3,76,73,93,05,c4,c7,27,6a,89,67,29,1f,3d,ff,e7,1e,16,3a,2c,1d,06,76,62,ef,9f,b5,dc,b3,82,79,26,07,fc,4d,48,a6,6b,f7,38,f2,07,fd,a5,75,21,ca,69,03,7a,48,1f,df,c4,c6,2a,38,d4,12,5a,e4,ba,d6,e2,bf,d9,2d,70,10,66,44,58,a2,13,05,76,a7,14,68,58,e7,ea,ec,c2,f0,2d,df,2c,79,7f,b9,70,73,2c,f3,fb,dc,72,4d,21,b8,39,d4,87,88,4e,98,e5,3f,7b,20,97,04,3d,ad,70,d1,6b,0d,30,53,d7,4c,6e,a1,01,35,5e,c9,27,0d,53,61,c4,5a,9c,87,aa,ec,01,45,aa,d1,52,b0,d4,bc,4a,56,16,8f,e1,00,ca,a1,43,14,1a,ff,1b,6d,b7,5f,b8,9d,db,d4,8d,02,2e,1a,c0,d0,58,3b,17,a9,4a,ef,c4,27,fb,be,7c,b9,78,03,39,4e,b2,03,ea,87,59,60,d7,7c,2c,3b,19,41,ae,91,29,34,32,82,cf,b7,56,9a,c8,0b,84,cf,72,40,ff,fc,fc,aa,5f,ac,d3,ce,fc,e6,c4,b3,68"
+ "01,02,02,00,8f,b3,b5,3f,0b,de,23,e1,5c,4a,77,ed,b2,4d,1c,4b,76,91,12,c4,fe,5b,15,23,13,a4,f3,b6,5b,23,8d,88,d5,77,0e,e4,1d,60,0b,58,1b,af,67,ee,31,fb,b6,ce,f5,1b,36,10,c1,f2,f0,83,e6,b9,23,13,1e,b2,9f,ae,e0,9e,42,64,4c,bd,1e,87,18,bd,a6,9b,ae,59,20,e8,9f,52,78,e6,f7,35,56,b6,3a,e6,82,8e,87,b5,c8,23,07,e1,f5,6e,95,8d,c6,83,83,88,b8,41,d8,63,58,33,fe,39,20,d4,9c,37,0e,68,5b,e9,1f,48,0e,85,d6,36,70,a2,06,a8,dc,5c,62,75,4d,bd,bd,3a,6f,03,b0,25,33,11,20,67,0f,76,23,d9,ab,5b,e9,c4,bc,ff,a8,1f,49,c0,e1,42,c7,3c,cb,25,7a,d3,c8,39,e2,f7,b1,22,ca,14,b2,3a,2e,7a,a0,80,a9,e0,dc,96,53,ca,d7,48,be,6d,bc,68,a9,38,b0,be,b0,1b,8c,85,9e,51,42,69,24,f0,28,c8,7c,f1,bc,e3,0f,1f,9c,f3,8b,3a,96,3b,52,ed,36,b1,88,10,9f,c8,02,89,2b,5a,eb,d5,fc,af,03,46,fa,cf,8a,ba,80,ae,8f,89,f7,fd,0f,77,f3,4e,24,35,32,35,e9,c4,82,97,25,51,ab,2b,01,dd,ca,53,5f,7c,3b,25,89,d2,54,69,30,48,6b,4a,03,25,dd,be,c6,ea,33,c2,86,7f,e9,d0,9b,31,fd,70,37,54,c2,8c,dc,96,6d,5a,2e,b6,c2,6d,85,ee,f2,32,b8,95,b0,66,40,44,1e,a2,bf,25,ed,1f,41,9d,37,5b,56,e0,1d,95,1d,ec,d8,f6,24,68,d4,06,17,16,7e,8c,31,7e,40,c2,88,29,d1,f9,8e,eb,4d,4e,5a,9d,65,c8,a2,43,83,4c,04,8b,93,eb,40,23,5f,80,8f,2f,29,ff,c3,13,47,ad,b0,c1,5a,28,08,dc,1e,83,e7,ed,26,4e,30,2c,6e,5a,0e,f1,db,68,ab,89,bb,61,63,6d,55,97,b2,94,16,cd,6f,d5,60,92,e8,71,ef,a3,b2,ae,0c,40,26,d5,35,1d,c8,ed,12,94,86,8c,1c,97,bd,cc,1d,53,0f,4c,99,21,fc,34,5a,79,8c,ca,ea,ae,99,bc,8b,a9,52,fe,f9,63,75,6f,7d,51,79,e6,ca,92,6c,b8,7e,7b,20,a9,c0,2a,15,1d,bb,c0,c2,b1,52,42,7f,dd,1c,8d,e5,a7,7f,26,f5,29,cb,4b,91,5b,80,c2,3a,94,e8,c5,2f,6d,7a,0d"
+ "01,03,03,00,13,37,f3,03,0c,1f,cf,3d,2f,9c,e1,aa,a2,d5,90,ab,4a,e0,e6,b3,87,d2,a2,16,1e,26,7b,21,17,7d,82,39,ce,d4,50,94,17,b4,d0,5a,37,6e,ba,82,2b,fa,0f,7c,b6,e2,1d,01,7d,40,ca,a9,c3,fb,0d,4e,ef,ce,8a,b8,f8,61,54,14,02,6c,50,f9,dd,86,a8,2c,a8,5b,06,ff,60,4d,19,a9,ff,77,77,ba,6d,96,72,b4,d2,46,71,e2,2b,45,d8,5e,1f,84,64,07,ef,56,f9,64,1b,11,ff,ad,05,19,f9,2b,5d,af,50,91,24,c1,ca,ff,c8,78,92,32,13,fc,90,f3,12,24,62,c6,97,7f,5d,73,90,70,72,43,e2,bc,90,3f,3b,a4,85,3e,53,2e,43,a2,4f,c6,c6,38,88,0b,07,52,3d,98,b7,e3,4d,24,86,02,86,36,b8,2c,fa,49,28,e2,b9,a8,8c,75,16,32,8b,c8,e4,90,47,ba,d8,da,a6,ae,2e,af,4c,1e,ae,a1,99,70,c9,cf,1d,a8,e1,5c,fc,1f,61,25,f8,e5,5c,d2,27,8c,32,a6,28,51,42,91,91,08,e5,8f,48,d0,33,ad,7f,45,1a,5f,ee,30,f7,29,2c,23,88,b0,5c,6e,76,2d,56,7c,bc,63,73,a0,d6,13,71,58,82,91,79,4c,9b,aa,22,05,61,48,b5,51,af,d0,0e,9c,7d,94,a7,f5,6a,b9,cb,57,97,55,ca,d1,cc,b8,f5,3e,f7,bc,93,05,1a,af,c4,57,54,4c,a3,83,80,53,90,ac,16,5b,ec,6d,5f,82,83,e5,ca,fa,12,c2,8d,2b,a6,36,a8,b2,38,50,fc,f0,a5,fb,52,2d,eb,68,95,4d,f7,94,6d,75,f7,41,1f,46,db,86,71,d0,37,16,91,34,df,2f,89,78,4c,88,27,7d,2a,46,39,f0,8b,ec,75,e1,f3,5c,3f,98,b4,03,f3,c4,ea,70,af,67,0d,ee,97,d0,31,cd,3e,c1,c9,6e,4c,97,a0,64,19,44,9f,ad,16,4c,be,10,b6,e4,cc,9c,9d,2d,4f,79,02,a4,ea,09,2c,1d,2e,fd,c2,12,1a,de,ba,c9,a1,98,77,41,1c,14,56,ca,d9,19,02,46,87,7c,8d,a1,c4,3f,90,99,ca,2e,99,18,40,7e,ae,93,91,c3,4a,5f,68,f8,62,f9,34,83,ae,2e,64,c6,cf,a7,6d,80,eb,28,8b,ac,90,3b,1a,a2,a2,13,26,f3,91,40,bb,3a,44,2b,d2,0c,58,74,fc,9d,60,a9,d2,a6,34,c4,21,65,f6,00,c2,73,e1,e4,29,9d,c8,a9,88,33,38,c7,dd,83,23,d8,4b,66,d5,7c,78,7f,c3,62,23,34,12,1a,ee,a1,62,84,fe,62,3a,09,6b,72,69,58,d8,1b,fd,b0,89,e9,e1,da,fa,35,db,83,5f,93,a5,62,ad,c7,f7,e2,a7,6d,db,00,9e,7e,ea,9f,53,ef,d4,bd,32,e7,9e,2a,d1,90,a4,37,1b,b2,cd,cc,21,28,4a,96,3f,35,54,78,88,90,3b,e5,22,94,e4,2a,9f,d2,ef,7f,75,3d,b2,83,34,fe,66,45,4c,c2,ca,06,f3,fd,46,29,6b,40,32,66,a2,64,30,16,ee,04,cb,3d,28,bd,bf,a7,f1,84,9d,23,bf,61,e1,59,c7,36,b5,60,b5,39,39,eb,fd,ff,06,9e,52,99,69,97,d4,8b,bb,8f,84,90,fd,e2,0d,fd,7b,85,49,cc,81,3c,1d,c1,37,1e,5f,34,cd,52,4f,61,9a,85,c5,29,1d,b4,42,8c,c4,8d,94,43,cb,6a,e2,af,90,a6,ec,09,89,07,ae,62,9d,66,bd,fe,87,4d,76,0c,ce,e4,70,87,74,89,02,00,6c,54,4b,86,45,b5,f2,d6,fe,6e,f1,74,ae,c5,1f,67,f0,19,44,44,32,5d,d1,8a,a4,71,17,b0,9c,a4,5d,90,d4,29,b6,24"
+ "01,04,04,00,67,47,f0,4b,9c,5b,75,a3,4d,9b,1f,b2,b4,32,56,a4,dd,23,69,70,4c,c3,ee,f2,0f,82,51,bc,54,8c,0d,a3,21,bf,94,88,82,7c,69,e8,55,d3,1d,8d,80,be,71,4d,4c,48,f8,ce,1e,f8,72,ac,a5,4c,74,aa,8f,a7,e0,51,99,ad,51,35,14,e7,98,02,1b,9d,07,e5,d1,07,d0,15,d2,9b,33,81,62,b7,7e,52,d5,b1,37,ea,55,f7,80,74,4c,25,cb,61,e9,75,c0,c9,7b,4e,19,4d,d1,69,46,ca,01,c9,14,06,a8,17,e0,f4,e5,c4,5d,e9,f6,2a,d5,02,b8,8b,6e,4a,26,ec,8c,a4,c0,bd,17,a6,48,5c,46,4f,bf,6f,c9,f1,4a,27,fa,4c,d1,93,e7,22,8c,2b,32,55,0c,2b,c6,ea,73,19,7d,e8,b7,fc,64,0d,f0,f9,bf,0d,3a,8b,3c,a9,30,a1,03,1b,e3,1b,d6,94,a8,39,4b,23,ce,ea,7b,2a,3a,af,4f,6c,15,cd,13,ca,67,84,05,9c,a7,d0,f6,7f,97,0b,e0,b3,bb,fd,ca,10,f6,35,57,5f,9b,e7,c2,5f,5c,16,f8,31,0c,23,34,7b,0b,f0,d1,b0,e4,e6,6a,45,db,32,be,fa,fc,92,df,01,3d,ca,bc,c8,d2,c9,57,8e,6b,eb,7b,f4,8c,23,b4,cf,16,73,a3,20,50,e7,f6,98,7a,19,f8,be,e4,72,3f,45,e7,e9,df,69,10,dd,72,24,94,d4,ce,c9,70,13,49,9d,af,bd,61,7a,a8,ee,82,9f,ce,2e,0f,4f,cf,c0,26,9b,98,a6,9e,a7,06,ed,b6,d7,f0,db,c6,c4,f0,db,55,94,87,92,af,11,dc,07,47,eb,e4,b5,3b,c8,5a,24,31,f2,d7,06,c5,a5,19,80,75,88,5e,45,f1,0f,e0,94,ea,9f,1b,65,4d,1a,ec,18,db,b0,c8,05,ca,25,46,6a,85,8a,49,d1,e7,06,9d,84,1f,ca,7e,48,02,34,b2,0d,4c,5e,61,d5,5d,b5,51,8c,19,18,2c,87,9e,69,b2,81,c1,4c,62,09,25,1f,e9,8d,0b,23,81,d3,36,a1,c5,41,f8,db,c6,8c,cf,1c,55,54,41,d0,5b,92,a8,3f,a5,ae,dd,69,98,c4,f3,8f,7b,26,70,43,f6,62,e5,89,4f,e4,cb,c7,de,63,13,f7,a9,6b,51,e4,41,dc,fe,9e,50,32,32,32,04,bd,d2,d7,8b,4d,29,9a,78,91,28,6e,56,30,5e,89,ba,1e,62,c5,8a,27,05,bc,ad,1e,2c,d1,cf,d4,bc,c0,69,a7,2d,3f,07,3c,77,f9,69,ca,16,1f,a7,14,4e,c8,0b,fa,e7,3a,9e,38,a6,c0,aa,b6,1e,66,30,a8,18,51,8f,76,27,fa,5c,c2,07,e8,e6,f0,98,6e,bb,b0,d7,53,d3,db,d4,2e,d6,1f,83,49,23,a3,1f,c4,0c,12,8c,67,ed,1c,01,a6,40,a8,ad,68,9a,6e,af,ee,ad,5f,d0,78,5f,15,5d,09,8e,e6,80,a4,f0,f3,c8,55,27,f1,44,6f,58,07,16,ed,87,1f,8e,26,d6,3c,a0,17,2e,79,d0,72,12,dc,81,d5,ae,a0,ad,86,31,8e,6d,45,d7,d1,3a,94,e7,e5,7b,3d,b7,5f,50,3c,af,e8,ea,2b,f0,e2,3c,eb,14,b6,16,31,0c,70,3b,92,e8,a2,f9,84,d1,aa,ba,73,80,89,ec,54,3c,23,a9,d5,87,87,b9,27,9a,87,bb,c5,06,96,9a,37,2b,d8,d9,af,32,e8,fd,8d,b0,49,c1,cb,81,bc,0d,0b,fe,dc,40,fb,b1,50,41,ed,71,3b,87,cc,95,6d,df,80,85,92,c6,66,cb,4c,75,16,46,f1,b1,08,ed,be,91,21,c5,b0,e8,83,58,96,24,16,28,15,e2,fe,94,e4,42,99,84,77,43,7b,1f,ac,a7,55,ff,33,09,6a,6e,b4,66,21,d6,c0,6f,88,35,94,6f,ab,1d,c6,74,7b,4c,30,a9,e0,70,36,7f,94,aa,c0,c7,98,71,ec,10,c9,96,86,32,08,83,37,16,60,cf,19,f0,19,11,4c,f4,65,87,d8,5f,16,ad,c6,80,89,1d,37,d6,26,91,bf,ef,de,47,62,c5,05,b8,b9,c1,a8,6c,19,ec,80,af,ec,dd,d8,ee,d3,c4,b5,13,77,88,20,fe,68,64,b3,bd,f1,90,67,c4,d7,29,e5,b9,4e,7c,29,34,a8,14,4f,09,60,9b,5f,87,c5,23,d2,49,da,e6,da,2a,cf,c4,c6,3d,c8,9a,5f,37,ca,fb,08,d0,28,1e,88,f0,30,37,74,b0,c3,8f,3f,2c,b3,bc,39,3a,96,27,d6,c0,c7,91,bb,d1,fc,f0,28,be,82,3b,ac,2b,28,72,9d,31,2d,42,5d,d8,36,d8,a8,c9,ca,58,b9,f9,4a,14,b8,38,52,c9,ea,aa,8d,05,52,d5,4b,22,87,8f,09,d3,0d,c9,16,f1,d3,26,61,e5,5c,bd,84,64,88,7d,32,8d,ea,6d,8a,00,dc,54,a5,75,50,a4,3b,99,33,b1,e2,ef,8d,e5,f6,78,d8,dd,71,1a,64,02,6f,ac,37,a5,2a,fc,5d,c8,af,f9,87,3b,77,f3,1c,2c,cc,db,a6"
  "105" "106" "107" "108" "109" "10a" "10b" "10c" "10d" "10e" "10f" )
  

--- a/testssl.sh
+++ b/testssl.sh
@@ -11881,7 +11881,7 @@ socksend_tls_clienthello() {
 
      if [[ 0x$tls_low_byte -gt 0x03 ]]; then
           # TLSv1.3 calls for sending a random 32-byte session id in middlebox compatibility mode.
-          session_id="20,44,b8,92,56,af,74,52,9e,d8,cf,52,14,c8,af,d8,34,0a,e7,7f,eb,86,01,84,50,5d,e4,a1,6a,09,3b,bf,6e"
+          session_id="20,44,b8,92,56,af,74,52,9e,d8,cf,52,14,c8,af,d8,34,0b,e7,7f,eb,86,01,84,50,5d,e4,a1,6a,09,3b,bf,6e"
           len_session_id=32
      else
           session_id="00"
@@ -11934,7 +11934,7 @@ socksend_tls_clienthello() {
      ,54, 51, 1e, 7a          # Unix time since  see www.moserware.com/2009/06/first-few-milliseconds-of-https.html
      ,de, ad, be, ef          # Random 28 bytes
      ,31, 33, 07, 00, 00, 00, 00, 00
-     ,cf, bd, 39, 04, cc, 16, 0a, 85
+     ,cf, bd, 39, 04, cc, 16, 0b, 85
      ,03, 90, 9f, 77, 04, 33, d4, de
      ,$session_id
      ,$len_ciph_suites_word   # Cipher suites length
@@ -12530,7 +12530,7 @@ run_ccs_injection(){
      # Random (32 byte)
      x53, x43, x5b, x90, x9d, x9b, x72, x0b,
      xbc, x0c, xbc, x2b, x92, xa8, x48, x97,
-     xcf, xbd, x39, x04, xcc, x16, x0a, x85,
+     xcf, xbd, x39, x04, xcc, x16, x0b, x85,
      x03, x90, x9f, x77, x04, x33, xd4, xde,
      x00,                # session ID length
      x00, x68,           # cipher suites length
@@ -12771,7 +12771,7 @@ run_ticketbleed() {
      # Random (32 byte) Unix time etc, see www.moserware.com/2009/06/first-few-milliseconds-of-https.html
      xee, xee, x5b, x90, x9d, x9b, x72, x0b,
      xbc, x0c, xbc, x2b, x92, xa8, x48, x97,
-     xcf, xbd, x39, x04, xcc, x16, x0a, x85,
+     xcf, xbd, x39, x04, xcc, x16, x0b, x85,
      x03, x90, x9f, x77, x04, x33, xff, xff,
      $xlen_sid,          # Session ID length
      $sid


### PR DESCRIPTION
As noted in #1130, the current implementation of `socksend_tls_clienthello()` results in packets being fragmented wherever a '0a' character appears in the message. This cannot be avoided, but there are a few places where a '0a' character appears in which the character could easily be replaced:

* In the session_id for a TLSv1.3 ClientHello.
* In the 32-byte client random value
* In any public key sent in the key_share extension

This PR removes those uses of the '0a' character. While this does not do much to address the problem, it does result in a slight reduction in the amount of fragmentation of messages.