### PR TITLE
Don't call s_client for unsupported protocol versions

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14821,11 +14821,12 @@ run_tls_fallback_scsv() {
                     # This may be an SSLv2-only server, if $OPENSSL does not support SSLv2.
                     prln_warning "test failed (couldn't connect)"
                     fileout "$jsonID" "WARN" "Check failed. (couldn't connect)"
+                    return 1
                elif [[ $(has_server_protocol tls1_3) -eq 1 ]]; then
                     # If the server does not support TLS 1.3, TLS 1.2, TLS 1.1, or TLS 1, and
                     # support for SSLv3 cannot be tested, then treat it as HIGH severity, since
                     # it is very likely that SSLv3 is the only supported protocol.
-                    prln_svrty_high "No fallback possible, TLS 1.2, TLS 1.1, and TLS 1 not supported (OK)"
+                    prln_svrty_high "No fallback possible, TLS 1.2, TLS 1.1, and TLS 1 not supported"
                     fileout "$jsonID" "HIGH" "TLS 1.2, TLS 1.1, and TLS 1 not supported"
                else
                     # TLS 1.2, TLS 1.1, and TLS 1 are not supported, but can't tell whether TLS 1.3 is supported.
@@ -14855,7 +14856,7 @@ run_tls_fallback_scsv() {
 
      if ! "$HAS_SSL3" && \
          ( [[ "$low_proto" == ssl3 ]] || \
-           ( [[ "$high_proto" == tls1 ]] && [[ $(has_server_protocol "$p") -eq 2 ]] ) ); then
+           ( [[ "$high_proto" == tls1 ]] && [[ $(has_server_protocol "ssl3") -eq 2 ]] ) ); then
           # If the protocol that the server would fall back to is SSLv3, but $OPENSSL does
           # not support SSLv3, then the test cannot be performed. So, if $OPENSSL does not
           # support SSLv3 and it is known that SSLv3 is the fallback protocol ($low_proto), then

--- a/testssl.sh
+++ b/testssl.sh
@@ -14826,8 +14826,8 @@ run_tls_fallback_scsv() {
                     # If the server does not support TLS 1.3, TLS 1.2, TLS 1.1, or TLS 1, and
                     # support for SSLv3 cannot be tested, then treat it as HIGH severity, since
                     # it is very likely that SSLv3 is the only supported protocol.
-                    prln_svrty_high "No fallback possible, TLS 1.2, TLS 1.1, and TLS 1 not supported"
-                    fileout "$jsonID" "HIGH" "TLS 1.2, TLS 1.1, and TLS 1 not supported"
+                    prln_svrty_high "No fallback possible, TLS 1.3, TLS 1.2, TLS 1.1, and TLS 1 not supported"
+                    fileout "$jsonID" "HIGH" "TLS 1.3, TLS 1.2, TLS 1.1, and TLS 1 not supported"
                else
                     # TLS 1.2, TLS 1.1, and TLS 1 are not supported, but can't tell whether TLS 1.3 is supported.
                     # This could be a TLS 1.3 only server, an SSLv3 only server (if SSLv3 support cannot be tested),

--- a/testssl.sh
+++ b/testssl.sh
@@ -14833,7 +14833,7 @@ run_tls_fallback_scsv() {
                     # This could be a TLS 1.3 only server, an SSLv3 only server (if SSLv3 support cannot be tested),
                     # or a server that does not support SSLv3 or any TLS protocol. So, don't report a severity,
                     # since this could either be good or bad.
-                    outln "No fallback possible, TLS 1.2, TLS 1.1, and TLS 1 not supported (OK)"
+                    outln "No fallback possible, TLS 1.2, TLS 1.1, and TLS 1 not supported"
                     fileout "$jsonID" "INFO" "TLS 1.2, TLS 1.1, and TLS 1 not supported"
                fi
                return 0


### PR DESCRIPTION
This PR fixes a couple of places where "$OPENSSL s_client" is called with "-ssl3" even if SSLv3 is not supported.

The fix in `ciphers_by_strength()` is easy, as the issue only occurs if "$using_sockets" is true. If SSLv3 (or TLSv1.3) is not supported, then testing using "$OPENSSL s_client" is skipped and all of the supported ciphers are found using `tls_sockets()`.

The fix for `run_tls_fallback_scsv()` is more complicated. While it is easy to avoid calling "$OPENSSL s_client" with "-ssl3" if SSLv3 is not supported, it is not easy to determine the correct message to present to the user if support for SSLv3 (and possibly also TLSv1.3) is unknown.

For the case in which $high_proto cannot be set, I believe that I have covered all of the possibilities, but am not sure if the correct message/rating is used in every case.

For the case in which it is not possible to determine whether SSLv3 is the $low_proto, more could be done. If $high_proto is TLS 1.1 or TLS 1, then this PR is okay, as it is possible that SSLv3 would be the fallback protocol, but there is no way to tell. However, it seems unlikely that a server would support TLS 1.2 and SSLv3, but not TLS 1.1 or TLS 1. So, perhaps if $high_proto is TLS 1.2 and the server does not support TLS 1.1 or TLS 1, it should just be assumed that SSLv3 is not supported, even if it cannot be tested.