### PR TITLE
Fix terminal codes / tput

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -666,7 +666,6 @@ set_color_functions() {
      type -p tput &>/dev/null || return 0      # Hey wait, do we actually have tput / ncurses ?
      tput cols &>/dev/null || return 0         # tput under BSDs and GNUs doesn't work either (TERM undefined?)
      tput sgr0 &>/dev/null || ncurses_tput=false
-     tput sgr 0 1 &>/dev/null || ncurses_tput=false    # OpenBSD succeed the previous one but fails here
      if [[ "$COLOR" -ge 2 ]]; then
           if $ncurses_tput; then
                red=$(tput setaf 1)


### PR DESCRIPTION
As noted in #1288 with some terminal settings under Linux there appeared some ~garbage on the screen.

This PR fixes that by partly reverting 695d02157a2c452598fedbc24ae69809a067592f . At least now and under an older OpenBSD like 6.2 this doesn't seem to be necessary (anymore).