### PR TITLE
More polishing of http basic auth

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -18419,10 +18419,10 @@ determine_service() {
           $SNEAKY && \
                ua="$UA_SNEAKY" || \
                ua="$UA_STD"
-          if [[ ! -z "$BASICAUTH" ]]; then
-               basicauth_header="Authorization: Basic $(openssl base64 <<< $BASICAUTH) \r\n"
+          if [[ -n "$BASICAUTH" ]]; then
+               basicauth_header="Authorization: Basic $($OPENSSL base64 <<< "$BASICAUTH" 2>/dev/null)\r\n"
           fi
-          GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n$basicauth_header Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
+          GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n${basicauth_header}Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
           # returns always 0:
           service_detection $OPTIMAL_PROTO
      else # STARTTLS


### PR DESCRIPTION
* Replace `! -z` with `-n`
* Replace "openssl' with "$OPENSSL"
* Redirect stderr output of $OPENSSL to /dev/null to supress "WARNING: can't open config file: /usr/local/etc/ssl/openssl.cnf" message (see #833)
* Remove unnecessary spaces from `$GET_REQ11` string.