### PR TITLE
Fix issues with run_protocols() in --ssl-native mode

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4802,12 +4802,18 @@ run_prototest_openssl() {
      sclient_connect_successful $? $TMPFILE
      ret=$?
      debugme grep -E "error|failure" $ERRFILE | grep -Eav "unable to get local|verify error"
-     # try again without $PROXY
-     $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $SNI") >$TMPFILE 2>&1 </dev/null
-     sclient_connect_successful $? $TMPFILE
-     ret=$?
-     debugme grep -E "error|failure" $ERRFILE | grep -Eav "unable to get local|verify error"
-     grep -aq "no cipher list" $TMPFILE && ret=5       # <--- important indicator for SSL2 (maybe others, too)
+     if [[ $ret -ne 0 ]]; then
+          if grep -aq "no cipher list" $TMPFILE; then
+               ret=5       # <--- important indicator for SSL2 (maybe others, too)
+          else
+               # try again without $PROXY
+               $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $SNI") >$TMPFILE 2>&1 </dev/null
+               sclient_connect_successful $? $TMPFILE
+               ret=$?
+               debugme grep -E "error|failure" $ERRFILE | grep -Eav "unable to get local|verify error"
+               grep -aq "no cipher list" $TMPFILE && ret=5       # <--- important indicator for SSL2 (maybe others, too)
+          fi
+     fi
      tmpfile_handle ${FUNCNAME[0]}$1.txt
      return $ret
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -4784,8 +4784,8 @@ locally_supported() {
 }
 
 
-# The protocol check in run_protocols needs to be redone. The using_socket part there kind of sucks.
-# 1) we need to have a variable where the results are being stored so that every other test doesn't have to do this agai
+# The protocol check in run_protocols needs to be redone. The using_sockets part there kind of sucks.
+# 1) we need to have a variable where the results are being stored so that every other test doesn't have to do this again
 #   --> we have that but certain information like "downgraded" are not being passed. That's not ok for run_protocols()/
 #   for all other functions we can use it
 # 2) the code is old and one can do that way better

--- a/testssl.sh
+++ b/testssl.sh
@@ -4964,7 +4964,7 @@ run_protocols() {
                     fileout "$jsonID" "OK" "not offered"
                     add_tls_offered ssl2 no
                     ;;
-               5)   pr_svrty_high "CVE-2015-3197: $supported_no_ciph2";
+               5)   prln_svrty_high "CVE-2015-3197: $supported_no_ciph2";
                     fileout "$jsonID" "HIGH" "offered, no cipher" "CVE-2015-3197" "CWE-310"
                     add_tls_offered ssl2 yes
                     ;;

