### PR TITLE
Don't run TLSv1.1 tests if server doesn't support TLSv1.1

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8153,7 +8153,8 @@ run_server_defaults() {
           # try again, but only with TLSv1.1 and without SNI.
           if [[ $n -ge 10 ]]; then
                ciphers_to_test[n]=""
-               [[ ${success[n-9]} -eq 0 ]] && ciphers_to_test[n]="${ciphers_to_test[n-9]}" && certificate_type[n]="${certificate_type[n-9]}"
+               [[ ${success[n-9]} -eq 0 ]] && [[ $(has_server_protocol "tls1_1") -ne 1 ]] && \
+                    ciphers_to_test[n]="${ciphers_to_test[n-9]}" && certificate_type[n]="${certificate_type[n-9]}"
           fi
 
           if [[ -n "${ciphers_to_test[n]}" ]] && \


### PR DESCRIPTION
As a result of #276, `run_server_defaults()` makes several attempts to find certificates that a server offers if the ClientHello is for TLSv1.2 and no SNI is offered. However, these tests are unnecessary if it is already known that the server does not support TLSv1.1.

This PR modifies `run_server_defaults()` so that the the TLSv1.1-only tests are skipped if the server is known to not support TLSv1.1.