### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM alpine:latest
 
-RUN apk update && apk upgrade
-RUN apk add bash procps drill git coreutils
-RUN apk add --no-cache curl
+WORKDIR /home/testssl/
+
+RUN apk add --no-cache \ 
+    bash \
+    procps \
+    drill \
+    git \
+    coreutils \ 
+    curl
 
 RUN addgroup testssl
-RUN adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl
+RUN adduser -G testssl -g "testssl user" -s /bin/bash -D testssl
 
-RUN ln -s /home/testssl/testssl.sh /usr/local/bin/
+RUN ln -s testssl.sh /usr/local/bin/
 
 USER testssl
-WORKDIR /home/testssl/
 
 RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git .
 


### PR DESCRIPTION
Adding **caching busting** technique, also adding `--no-cache` option which avoids using `apk update` instruction explicitly

References:

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
- https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache