### PR TITLE
Warn if bad version negotiation detected

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17905,6 +17905,9 @@ determine_optimal_sockets_params() {
           sslv2_sockets
           [[ $? -eq 3 ]] && all_failed=false && add_tls_offered ssl2 yes
      fi
+     if [[ -n "$OPTIMAL_SOCKETS_PROTO" ]]; then
+          prln_warning " $NODEIP:$PORT doesn't seem to handle version negotiation correctly. This may lead to some false positives and/or false negatives."
+     fi
      return 0
 }
 


### PR DESCRIPTION
There are a few places where testssl.sh sends a TLS 1.2 (or TLS 1.3) ClientHello and expects the server to respond with a ServerHello as long as it supports TLS 1.2 (or TLS 1.3) or earlier.

`run_protocols()` performs a fairly thorough check for a server's ability to handle version negotiation, but the problem may also be caught by `determine_optimal_sockets_params()`, if the server rejects a TLS 1.2 ClientHello even though it supports some earlier protocol version.

In the future, we could try to make use of `$OPTIMAL_SOCKETS_PROTO` in order to make testssl.sh work a bit better with servers (if any still exist) that don't handle version negotiation correctly. At the moment, though, this PR just prints a warning to the user that the server is buggy, and that this may lead to problems in the scan. It doesn't call `fileout()` to add anything to the JSON/CSV output, since `run_protocols()` should already be doing that.