### PR TITLE
SNI STARTTLS, minor polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * TLS Robustness check (GREASE)
 * Expect-CT Header Detection
 * `--phone-out` does certificate revocation checks via OCSP (LDAP+HTTP) and with CRL
+* `--phone-out` checks whether the private key has been compromised via https://pwnedkeys.com/
 * Fully OpenBSD and LibreSSL support
 * Missing SAN warning
 * Added support for private CAs
@@ -33,6 +34,7 @@
 * Better support for XMPP via STARTTLS & faster
 * Certificate check for to-name in stream of XMPP
 * Support for NNTP via STARTTLS
+* Support for SNI and STARTTLS
 * More robustness for any STARTTLS protocol (fall back to plaintext while in TLS)
 * Fixed TCP fragmentation
 * Added `--ids-friendly` switch


### PR DESCRIPTION
This PR addresses #316 and #1280: it implements server name indication
also for STARTTLS which has been supported by a number of server
implemantations, in the meantime.

Also it does a final polish to David's pwnedkeys PR #1274 a while back:
UI improvement and detection of network problems.

In addition to PR #1279 it introduces a env variable to devel
mode so that "CERT_COMPRESSION=true ./testssl.sh --devel <params> <target>"
can be used to explore certificate compression on a host.