### PR TITLE
Fix parse_tls_serverhello() bug

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11527,7 +11527,7 @@ parse_tls_serverhello() {
                else
                     # This could just be a result of the server's response being
                     # split across two or more packets.
-                    continue
+                    break
                fi
           fi
           tls_content_type="${tls_hello_ascii:i:2}"


### PR DESCRIPTION
This PR fixes a minor bug in `parse_tls_serverhello()`. In some cases the server's entire response is not retrieved. In these cases, it is possible that the response from the server ends with a portion of a handshake message.

The loop at the beginning of `parse_tls_serverhello()` extracts the various handshake and alert messages from the server's response. If it gets to the end of the response, and what is at the end is not a small (< 10 byte) fragment of a message, it should just ignore that fragment and `break` out of the loop. At the moment, however, `parse_tls_serverhello()` just continues in the loop rather than breaking out. This has not been a problem up to now, since `$msg_len` is usually set to a positive value from a previous iteration of the loop, which causes the loop to end.

In the case of the server identified in #1353, however, `$msg_len` is 0 and so the `continue` rather than `break` results in an endless loop.