### PR TITLE
Try temp file creation in a different location

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17194,7 +17194,12 @@ EOF
 }
 
 maketempf() {
-     TEMPDIR=$(mktemp -d /tmp/testssl.XXXXXX) || exit $ERR_FCREATE
+     TEMPDIR=$(mktemp -d /tmp/testssl.XXXXXX)
+     if [[ $? -ne 0 ]]; then
+          # for e.g. devices where we can't write to /tmp:
+          TEMPPATH=$PWD
+          TEMPDIR=$(mktemp -d $PWD/testssl.XXXXXX) || exit $ERR_FCREATE
+     fi
      TMPFILE=$TEMPDIR/tempfile.txt || exit $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then
           ERRFILE="/dev/null"

--- a/testssl.sh
+++ b/testssl.sh
@@ -17198,10 +17198,10 @@ maketempf() {
      if [[ $? -ne 0 ]]; then
           # For e.g. devices where we can't write to /tmp we chose $PWD but we can't
           # allow every char as we haven't quoted all strings depending on it, see #1445
-          if [[ $PWD =~ ^[A-Za-z0-9\.,-/_]+$ ]]; then
-               fatal "\$PWD contains illegal chars: \"$PWD\"" $ERR_FCREATE
+          if [[ $PWD =~ [^A-Za-z0-9\.,/_-] ]]; then
+               fatal "\$PWD contains illegal chars: \"$BASH_REMATCH\"" $ERR_FCREATE
           fi
-          TEMPDIR=$(mktemp -d "PWD/testssl.XXXXXX") || exit $ERR_FCREATE
+          TEMPDIR=$(mktemp -d "$PWD/testssl.XXXXXX") || exit $ERR_FCREATE
      fi
      TMPFILE=$TEMPDIR/tempfile.txt || exit $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then
@@ -20002,8 +20002,8 @@ lets_roll() {
      initialize_globals
      check_base_requirements            # needs to come after $do_html is defined
      parse_cmd_line "$@"
-     # CMDLINE_PARSED has been set now. Don't put a now function after this which calls fatal(). Rather
-     # put it after csv_header below
+     # CMDLINE_PARSED has been set now. Don't put a function immediately after this which calls fatal().
+     # Rather put it after csv_header below.
      # html_header() needs to be called early! Otherwise if html_out() is called before html_header() and the
      # command line contains --htmlfile <htmlfile> or --html, it'll make problems with html output, see #692.
      # json_header and csv_header could be called later but for context reasons we'll leave it here

--- a/testssl.sh
+++ b/testssl.sh
@@ -17196,10 +17196,10 @@ EOF
 maketempf() {
      TEMPDIR=$(mktemp -d /tmp/testssl.XXXXXX)
      if [[ $? -ne 0 ]]; then
-          # for e.g. devices where we can't write to /tmp:
-          if [[ $PWD =~ \  ]]; then
-               # We can't allow this as we haven't quoted all strings depending on it, see #1445
-               fatal "\$PWD contains a blank: \"$PWD\"" $ERR_FCREATE
+          # For e.g. devices where we can't write to /tmp we chose $PWD but we can't
+          # allow every char as we haven't quoted all strings depending on it, see #1445
+          if [[ $PWD =~ ^[A-Za-z0-9\.,-/_]+$ ]]; then
+               fatal "\$PWD contains illegal chars: \"$PWD\"" $ERR_FCREATE
           fi
           TEMPDIR=$(mktemp -d "PWD/testssl.XXXXXX") || exit $ERR_FCREATE
      fi

--- a/testssl.sh
+++ b/testssl.sh
@@ -17197,8 +17197,11 @@ maketempf() {
      TEMPDIR=$(mktemp -d /tmp/testssl.XXXXXX)
      if [[ $? -ne 0 ]]; then
           # for e.g. devices where we can't write to /tmp:
-          TEMPPATH=$PWD
-          TEMPDIR=$(mktemp -d $PWD/testssl.XXXXXX) || exit $ERR_FCREATE
+          if [[ $PWD =~ \  ]]; then
+               # We can't allow this as we haven't quoted all strings depending on it, see #1445
+               fatal "\$PWD contains a blank: \"$PWD\"" $ERR_FCREATE
+          fi
+          TEMPDIR=$(mktemp -d "PWD/testssl.XXXXXX") || exit $ERR_FCREATE
      fi
      TMPFILE=$TEMPDIR/tempfile.txt || exit $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then


### PR DESCRIPTION
... if the standard directory /tmp is not allowed to write to. As noted in #1273 this might be the case for Termux on Android.

Looking at #1273 this PT amends #1443 and replaces #1277