### PR TITLE
Earlier initialisation of DNS HAS_* related vars

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19760,11 +19760,12 @@ lets_roll() {
      choose_printf
      prepare_debug  ; stopwatch parse
      prepare_arrays ; stopwatch prepare_arrays
+     check_resolver_bins
      mybanner
      check_proxy
      check4openssl_oldfarts
      check_bsd_mount
-     check_resolver_bins
+     
 
      if "$do_display_only"; then
           prettyprint_local "$PATTERN2SHOW"


### PR DESCRIPTION
This fixes a bug e.g. when supplying a proxy by a DNS name, testssl couldn't resolve the name as the HAS_ variables initialized by ``check_resolver_bins()`` was done later than ``check_proxy()``.

The patch just puts ``check_resolver_bins()`` earlier in  "main"