### PR TITLE
Shortcuts for vulnerability tests for TLS 1.3 only servers

### DIFF
--- a/t/08_isHTML_valid.t
+++ b/t/08_isHTML_valid.t
@@ -9,12 +9,12 @@ use Data::Dumper;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $uri="dev.testssl.sh";
+my $uri="heise.de";
 my $out="";
 my $html="";
 my $debughtml="";
 my $edited_html="";
-my $check2run="--ip=one  --color 0 --htmlfile tmp.html";
+my $check2run="--ip=one --color 0 --htmlfile tmp.html";
 
 die "Unable to open $prg" unless -f $prg;
 
@@ -44,7 +44,6 @@ $edited_html =~ s/&gt;/>/g;
 $edited_html =~ s/&quot;/"/g;
 $edited_html =~ s/&apos;/'/g;
 
-printf "\n%s\n", " .. comparing HTML and terminal outputs";
 cmp_ok($edited_html, "eq", $out, "HTML file matches terminal output");
 $tests++;
 
@@ -70,7 +69,6 @@ $debughtml =~ s/ Pre-test: .*\n//g;
 $debughtml =~ s/.*OK: below 825 days.*\n//g;
 $debughtml =~ s/.*DEBUG:.*\n//g;
 
-printf "\n%s\n", " .. checking that using the --debug option doesn't affect the HTML file";
 cmp_ok($debughtml, "eq", $html, "HTML file created with --debug 4 matches HTML file created without --debug");
 $tests++;
 

--- a/t/08_isHTML_valid.t
+++ b/t/08_isHTML_valid.t
@@ -9,12 +9,12 @@ use Data::Dumper;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $uri="testssl.net";
+my $uri="dev.testssl.sh";
 my $out="";
 my $html="";
 my $debughtml="";
 my $edited_html="";
-my $check2run="--ip=one --color 0 --htmlfile tmp.html";
+my $check2run="--ip=one  --color 0 --htmlfile tmp.html";
 
 die "Unable to open $prg" unless -f $prg;
 

--- a/t/08_isHTML_valid.t
+++ b/t/08_isHTML_valid.t
@@ -9,12 +9,12 @@ use Data::Dumper;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $uri="badssl.com";
+my $uri="testssl.net";
 my $out="";
 my $html="";
 my $debughtml="";
 my $edited_html="";
-my $check2run="--color 0 --htmlfile tmp.html";
+my $check2run="--fast --ip=one --color 0 --htmlfile tmp.html";
 
 die "Unable to open $prg" unless -f $prg;
 
@@ -22,7 +22,7 @@ printf "\n%s\n", "Doing HTML output checks";
 unlink 'tmp.html';
 
 #1
-printf "%s\n", " .. running $prg against $uri to create HTML and terminal outputs (may take 2~3 minutes)";
+printf "%s\n", " .. running $prg against \"$uri\" to create HTML and terminal outputs (may take ~2 minutes)";
 # specify a TERM_WIDTH so that the two calls to testssl.sh don't create HTML files with different values of TERM_WIDTH
 $out = `TERM_WIDTH=120 $prg $check2run $uri`;
 $html = `cat tmp.html`;
@@ -49,7 +49,7 @@ cmp_ok($edited_html, "eq", $out, "HTML file matches terminal output");
 $tests++;
 
 #2
-printf "\n%s\n", " .. running $prg against $uri with --debug 4 to create HTML output (may take another 2~3 minutes)";
+printf "\n%s\n", " .. running again $prg against \"$uri\", now with --debug 4 to create HTML output (may take another ~2 minutes)";
 # Redirect stderr to /dev/null in order to avoid some unexplained "date: invalid date" error messages
 $out = `TERM_WIDTH=120 $prg $check2run --debug 4 $uri 2> /dev/null`;
 $debughtml = `cat tmp.html`;
@@ -68,6 +68,7 @@ $debughtml =~ s/HTTP clock skew              \+?-?[0-9]* /HTTP clock skew       
 
 $debughtml =~ s/ Pre-test: .*\n//g;
 $debughtml =~ s/.*OK: below 825 days.*\n//g;
+$debughtml =~ s/.*DEBUG:.*\n//g;
 
 printf "\n%s\n", " .. checking that using the --debug option doesn't affect the HTML file";
 cmp_ok($debughtml, "eq", $html, "HTML file created with --debug 4 matches HTML file created without --debug");

--- a/t/08_isHTML_valid.t
+++ b/t/08_isHTML_valid.t
@@ -14,7 +14,7 @@ my $out="";
 my $html="";
 my $debughtml="";
 my $edited_html="";
-my $check2run="--fast --ip=one --color 0 --htmlfile tmp.html";
+my $check2run="--ip=one --color 0 --htmlfile tmp.html";
 
 die "Unable to open $prg" unless -f $prg;
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -14801,9 +14801,8 @@ run_ssl_poodle() {
      if "$TLS13_ONLY" || [[ $(has_server_protocol ssl3) -ne 0 ]]; then
           # one condition should normally suffice but we don't know when run_poddle() was called
           pr_svrty_best "not vulnerable (OK)"
-          [[ $DEBUG -ge 1 ]] && out ", no SSLv3 support"
-          outln
-          fileout "$jsonID" "OK" "not vulnerable, no SSLv3 support" "$cve" "$cwe"
+          outln ", no SSLv3 support"
+          fileout "$jsonID" "OK" "not vulnerable, no SSLv3" "$cve" "$cwe"
           return 0
      fi
 
@@ -15530,8 +15529,7 @@ run_beast(){
 
      if "$TLS13_ONLY" || ( [[ $(has_server_protocol ssl3) -eq 1 ]] && [[ $(has_server_protocol tls1) -eq 1 ]] ); then
           pr_svrty_good "not vulnerable (OK)"
-          [[ $DEBUG -ge 1 ]] && out ", no SSL3 or TLS1"
-          outln
+          outln ", no SSL3 or TLS1"
           fileout "$jsonID" "OK" "not vulnerable, no SSL3 or TLS1" "$cve" "$cwe"
           return 0
      fi

--- a/testssl.sh
+++ b/testssl.sh
@@ -8789,7 +8789,7 @@ certificate_info() {
      else
           # All is fine with valididy period
           # We ignore for now certificates < 2018/03/01. On the screen we only show debug info
-          [[ "$DEBUG" -ge 1 ]] && outln "${spaces}DEBUG: all is fine with certificate life time"
+          [[ "$DEBUG" -ge 1 ]] && outln "${spaces}DEBUG: all is fine with total certificate life time"
           fileout "cert_validityPeriod${json_postfix}" "INFO" "No finding"
      fi
 


### PR DESCRIPTION
Several vulnerability checks add a time penalty when the server side only support TLS 1.3 as The TLS 1.3 RFC 8446 and implementations known so far don't support the flaws being checked for.

This PR adds "shortcut" checks for all TLS 1.3, assuming that the TLS 1.3 implementation is correct which seems at this time a valid assumpution. That either saves a TCP connect or at least some logic to be executed.  Also in some cases a TLS 1.3 only server emitted unnecessary warnings, see #1444.

If $DEBUG -eq 1 then it outputs information that a shortcut was used. It doesn't do that in other cases because the screen output seems too obtrusive.

It also adds a shortcut for beast when SSL 3 or TLS 1.0 is is known not to be supported.

This commit readds 747fb039edc329e759aa634fed8a256031808324 which was accidentally reverted in 45f28d816652be59f6d41e7b2200f3325bf04f3e.It fixes #1462.

See also #1459.