### PR TITLE
Check for the Cache-Control and Pragma header

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3034,7 +3034,7 @@ run_cookie_flags() {     # ARG1: Path
 
 run_security_headers() {
      local good_header="X-Frame-Options X-XSS-Protection X-Content-Type-Options Content-Security-Policy X-Content-Security-Policy X-WebKit-CSP Content-Security-Policy-Report-Only Expect-CT"
-     local other_header="Access-Control-Allow-Origin Upgrade X-Served-By Referrer-Policy X-UA-Compatible"
+     local other_header="Access-Control-Allow-Origin Upgrade X-Served-By Referrer-Policy X-UA-Compatible Cache-Control"
      local header header_output
      local first=true
      local spaces="                              "

--- a/testssl.sh
+++ b/testssl.sh
@@ -3034,7 +3034,7 @@ run_cookie_flags() {     # ARG1: Path
 
 run_security_headers() {
      local good_header="X-Frame-Options X-XSS-Protection X-Content-Type-Options Content-Security-Policy X-Content-Security-Policy X-WebKit-CSP Content-Security-Policy-Report-Only Expect-CT"
-     local other_header="Access-Control-Allow-Origin Upgrade X-Served-By Referrer-Policy X-UA-Compatible Cache-Control"
+     local other_header="Access-Control-Allow-Origin Upgrade X-Served-By Referrer-Policy X-UA-Compatible Cache-Control Pragma"
      local header header_output
      local first=true
      local spaces="                              "


### PR DESCRIPTION
Hi Dirk,
when testing webservers, I would like to see if the Cache-Control and Pragma headers are set. In some cases this is a good hint (see the following post for reference https://isc.sans.edu/forums/diary/The+Security+Impact+of+HTTP+Caching+Headers/17033/)

I have added the two headers in the other_header variable. I'm not sure if it would better fit to security_header? If you like this PR just tell me if I should put it to a different location.

Cheers

Manuel
