### PR TITLE
Fixes for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: perl
 perl:
-   - "5.18"
-   - "5.22"
-   - "5.24"
    - "5.26"
 addons:
   apt:
     packages:
     - dnsutils
+    - jsonlint
 install:
-  - cpanm Test::More
-  - cpanm Data::Dumper
-  - cpanm JSON
-  - cpanm JSON::Validator
+  - cpanm --notest Test::More
+  - cpanm --notest Data::Dumper
+  - cpanm --notest JSON
+#  - cpanm JSON::Validator
 script:
   - prove -v

--- a/testssl.sh
+++ b/testssl.sh
@@ -17880,7 +17880,7 @@ determine_service() {
      local ua
      local protocol
 
-     # check if we can connect to $NODEIP:$PORT
+     # Check if we can connect to $NODEIP:$PORT. Attention: This ALWAYS uses sockets. Thus timeouts for --ssl-=native do not apply
      if ! fd_socket 5; then
           if [[ -n "$PROXY" ]]; then
                fatal "You're sure $PROXYNODE:$PROXYPORT allows tunneling here? Can't connect to \"$NODEIP:$PORT\"" $ERR_CONNECT


### PR DESCRIPTION
Travis updated the container images so that the perl
reference to 5.18 was outdated. We use now 5.26 which
works, however we should consider to be more flexible.

JSON::Validator didn't compile in the container. Thus
we switched to just use 'JSON'. That also supports JSON
pretty. For the future we should just test for valid JSON
in all unit test files as it is more effective.