### PR TITLE
Fix do_starttls initialization bug

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -18847,7 +18847,7 @@ initialize_globals() {
      do_tls_sockets=false
      do_client_simulation=false
      do_display_only=false
-     do_starttls=true
+     do_starttls=false
 }
 
 


### PR DESCRIPTION
At the moment, `$do_starttls` is initialized to `true` in `initialize_globals()` and then it is set to `true` again in `parse_cmd_line()`, if the `--starttls` command line option is used. Presumably the intention was to set `$do_starttls` to `false` in `initialize_globals()`.