### PR TITLE
'IPv4 address in header' shows body content

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2175,10 +2175,8 @@ run_http_header() {
      # Populate vars for HTTP time
      debugme echo "$NOW_TIME: $HTTP_TIME"
 
-     # delete from pattern til the end. We ignore any leading spaces (e.g. www.amazon.de)
-     sed -e '/<HTML>/,$d' -e '/<html>/,$d' -e '/<\!DOCTYPE/,$d' -e '/<\!doctype/,$d' \
-         -e '/<XML/,$d' -e '/<xml/,$d' -e '/<\?XML/,$d' -e '/<?xml/,$d' $HEADERFILE >$HEADERFILE.tmp
-         # ^^^ Attention: filtering is for html body only as of now, doesn't work for other content yet
+     # Quit on first empty line
+     sed -e '/^$/q' $HEADERFILE >$HEADERFILE.tmp
      mv $HEADERFILE.tmp $HEADERFILE
 
      HTTP_STATUS_CODE=$(awk '/^HTTP\// { print $2 }' $HEADERFILE 2>>$ERRFILE)

--- a/testssl.sh
+++ b/testssl.sh
@@ -2175,9 +2175,12 @@ run_http_header() {
      # Populate vars for HTTP time
      debugme echo "$NOW_TIME: $HTTP_TIME"
 
-     # Quit on first empty line
+     # Quit on first empty line to catch 98% of the cases
      sed -e '/^$/q' $HEADERFILE >$HEADERFILE.tmp
-     mv $HEADERFILE.tmp $HEADERFILE
+     # Now to be more sure delete from ~html patterns until the end. We ignore any leading spaces (e.g. www.amazon.de)
+     sed -e '/<HTML>/,$d' -e '/<html>/,$d' -e '/<\!DOCTYPE/,$d' -e '/<\!doctype/,$d' \
+         -e '/<XML/,$d' -e '/<xml/,$d' -e '/<\?XML/,$d' -e '/<?xml/,$d' $HEADERFILE.tmp >$HEADERFILE
+         # ^^^ Attention: filtering is for ~html body only as of now
 
      HTTP_STATUS_CODE=$(awk '/^HTTP\// { print $2 }' $HEADERFILE 2>>$ERRFILE)
      msg_thereafter=$(awk -F"$HTTP_STATUS_CODE" '/^HTTP\// { print $2 }' $HEADERFILE 2>>$ERRFILE)   # dirty trick to use the status code as a


### PR DESCRIPTION
'IPv4 address in header' shows body content if there is no match with the specified patterns.
Probably the HEADERFILE should end on the first empty line.

Please check if this works for all supported platforms or if there are any side effects caused by this approach before merging.