### PR TITLE
determine_optimal_proto_sockets_helper() speedup and bug fix

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17382,19 +17382,18 @@ determine_optimal_proto_sockets_helper() {
      local proto=""
      local optimal_proto=""
      local starttls="$1"
+     local -i ret
 
      for proto in 03 01 04 00 02 22; do
           case $proto in
                03) tls_sockets "$proto" "$TLS12_CIPHER"
-                    if [[ $? -eq 0 ]]; then
-                         add_tls_offered tls1_2 yes; optimal_proto="-tls1_2"
-                         all_failed=false
-                         break
-                    elif [[ $? -eq 2 ]]; then
-                         case $(get_protocol "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt") in
-                              *1.1)   add_tls_offered tls1_1 yes; optimal_proto="-tls1_1" ;;
-                              TLSv1)  add_tls_offered tls1 yes; optimal_proto="-tls1" ;;
-                              SSLv3)  add_tls_offered ssl3 yes; optimal_proto="-ssl3" ;;
+                    ret=$?
+                    if [[ $ret -eq 0 ]] || [[ $ret -eq 2 ]]; then
+                         case $DETECTED_TLS_VERSION in
+                              0303)  add_tls_offered tls1_2 yes; optimal_proto="-tls1_2" ;;
+                              0302)  add_tls_offered tls1_1 yes; optimal_proto="-tls1_1" ;;
+                              0301)  add_tls_offered tls1 yes; optimal_proto="-tls1" ;;
+                              0300)  add_tls_offered ssl3 yes; optimal_proto="-ssl3" ;;
                          esac
                          all_failed=false
                          break
@@ -17406,19 +17405,12 @@ determine_optimal_proto_sockets_helper() {
                          break
                     fi ;;
                01|00|02) tls_sockets "$proto" "$TLS_CIPHER" "" "" "true"
-                    if [[ $? -eq 0 ]]; then
-                         case $proto in
-                              01)  add_tls_offered tls1 yes; optimal_proto="-tls1" ;;
-                              00)  add_tls_offered ssl3 yes; optimal_proto="-ssl3" ;;
-                              02)  add_tls_offered tls1_1 yes; optimal_proto="-tls1_1" ;;
-                         esac
-                         all_failed=false
-                         break
-                    elif [[ $? -eq 2 ]]; then
-                         case $(get_protocol "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt") in
-                              *1.1)   add_tls_offered tls1_1 yes; optimal_proto="-tls1_1" ;;
-                              TLSv1)  add_tls_offered tls1 yes; optimal_proto="-tls1" ;;
-                              SSLv3)  add_tls_offered ssl3 yes; optimal_proto="-ssl3" ;;
+                    ret=$?
+                    if [[ $ret -eq 0 ]] || [[ $ret -eq 2 ]]; then
+                         case $DETECTED_TLS_VERSION in
+                              0302)  add_tls_offered tls1_1 yes; optimal_proto="-tls1_1" ;;
+                              0301)  add_tls_offered tls1 yes; optimal_proto="-tls1" ;;
+                              0300)  add_tls_offered ssl3 yes; optimal_proto="-ssl3" ;;
                          esac
                          all_failed=false
                          break


### PR DESCRIPTION
There is currently a bug in `determine_optimal_proto_sockets_helper()`. In two places there is code of the form:
```
   tls_sockets ...
   if [[ $? -eq 0 ]]; then
        ...
   elif [[ $? -eq 2 ]]; then
        ...
   fi
```
This code does not work as intended since the second check (`elif [[ $? -eq 2 ]]`) is actually comparing the results of the first check to 2 rather than the results of the call to `tls_sockets()`.

This PR fixes that problem and also speeds up the code. Since `tls_sockets()` sets `$DETECTED_TLS_VERSION` to the protocol version that was negotiated, there is no need to scan `$TEMPDIR/$NODEIP.parse_tls_serverhello.txt` for this information.