--- a/testssl.sh
+++ b/testssl.sh
@@ -4798,12 +4798,12 @@ run_prototest_openssl() {
 
      # check whether the protocol being tested is supported by $OPENSSL
      $OPENSSL s_client "$1" -connect x 2>&1 | grep -aq "unknown option" && return 7
-     $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE </dev/null
+     $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>&1 </dev/null
      sclient_connect_successful $? $TMPFILE
      ret=$?
      debugme grep -E "error|failure" $ERRFILE | grep -Eav "unable to get local|verify error"
      # try again without $PROXY
-     $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $SNI") >$TMPFILE 2>$ERRFILE </dev/null
+     $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $SNI") >$TMPFILE 2>&1 </dev/null
      sclient_connect_successful $? $TMPFILE
      ret=$?
      debugme grep -E "error|failure" $ERRFILE | grep -Eav "unable to get local|verify error"

--- a/testssl.sh
+++ b/testssl.sh
@@ -4796,7 +4796,8 @@ locally_supported() {
 run_prototest_openssl() {
      local -i ret=0
 
-     ! locally_supported "$1" && return 7
+     # check whether the protocol being tested is supported by $OPENSSL
+     $OPENSSL s_client "$1" -connect x 2>&1 | grep -aq "unknown option" && return 7
      $OPENSSL s_client $(s_client_options "-state $1 $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE </dev/null
      sclient_connect_successful $? $TMPFILE
      ret=$?
@@ -4967,7 +4968,8 @@ run_protocols() {
                     fileout "$jsonID" "HIGH" "offered, no cipher" "CVE-2015-3197" "CWE-310"
                     add_tls_offered ssl2 yes
                     ;;
-               7)   fileout "$jsonID" "INFO" "not tested due to lack of local support"
+               7)   prln_local_problem "$OPENSSL doesn't support \"s_client -ssl2\""
+                    fileout "$jsonID" "INFO" "not tested due to lack of local support"
                     ((ret++))
                     ;;
           esac
@@ -5030,7 +5032,7 @@ run_protocols() {
                     # can only happen in debug mode
                     pr_warning "strange reply, maybe a client side problem with SSLv3"; outln "$debug_recomm"
                else
-                    # warning on screen came already from locally_supported()
+                    prln_local_problem "$OPENSSL doesn't support \"s_client -ssl3\""
                     fileout "$jsonID" "WARN" "not tested due to lack of local support"
                fi
                ;;
@@ -5107,7 +5109,7 @@ run_protocols() {
                     # can only happen in debug mode
                     pr_warning "strange reply, maybe a client side problem with TLS 1.0"; outln "$debug_recomm"
                else
-                    # warning on screen came already from locally_supported()
+                    prln_local_problem "$OPENSSL doesn't support \"s_client -tls1\""
                     fileout "$jsonID" "WARN" "not tested due to lack of local support"
                fi
                ((ret++))
@@ -5188,7 +5190,7 @@ run_protocols() {
                     # can only happen in debug mode
                     pr_warning "strange reply, maybe a client side problem with TLS 1.1"; outln "$debug_recomm"
                else
-                    # warning on screen came already from locally_supported()
+                    prln_local_problem "$OPENSSL doesn't support \"s_client -tls1_1\""
                     fileout "$jsonID" "WARN" "not tested due to lack of local support"
                fi
                ((ret++))
@@ -5309,7 +5311,7 @@ run_protocols() {
                     # can only happen in debug mode
                     pr_warning "strange reply, maybe a client side problem with TLS 1.2"; outln "$debug_recomm"
                else
-                    # warning on screen came already from locally_supported()
+                    prln_local_problem "$OPENSSL doesn't support \"s_client -tls1_2\""
                     fileout "$jsonID" "WARN" "not tested due to lack of local support"
                fi
                ((ret++))
@@ -5462,7 +5464,7 @@ run_protocols() {
                     # can only happen in debug mode
                     prln_warning "strange reply, maybe a client side problem with TLS 1.3"; outln "$debug_recomm"
                else
-                    # warning on screen came already from locally_supported()
+                    prln_local_problem "$OPENSSL doesn't support \"s_client -tls1_3\""
                     fileout "$jsonID" "WARN" "not tested due to lack of local support"
                fi
                ((ret++))


### PR DESCRIPTION
This PR fixes a minor problem with `run_protocols()` in "--ssl-native" mode if `$OPENSSL` does not support TLS 1.3. Currently, the warning message that `$OPENSSL` does not support a protocol is printed when `run_prototest_openssl()` is called. This causes a problem for the output if `$OPENSSL` does not support TLS 1.3, since the `run_prototest_openssl()` is called before the results for TLS 1.2 are printed. The result is something like this:
```
 SSLv2      not offered (OK)
 SSLv3      not offered (OK)
 TLS 1      offered (deprecated)
 TLS 1.1    offered (deprecated)
Local problem: /home/cooper/Desktop/testssl.sh/bin/openssl.Linux.x86_64 doesn't support "s_client -tls1_3"
 TLS 1.2    offered (OK)
 TLS 1.3     NPN/SPDY   not offered
 ALPN/HTTP2 http/1.1 (offered)
```
This PR moves the printing of the warning message to run_protocols() in order to fix the problem.