### PR TITLE
Fix #1328

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1490,7 +1490,7 @@ tmpfile_handle() {
 
 # arg1: line with comment sign, tabs and so on
 filter_input() {
-     sed -e 's/#.*$//' -e '/^$/d' <<< "$1" | tr -d '\n' | tr -d '\t'
+     sed -e 's/#.*$//' -e '/^$/d' <<< "$1" | tr -d '\n' | tr -d '\t' | tr -d '\r'
 }
 
 # Dl's any URL (arg1) via HTTP 1.1 GET from port 80, arg2: file to store http body.


### PR DESCRIPTION
This PR fixes #1328 by removing any '\r' characters that appear in the command line read from the file provided to the `--file` option.