### PR TITLE
Add --connect-timeout parameter

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -377,6 +377,9 @@ Security headers (X\-Frame\-Options, X\-XSS\-Protection, Expect\-CT,\.\.\. , CSP
 \fB\-\-warnings <batch|off|false>\fR The warnings parameter determines how testssl\.sh will deal with situations where user input normally will be necessary\. There are a couple of options here\. \fBbatch\fR doesn\'t wait for a confirming keypress\. This is automatically being chosen for mass testing (\fB\-\-file\fR)\. \fB\-false\fR just skips the warning AND the confirmation\. Please note that there are conflicts where testssl\.sh will still ask for confirmation which are the ones which otherwise would have a drastic impact on the results\. Almost any other decision will be made as a best guess by testssl\.sh\. The same can be achieved by setting the environment variable \fBWARNINGS\fR\.
 .
 .P
+\fB\-\-connect\-timeout <seconds>\fR This is useful for direct TCP connections to a node\. If the node does not complete a TCP handshake (e\.g\. because it is down or behind a firewall) testssl\.sh may hang for ~2 minutes\. This parameter instructs testssl\.sh to wait at most \fBseconds\fR for the handshake to complete. This option only works if your OS has a \fBtimeout\fR binary installed\.
+.
+.P
 \fB\-\-openssl\-timeout <seconds>\fR This is especially useful for all connects using openssl and practically useful for mass testing\. It avoids the openssl connect to hang for ~2 minutes\. The expected parameter \fBseconds\fR instructs testssl\.sh to wait before the openssl connect will be terminated\. The option is only available if your OS has a timeout binary installed\. As there are different implementations of \fBtimeout\fR: It automatically calls the binary with the right parameters\. OPENSSL_TIMEOUT is the equivalent environment variable\.
 .
 .P

--- a/testssl.sh
+++ b/testssl.sh
@@ -10173,7 +10173,7 @@ fd_socket() {
                     break
                fi
           done
-     elif ! timeout $CONNECT_TIMEOUT bash -c "exec 3<>/dev/tcp/$nodeip/$PORT" || \
+     elif ! timeout "$CONNECT_TIMEOUT" bash -c "exec 3<>/dev/tcp/$nodeip/$PORT" || \
           ! exec 5<>/dev/tcp/$nodeip/$PORT; then  #  2>/dev/null would remove an error message, but disables debugging
           ((NR_SOCKET_FAIL++))
           connectivity_problem $NR_SOCKET_FAIL $MAX_SOCKET_FAIL "TCP connect problem" "repeated TCP connect problems, giving up"

--- a/testssl.sh
+++ b/testssl.sh
@@ -10172,7 +10172,8 @@ fd_socket() {
                     break
                fi
           done
-     elif ! exec 5<>/dev/tcp/$nodeip/$PORT; then  #  2>/dev/null would remove an error message, but disables debugging
+     elif ! timeout 2 bash -c "exec 3<>/dev/tcp/$nodeip/$PORT" || \
+          ! exec 5<>/dev/tcp/$nodeip/$PORT; then  #  2>/dev/null would remove an error message, but disables debugging
           ((NR_SOCKET_FAIL++))
           connectivity_problem $NR_SOCKET_FAIL $MAX_SOCKET_FAIL "TCP connect problem" "repeated TCP connect problems, giving up"
           outln

--- a/testssl.sh
+++ b/testssl.sh
@@ -16919,6 +16919,7 @@ tuning / connect options (most also can be preset via environment variables):
 
 output options (can also be preset via environment variables):
      --warnings <batch|off|false>  "batch" doesn't ask for a confirmation, "off" or "false" skips connection warnings
+     --connect-timeout <seconds>   useful to avoid hangers. Max <seconds> to wait for the TCP handshake to complete
      --openssl-timeout <seconds>   useful to avoid hangers. <seconds> to wait before openssl connect will be terminated
      --quiet                       don't output the banner. By doing this you acknowledge usage terms normally appearing in the banner
      --wide                        wide output for tests like RC4, BEAST. PFS also with hexcode, kx, strength, RFC name

--- a/testssl.sh
+++ b/testssl.sh
@@ -393,6 +393,7 @@ SERVER_COUNTER=0                        # Counter for multiple servers
 
 TLS_LOW_BYTE=""                         # For "secret" development stuff, see -q below
 HEX_CIPHER=""                           # "
+CONNECT_TIMEOUT=180
 
 
 ########### Global variables for parallel mass testing
@@ -10172,7 +10173,7 @@ fd_socket() {
                     break
                fi
           done
-     elif ! timeout 2 bash -c "exec 3<>/dev/tcp/$nodeip/$PORT" || \
+     elif ! timeout $CONNECT_TIMEOUT bash -c "exec 3<>/dev/tcp/$nodeip/$PORT" || \
           ! exec 5<>/dev/tcp/$nodeip/$PORT; then  #  2>/dev/null would remove an error message, but disables debugging
           ((NR_SOCKET_FAIL++))
           connectivity_problem $NR_SOCKET_FAIL $MAX_SOCKET_FAIL "TCP connect problem" "repeated TCP connect problems, giving up"
@@ -19459,6 +19460,10 @@ parse_cmd_line() {
                     ;;
                --openssl-timeout|--openssl-timeout=*)
                     OPENSSL_TIMEOUT="$(parse_opt_equal_sign "$1" "$2")"
+                    [[ $? -eq 0 ]] && shift
+                    ;;
+               --connect-timeout|--connect-timeout=*)
+                    CONNECT_TIMEOUT="$(parse_opt_equal_sign "$1" "$2")"
                     [[ $? -eq 0 ]] && shift
                     ;;
                --mapping|--mapping=*)


### PR DESCRIPTION
Currently there is an `--openssl-timeout` option. However, there is no option to control TCP handshake timeouts. When testing many hosts if any of them is unexpectedly unresponsive (TCP 443 port closed, host down, behind a firewall, etc.) `testssl.sh` will hang for about 2 minutes for each host.

This PR adds the parameter `--connect-timeout` to limit the maximum amount of time to wait for the TCP handshake to complete successfully. The default value is 3 minutes, so that current users of `testssl.sh` should not be affected by this change.

I tested this feature and it seems to be working as intended.