### PR TITLE
Fix #1385

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6098,7 +6098,7 @@ sub_session_resumption() {
                return 1
           fi
      fi
-     "$CLIENT_AUTH" && return 3
+     "$CLIENT_AUTH" && return 6
      if "$HAS_NO_SSL2"; then
           addcmd+=" -no_ssl2"
      else


### PR DESCRIPTION
This PR fixes #1385.

`sub_session_resumption()` returns 3 when `$CLIENT_AUTH` is true. However, the comment at the beginning of the function indicates that 6 will be returned. `run_server_defaults()` is prepared to handle a return value of 6 (to indicate client auth), but is not expecting 3 as a possible return value.