### PR TITLE
Fix run_server_preference() in --ssl-native mode

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6293,6 +6293,7 @@ run_server_preference() {
           if sclient_connect_successful $? $TMPFILE; then
                cipher0=$(get_cipher $TMPFILE)
                debugme tm_out "0 --> $cipher0\n"
+               cp $TMPFILE "$TEMPDIR/$NODEIP.parse_tls13_serverhello.txt"
           else
                # 2 second try with $OPTIMAL_PROTO especially for intolerant IIS6 servers:
                $OPENSSL s_client $(s_client_options "$STARTTLS $OPTIMAL_PROTO $BUGS -connect $NODEIP:$PORT $PROXY $SNI") </dev/null 2>>$ERRFILE >$TMPFILE
@@ -6309,12 +6310,12 @@ run_server_preference() {
      # Some servers don't have a TLS 1.3 cipher order, see #1163
      if [[ "$default_proto" == TLSv1.3 ]]; then
           tls_sockets "04" "13,05, 13,04, 13,03, 13,02, 13,01, 00,ff"
-          [[ $sclient_success -ne 0 ]] && ret=1 && prln_fixme "something weird happened around line $((LINENO - 1))"
+          [[ $? -ne 0 ]] && ret=1 && prln_fixme "something weird happened around line $((LINENO - 1))"
           cp "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt" $TMPFILE
           tls13_cipher1=$(get_cipher $TMPFILE)
           debugme tm_out "TLS 1.3: --> $tls13_cipher1\n"
           tls_sockets "04" "13,01, 13,02, 13,03, 13,04, 13,05, 00,ff"
-          [[ $sclient_success -ne 0 ]] && ret=1 && prln_fixme "something weird happened around line $((LINENO - 1))"
+          [[ $? -ne 0 ]] && ret=1 && prln_fixme "something weird happened around line $((LINENO - 1))"
           cp "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt" $TMPFILE
           tls13_cipher2=$(get_cipher $TMPFILE)
           debugme tm_out "TLS 1.3: --> $tls13_cipher2\n"


### PR DESCRIPTION
This PR fixes two problems that occur when testing a server that supports TLSv1.3 using OpenSSL 1.1.1 in `--ssl-native` mode.

First, when testing whether the server has a cipher order, the value of `$sclient_success` is checked after each call to `tls_sockets()`, but `$sclient_success` is not to the result of the `tls_sockets()` call. As the goal is just to verify that the connection was successful (and didn't downgrade), `$?` can be checked rather than `$sclient_success`. [When not in `--ssl-native mode` this problem is masked since `$sclient_success` is set to 0 earlier in the function.]

The second problem is that line 6646 tries to copy "$TEMPDIR/$NODEIP.parse_tls13_serverhello.txt", but this file is currently only created (on line 6287) if `tls_sockets()` is used to determine the negotiated protocol. This PR fixes the problem by also populating "$TEMPDIR/$NODEIP.parse_tls13_serverhello.txt" when OpenSSL is used to determine the negotiated protocol.