### PR TITLE
Deprecate Java 9, its EOL since March 2018

### DIFF
--- a/etc/client-simulation.txt
+++ b/etc/client-simulation.txt
@@ -2934,3 +2934,4 @@
      curves+=("sect571r1:sect571k1:secp521r1:sect409k1:sect409r1:secp384r1:sect283k1:sect283r1:secp256k1:prime256v1:sect239k1:sect233k1:sect233r1:secp224k1:secp224r1:sect193r1:sect193r2:secp192k1:prime192v1:sect163k1:sect163r1:sect163r2:secp160k1:secp160r1:secp160r2")
      requiresSha2+=(false)
      current+=(false)
+

--- a/etc/client-simulation.txt
+++ b/etc/client-simulation.txt
@@ -2405,7 +2405,7 @@
      minEcdsaBits+=(-1)
      curves+=("prime256v1:secp384r1:secp521r1:sect283k1:sect283r1:sect409k1:sect409r1:sect571k1:sect571r1:secp256k1")
      requiresSha2+=(false)
-     current+=(true)
+     current+=(false)
 
      names+=("Java 11.0.2 (Ubuntu)")
      short+=("java1102")
@@ -2934,4 +2934,3 @@
      curves+=("sect571r1:sect571k1:secp521r1:sect409k1:sect409r1:secp384r1:sect283k1:sect283r1:secp256k1:prime256v1:sect239k1:sect233k1:sect233r1:secp224k1:secp224r1:sect193r1:sect193r2:secp192k1:prime192v1:sect163k1:sect163r1:sect163r2:secp160k1:secp160r1:secp160r2")
      requiresSha2+=(false)
      current+=(false)
-


### PR DESCRIPTION
No current distro (Ubuntu, Debian, Fedora) is still shipping it,
Oracle has EOLed it in March 2018 according to

https://www.oracle.com/technetwork/java/java-se-support-roadmap.html