### PR TITLE
Add missing variable declarations

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11054,6 +11054,7 @@ derive-handshake-traffic-keys() {
      local -i retcode
      local hash_fn
      local pub_file priv_file tmpfile
+     local derived_secret server_write_key server_write_iv
 
      if [[ "$cipher" == *SHA256 ]]; then
           hash_fn="-sha256"


### PR DESCRIPTION
`derive-handshake-traffic-keys()` uses the variables `derived_secret`, `server_write_key`, and `server_write_iv`, but they are not declared as local variables of the function. This PR fixes that.