### PR TITLE
remove duplicate header name for other_header in file output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3046,7 +3046,7 @@ run_security_headers() {
                fi
                pr_litecyan "$header"
                outln " $HEADERVALUE"     # shouldn't be that long
-               fileout "$header" "INFO" "$header: $HEADERVALUE"
+               fileout "$header" "INFO" "$HEADERVALUE"
           fi
      done
      #TODO: I am not testing for the correctness or anything stupid yet, e.g. "X-Frame-Options: allowall" or Access-Control-Allow-Origin: *


### PR DESCRIPTION
The Finding of other_headers such as "Referrer-Policy" during file output are displayed as `$header: $HEADERVALUE` instead of only `$HEADERVALUE` as the good_headers. This leads to duplicate information e.g. in the JSON output file.