### PR TITLE
Fix run_server_preference() for SSLv2 only server

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5941,7 +5941,7 @@ run_server_preference() {
           cp "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt" $TMPFILE
           tls13_cipher2=$(get_cipher $TMPFILE)
           debugme tm_out "TLS 1.3: --> $tls13_cipher2\n"
-     else
+     elif [[ "$OPTIMAL_PROTO" != -ssl2 ]]; then
           [[ $DEBUG -ge 4 ]] && echo -e "\n Forward: ${list_fwd}\n ${tls13_list_fwd}"
           $OPENSSL s_client $(s_client_options "$STARTTLS -cipher $list_fwd -ciphersuites $tls13_list_fwd $BUGS -connect $NODEIP:$PORT $PROXY $addcmd") </dev/null 2>$ERRFILE >$TMPFILE
           if ! sclient_connect_successful $? $TMPFILE && [[ -z "$STARTTLS_PROTOCOL" ]]; then
@@ -5995,7 +5995,7 @@ run_server_preference() {
           fileout "$jsonID" "OK" "server -- TLS 1.3 client determined"
           cipher1="$tls13_cipher1"
           cipher2="$tls13_cipher2"
-     elif [[ "$cipher1" != $cipher2 ]]; then
+     elif [[ "$OPTIMAL_PROTO" == -ssl2 ]] || [[ "$cipher1" != $cipher2 ]]; then
           # server used the different ends (ciphers) from the client hello
           pr_svrty_high "nope (NOT ok)"
           limitedsense=" (limited sense as client will pick)"


### PR DESCRIPTION
When `run_server_preference()` is run on a server that only supports SSLv2 it incorrectly reports that the server has a cipher order. The reason for this is that `$list_fwd` and `$list_reverse` only include one SSLv2 cipher.

In SSLv2 the server sends a list of all ciphers it supports in common with the client and the client chooses which cipher to use. As a result, the server cannot enforce a cipher order for SSLv2.

So, this PR fixes the problem in `run_server_preference()` by skipping the test for whether the server enforces a cipher order if `$OPTIMAL_PROTO` is -ssl2 and simply declares that the server does not enforce a cipher order.

Note that this PR is somewhat dependent on #1194, as #1194 needs to be applied in order for `$OPTIMAL_PROTO` to be set to -ssl2 when testing an SSLv2-only server.