### PR TITLE
Fix TLS 1.3 key derivation

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -13479,6 +13479,7 @@ resend_if_hello_retry_request() {
      fi
      debugme echo -en "\nsending second client hello... "
      second_clienthello="$(modify_clienthello "$original_clienthello" "$new_key_share" "$cookie")"
+     TLS_CLIENT_HELLO="${second_clienthello:10}"
      msg_len=${#second_clienthello}
      for (( i=0; i < msg_len; i=i+2 )); do
           data+=", ${second_clienthello:i:2}"
@@ -13542,6 +13543,7 @@ tls_sockets() {
 
           tls_hello_ascii=$(hexdump -v -e '16/1 "%02X"' "$SOCK_REPLY_FILE")
           tls_hello_ascii="${tls_hello_ascii%%[!0-9A-F]*}"
+          tls_hello_ascii="${tls_hello_ascii%%140303000101}"
 
           # Check if the response is a HelloRetryRequest.
           original_clienthello="160301$(printf "%04x" "${#clienthello1}")$clienthello1"


### PR DESCRIPTION
At the moment, testssl.sh does not correctly derive the handshake traffic keys in the case that the server responds to the initial ClientHello with a HelloRetryRequest. The handshake traffic keys are computed incorrectly because the wrong messages are provided to `derive-handshake-traffic-keys()` for input to the Transcript-Hash calculation:

* `$TLS_CLIENT_HELLO `is not updated to contain the value of the second ClientHello, and so the first ClientHello is being provided to derive-handshake-traffic-keys() as both the first and the second ClientHello.

* In middlebox compatibility mode the server may send a dummy ChangeCipherSpec message immediately after the HelloRetryRequest. Since it is part of the server's response to the initial ClientHello, the ChangeCipherSpec message is included in the `$hrr` that is sent to `derive-handshake-traffic-keys()`, but it should not be included in the computation of the Transcript-Hash.

This PR fixes the above two problems by updating `$TLS_CLIENT_HELLO` when a second ClientHello is sent and by removing any ChangeCipherSpec message (140303000101) from the end of the server's initial response.