### PR TITLE
Add support for HTTP Basic Auth

### DIFF
--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -105,6 +105,7 @@ The same can be achieved by setting the environment variable `WARNINGS`.
 
 `--openssl-timeout <seconds>` This is especially useful for all connects using openssl and practically useful for mass testing. It avoids the openssl connect to hang for ~2 minutes. The expected parameter `seconds` instructs testssl.sh to wait before the openssl connect will be terminated. The option is only available if your OS has a timeout binary installed. As there are different implementations of `timeout`: It automatically calls the binary with the right parameters. OPENSSL_TIMEOUT is the equivalent environment variable.
 
+`--basicauth <user:pass>` This can be set to provide HTTP basic auth credentials which are used during checks for security headers. 
 
 
 ### SPECIAL INVOCATIONS

--- a/testssl.sh
+++ b/testssl.sh
@@ -204,6 +204,7 @@ SNEAKY=${SNEAKY:-false}                 # is the referer and useragent we leave 
 QUIET=${QUIET:-false}                   # don't output the banner. By doing this you acknowledge usage term appearing in the banner
 SSL_NATIVE=${SSL_NATIVE:-false}         # we do per default bash sockets where possible "true": switch back to "openssl native"
 ASSUME_HTTP=${ASSUME_HTTP:-false}       # in seldom cases (WAF, old servers, grumpy SSL) service detection fails. "True" enforces HTTP checks
+BASICAUTH=${BASICAUTH:-""}              # HTTP basic auth credentials can be set here like user:pass
 BUGS=${BUGS:-""}                        # -bugs option from openssl, needed for some BIG IP F5
 WARNINGS=${WARNINGS:-""}                # can be either off or batch
 DEBUG=${DEBUG:-0}                       # 1: normal output the files in /tmp/ are kept for further debugging purposes
@@ -17310,6 +17311,7 @@ HAS_SED_E: $HAS_SED_E
 SHOW_EACH_C: $SHOW_EACH_C
 SSL_NATIVE: $SSL_NATIVE
 ASSUME_HTTP $ASSUME_HTTP
+BASICAUTH: $BASICAUTH
 SNEAKY: $SNEAKY
 OFFENSIVE: $OFFENSIVE
 PHONE_OUT: $PHONE_OUT
@@ -19790,6 +19792,7 @@ parse_cmd_line() {
                     ;;
                --basicauth|--basicauth=*)
                    BASICAUTH="$(parse_opt_equal_sign "$1" "$2")"
+                   [[ $? -eq 0 ]] && shift
                    ;;
                (--) shift
                     break

--- a/testssl.sh
+++ b/testssl.sh
@@ -18392,6 +18392,7 @@ determine_optimal_proto() {
 determine_service() {
      local ua
      local protocol
+     local basicauth_header=""
 
      # Check if we can connect to $NODEIP:$PORT. Attention: This ALWAYS uses sockets. Thus timeouts for --ssl-=native do not apply
      if ! fd_socket 5; then
@@ -18413,14 +18414,13 @@ determine_service() {
           # no STARTTLS.
           determine_optimal_sockets_params
           determine_optimal_proto
-          BASIC_AUTH_HEADER=""
           $SNEAKY && \
                ua="$UA_SNEAKY" || \
                ua="$UA_STD"
           if [[ ! -z "$BASICAUTH" ]]; then
-               BASIC_AUTH_HEADER="Authorization: Basic `echo $BASICAUTH | basenc --base64` \r\n"
+               basicauth_header="Authorization: Basic $(echo $BASICAUTH | openssl base64) \r\n"
           fi
-          GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n$BASIC_AUTH_HEADER Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
+          GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n$basicauth_header Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
           # returns always 0:
           service_detection $OPTIMAL_PROTO
      else # STARTTLS


### PR DESCRIPTION
Hi Dirk,
I had the problem, when scanning a webserver with HTTP basic auth the test for the security headers is not working correctly. I was looking in the help section of testssl for a switch to provide the basic auth credentials but could not find this feature. So I decided to implement it and open a PR on this issue.

Please let me know if anything is missing.

Cheers