### PR TITLE
Fix client simulation bug

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4303,7 +4303,7 @@ modify_clienthello() {
      offset+=4
      for (( 1; offset < tls_handshake_ascii_len; 1 )); do
           extension_type="${tls_handshake_ascii:$offset:4}"
-          offset+=+4
+          offset+=4
           len_extension=2*$(hex2dec "${tls_handshake_ascii:$offset:4}")
 
           if [[ "$extension_type" == 0000 ]] && [[ -z "$new_key_share" ]]; then
@@ -4320,8 +4320,8 @@ modify_clienthello() {
                     len_sni_listlen=$(printf "%02x\n" $((len_servername+3)))
                     len_sni_ext=$(printf "%02x\n" $((len_servername+5)))
                     tls_extensions+="000000${len_sni_ext}00${len_sni_listlen}0000${len_servername_hex}${servername_hexstr}"
-                    offset+=$len_extension+4
                fi
+               offset+=$len_extension+4
           elif [[ "$extension_type" != 00$KEY_SHARE_EXTN_NR ]] || [[ -z "$new_key_share" ]]; then
                # If this is in response to a HelloRetryRequest, then do
                # not copy over the old key_share extension, but


### PR DESCRIPTION
This PR fixes a bug in `modify_clienthello()` that occurs when client simulation is being performed, the ClientHello contain an SNI extension, and `$SNI` is empty. In the case, `modify_clienthello()` should just skip over the SNI extension and not include one in the modified ClientHello. However, the code currently only skips over the 2-byte extension type. The result being that the remainder of the extension is included in the modified ClientHello. This PR fixes the problem by ensuring the `$offset` is advanced whether or not `$SNI` is empty.