### PR TITLE
Remove typo

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -18080,7 +18080,7 @@ lets_roll() {
      else                                              # Just 1x ip4v to check, applies also if CMDLINE_IP was supplied
           NODEIP="$IPADDRs"
           lets_roll "${STARTTLS_PROTOCOL}"
-P          RET=$?
+          RET=$?
      fi
 
 exit $RET


### PR DESCRIPTION
This PR removes a typo that was introduced in https://github.com/drwetter/testssl.sh/commit/b49399e7c731a6b5906d44b34cc41204ff34734a.