### PR TITLE
Use $jsonID rather than literal string

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -15180,7 +15180,7 @@ run_drown() {
                fi
                ;;
           *)   prln_svrty_best "not vulnerable on this host and port (OK)"
-               fileout "DROWN" "OK" "not vulnerable to DROWN on this host and port" "$cve" "$cwe"
+               fileout "$jsonID" "OK" "not vulnerable to DROWN on this host and port" "$cve" "$cwe"
                if [[ -n "$cert_fingerprint_sha2" ]]; then
                     outln "$spaces make sure you don't use this certificate elsewhere with SSLv2 enabled services"
                     out "$spaces "


### PR DESCRIPTION
In `run_drown()`, `$jsonID` is set to "DROWN" and most calls to `fileout()` are of the form
```
fileout "$jsonID" ...
```
However, one call is written as
```
fileout "DROWN" ...
```
This PR changes this one call to be consistent with the others. This does not change the functionality of the program.