### PR TITLE
Squash message to use ./bin/openssl.* when --ssl-native is supplied

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -18041,12 +18041,12 @@ determine_optimal_proto() {
           prln_bold "doesn't seem to be a TLS/SSL enabled server";
           ignore_no_or_lame " The results might look ok but they could be nonsense. Really proceed ? (\"yes\" to continue)" "yes"
           [[ $? -ne 0 ]] && exit $ERR_CLUELESS
-     elif ! "$all_failed" && "$ALL_FAILED_SOCKETS"; then
+     elif ! "$all_failed" && "$ALL_FAILED_SOCKETS" && ! "$SSL_NATIVE"; then
           # For some reason connecting with tls_sockets/sslv2_sockets didn't work, but connecting
           # with $OPENSSL s_client did.
           # FIXME: Should we include some sort of "please report" note here?
           prln_magenta " Testing with $NODE:$PORT only worked using $OPENSSL."
-          "$SSL_NATIVE" || prln_magenta " Test results may be somewhat better if the --ssl-native option is used."
+          prln_magenta " Test results may be somewhat better if the --ssl-native option is used."
           ignore_no_or_lame " Type \"yes\" to proceed and accept false negatives or positives" "yes"
           [[ $? -ne 0 ]] && exit $ERR_CLUELESS
      fi


### PR DESCRIPTION
PR #1336 included logic to pre-test the server side with sockets
and/or with openssl. However when the user supplied --ssl-native
sockets were never tested before. As a result ALL_FAILED_SOCKETS
was still true, so that the final eif statement complaint erroneously
that sockets didn't work but openssl does.

Also Travis complaint.

This PR fixes it by checking SSL_NATIVE to the final part of the
if statement.

One could also test sockets before and then set ALL_FAILED_SOCKETS
appropriately but that would only make sense if the socket methods
like run_robot() or run_heartbleed() would check ALL_FAILED_SOCKETS
first.

At the moment I went for this as it is easier and the case that sockets
aren't working but openssl does seems not very likely.