### PR TITLE
Fix run_ssl_poodle()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14798,7 +14798,7 @@ run_ssl_poodle() {
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for SSLv3 POODLE (Padding Oracle On Downgraded Legacy Encryption) " && outln
      pr_bold " POODLE, SSL"; out " ($cve)               "
 
-     if "$TLS13_ONLY" || [[ $(has_server_protocol ssl3) -ne 0 ]]; then
+     if "$TLS13_ONLY" || [[ $(has_server_protocol ssl3) -eq 1 ]]; then
           # one condition should normally suffice but we don't know when run_poddle() was called
           pr_svrty_best "not vulnerable (OK)"
           outln ", no SSLv3 support"


### PR DESCRIPTION
PR #1463 changed run_ssl_poodle() to only run the test if it is known that the server supports SSLv3. However, support for SSLv3 may be unknown at the time run_ssl_poodle() is run (e.g., if the server supports both TLS 1 and SSLv3, and run_ssl_poodle() is the first test performed). So, run_ssl_poodle() should perform testing unless it is known that SSLv3 is not supported.