### PR TITLE
Add IDN/punycode support for non-ASCII URIs (#1319, #1320, #1321)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19340,7 +19340,15 @@ parse_cmd_line() {
           fatal "URI missing" $ERR_CMDLINE
      else
      # left off here is the URI
-          URI="$1"
+          if [[ $1 = *[![:ascii:]]* ]]; then
+              if [[ "$(command -v idn)" == "" ]]; then
+                  fatal "URI contains non-ASCII, IDN not available."
+              else
+                  URI="$(echo $1 | idn)"
+              fi
+          else
+              URI="$1"
+          fi
           # parameter after URI supplied:
           [[ -n "$2" ]] && fatal "URI comes last" $ERR_CMDLINE
      fi

--- a/testssl.sh
+++ b/testssl.sh
@@ -19342,7 +19342,7 @@ parse_cmd_line() {
      # left off here is the URI
           if [[ $1 = *[![:ascii:]]* ]]; then
               if [[ "$(command -v idn)" == "" ]]; then
-                  fatal "URI contains non-ASCII, IDN not available."
+                  fatal "URI contains non-ASCII characters, and IDN not available."
               else
                   URI="$(echo $1 | idn)"
               fi


### PR DESCRIPTION
This should address the issues #1319 and #1320 *if* `idn` is available on the system used to test those cases, and my corresponding feature request in #1321 

This takes approach number 1 for #1321 and does several tests to determine how to handle the entered URI:

1. We test if there are non-ASCII characters in the provided URI.  If there are not any non-ASCII characters in the provided URI, then we accept the URI as entered and continue on, processing the URI as we would normally in the 3.0 branch.  Otherwise, we continue on, as we have a second test to run before we can handle the IDN and convert to punycode.

2. If the test revealed that there are non-ASCII characters in the URI, the next test we do is to see if the `idn` binary is available, using Bash's `command -v` call.

    1. If `idn` is available, then `URI` is set to the output of the command `echo $1 | idn`, which will return punycode.  In the case of #1319 and #1320, using their example of `♨️.com`this properly will detect the non-ASCII characters and convert to Punycode, and then properly handle the URI as `xn--j6h.com`.

    2. If `idn` is not available, then error with a Fatal call indicating that the URI contains non-ASCII characters and there is no IDN handler available to convert to Punycode.

This can be tested *directly* at my fork of this through https://github.com/teward/testssl.sh/tree/idn-support which contains the code in this PR.  Just check out the `idn-support` branch.  That branch was forked from the `3.0` branch here.