### PR TITLE
Fix HTML generation

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -495,7 +495,7 @@ html_reserved(){
      output="${output//>/&gt;}"
      output="${output//\"/&quot;}"
      output="${output//\'/&apos;}"
-     tm_out "$output"
+     printf -- "%s" "$output"
      return 0
 }
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -490,11 +490,11 @@ html_reserved(){
      local output
      "$do_html" || return 0
      #sed  -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g" <<< "$1"
-     output="${1//\&/\&amp;}"
-     output="${output//</\&lt;}"
-     output="${output//>/\&gt;}"
-     output="${output//\"/\&quot;}"
-     output="${output//\'/\&apos;}"
+     output="${1//&/&amp;}"
+     output="${output//</&lt;}"
+     output="${output//>/&gt;}"
+     output="${output//\"/&quot;}"
+     output="${output//\'/&apos;}"
      tm_out "$output"
      return 0
 }
@@ -510,8 +510,8 @@ safe_echo()  { printf -- "%b" "${1//%/%%}"; }
 tm_out()     { printf -- "%b" "${1//%/%%}"; }
 tmln_out()   { printf -- "%b" "${1//%/%%}\n"; }
 
-out()   { printf -- "%b" "${1//%/%%}"; html_out "$1"; }
-outln() { printf -- "%b" "${1//%/%%}\n"; html_out "$1\n"; }
+out()   { printf -- "%b" "${1//%/%%}"; html_out "$(html_reserved "$1")"; }
+outln() { printf -- "%b" "${1//%/%%}\n"; html_out "$(html_reserved "$1")\n"; }
 
 #TODO: Still no shell injection safe but if just run it from the cmd line: that's fine
 


### PR DESCRIPTION
This PR fixes two issues related to the generation of HTML files.

First, text that is to appear in the HTML file is first passed through `html_reserved()` to replace reserved characters with their corresponding entity names (e.g., '>' becomes '\&gt;'). `html_reserved()` seems to work correctly on Ubuntu Linux, but it does not work as expected on MacOS. On MacOS, rather than converting '>' to '\&gt;', it gets converted to '\\\&gt;', and the backslash is rendered by browsers.

This PR appears to fix the problem -- at least it works on both Ubuntu and MacOS. However, given that the original version of `html_reserved()` was not portable, this revised version should be tested on multiple platforms.

I also noticed that in almost every case in which a string is passed to `html_out()`, it is first run through `html_reserved()`, but for some reason that is not the case in `out()` and `outln()`. I can't see any reason why `html_reserved()` is not called first in these two cases, so this PR adds in the calls.