### PR TITLE
fix bug in f5_ip_oldstyle() printf format string

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1367,7 +1367,7 @@ f5_ip_oldstyle() {
      local a b c d
 
      tmp="${1/%.*}"                     # until first dot
-     tmp="$(printf "%x8" "$tmp")"       # convert the whole thing to hex, now back to ip (reversed notation:
+     tmp="$(printf "%08x" "$tmp")"       # convert the whole thing to hex, now back to ip (reversed notation:
      tmp="$(f5_hex2ip $tmp)"               # transform to ip with reversed notation
      IFS="." read -r a b c d <<< "$tmp" # reverse it
      echo $d.$c.$b.$a


### PR DESCRIPTION
The printf format string in `f5_ip_oldstyle()` is incorrect. It works most of the time, but in cases where the hexadecimal output is less than 8 characters, it fails.