### PR TITLE
Fix formatting of HTTP security headers

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3029,7 +3029,7 @@ run_cookie_flags() {     # ARG1: Path
 run_security_headers() {
      local good_header="X-Frame-Options X-XSS-Protection X-Content-Type-Options Content-Security-Policy X-Content-Security-Policy X-WebKit-CSP Content-Security-Policy-Report-Only Expect-CT"
      local other_header="Access-Control-Allow-Origin Upgrade X-Served-By Referrer-Policy X-UA-Compatible"
-     local header
+     local header header_output
      local first=true
      local spaces="                              "
      local have_header=false
@@ -3047,8 +3047,11 @@ run_security_headers() {
                if "$first"; then
                     first=false
                fi
+               # Include $header when determining where to insert line breaks, but print $header
+               # separately.
                pr_svrty_good "$header"
-               outln " $(out_row_aligned_max_width "$HEADERVALUE" "$spaces" $TERM_WIDTH)"
+               header_output="$(out_row_aligned_max_width "$header $HEADERVALUE" "$spaces" $TERM_WIDTH)"
+               outln "${header_output#$header}"
                fileout "$header" "OK" "$HEADERVALUE"
           fi
      done

--- a/testssl.sh
+++ b/testssl.sh
@@ -3050,8 +3050,8 @@ run_security_headers() {
                # Include $header when determining where to insert line breaks, but print $header
                # separately.
                pr_svrty_good "$header"
-               header_output="$(out_row_aligned_max_width "$header $HEADERVALUE" "$spaces" $TERM_WIDTH)"
-               outln "${header_output#$header}"
+               header_output="$(out_row_aligned_max_width "${header:2} $HEADERVALUE" "$spaces  " $TERM_WIDTH)"
+               outln "${header_output#${header:2}}"
                fileout "$header" "OK" "$HEADERVALUE"
           fi
      done


### PR DESCRIPTION
When printing out HTTP security headers, `run_security_headers()` uses `out_row_aligned_max_width()`, since some headers are very long and need to be wrapped. At the moment, however, the first line is too long. The problem is that while `"$header $HEADERVALUE"` is printed in the indented area, only `$HEADERVALUE` is passed to `out_row_aligned_max_width()`.

This PR fixes the problem by passing `"$header $HEADERVALUE"` to `out_row_aligned_max_width()` so that the the first line is wrapped at the correct place.