### PR TITLE
Fix Bash error messages on bad command line

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -734,6 +734,9 @@ strip_quote() {
 #################### JSON FILE FORMATTING ####################
 
 fileout_json_footer() {
+     if [[ ! -s "$JSONFILE" ]] || [[ -d "$JSONFILE" ]]; then
+          return 0
+     fi
      if "$do_json"; then
           if [[ "$SCAN_TIME" -eq 0 ]]; then
                fileout_json_finding "scanTime" "WARN" "Scan interrupted" "" "" ""


### PR DESCRIPTION
If the command line is bad and either `$do_json` or `$do_pretty_json` is set, but `$JSONFILE` is not set, then this results in a Bash error messages. For example:
```
testssl.sh --json out.json 127.0.0.1

Fatal error: URI comes last

./testssl.sh: line 811: : No such file or directory
./testssl.sh: line 812: : No such file or directory
./testssl.sh: line 798: : No such file or directory
./testssl.sh: line 799: : No such file or directory
./testssl.sh: line 798: : No such file or directory
./testssl.sh: line 799: : No such file or directory
./testssl.sh: line 798: : No such file or directory
./testssl.sh: line 799: : No such file or directory
./testssl.sh: line 798: : No such file or directory
./testssl.sh: line 799: : No such file or directory
./testssl.sh: line 798: : No such file or directory
./testssl.sh: line 821: : No such file or directory
./testssl.sh: line 744: : No such file or directory
```
The problem occurs because `cleanup()` calls `fileout_footer()`, which in turn calls `fileout_json_footer()`. In the case above, `$do_json` has been set, but `$JSONFILE` is empty.

A similar problem would occur if `$do_json` has been set, but `$JSONFILE` is a directory, which could happen with a command line such as:
```
   testssl.sh --jsonfile jsondirectory --html out.html 127.0.0.1
```
If `$do_json` is set and `$JSONFILE` points to a file, then another problem occurs:
```
testssl.sh --jsonfile out.json --html out.html 127.0.0.1
```
results in just a footer being added to out.json, so that the resulting file is not valid JSON.

This PR fixes the problem by having `fileout_json_footer()` check that `$JSONFILE` is not empty and that it is not directory before attempting to write to `$JSONFILE`.