### PR TITLE
Log cookie names without HttpOnly or secure flags

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3022,6 +3022,16 @@ run_cookie_flags() {     # ARG1: Path
           else
                fileout "cookie_httponly" "INFO" "$nr_secure/$nr_cookies at \"$1\" marked as HttpOnly$msg302_"
           fi
+          IFS=$'; ' read -r -a not_secure <<< $(echo $(awk -F"=" '{print$1}' <<< $(awk -F" " '{print$2}' <<< $(grep -iav secure $TMPFILE))))
+          if [[ -v not_secure ]]; then
+               not_secure_cookies=$(printf '%s,' "${not_secure[@]}")
+               fileout "cookie_not_secure" "INFO" "The cookie(s) with name(s) '${not_secure_cookies::-1}' does not have the secure flag set."
+          fi
+          IFS=$'; ' read -r -a not_httponly <<< $(echo $(awk -F"=" '{print$1}' <<< $(awk -F" " '{print$2}' <<< $(grep -iav httponly $TMPFILE))))
+          if [[ -v not_httponly ]]; then
+               not_httponly_cookies=$(printf '%s,' "${not_httponly[@]}")
+               fileout "cookie_not_httponly" "INFO" "The cookie(s) with name(s) '${not_httponly_cookies::-1}' does not have the httponly flag set."
+          fi
           outln "$msg302"
           allcookies="$(awk '/[Ss][Ee][Tt]-[Cc][Oo][Oo][Kk][Ii][Ee]:/ { print $2 }' "$TMPFILE")"
           sub_f5_bigip_check "$allcookies" "$spaces"

--- a/testssl.sh
+++ b/testssl.sh
@@ -3022,12 +3022,12 @@ run_cookie_flags() {     # ARG1: Path
           else
                fileout "cookie_httponly" "INFO" "$nr_secure/$nr_cookies at \"$1\" marked as HttpOnly$msg302_"
           fi
-          IFS=$'; ' read -r -a not_secure <<< $(echo $(awk -F"=" '{print$1}' <<< $(awk -F" " '{print$2}' <<< $(grep -iav secure $TMPFILE))))
+          IFS=$'; ' read -r -a not_secure <<< $(awk -F"=" '{print$1}' <<< $(awk -F" " '{print$2}' <<< $(grep -iav secure $TMPFILE)))
           if [[ -v not_secure ]]; then
                not_secure_cookies=$(printf '%s,' "${not_secure[@]}")
                fileout "cookie_not_secure" "INFO" "The cookie(s) with name(s) '${not_secure_cookies::-1}' does not have the secure flag set."
           fi
-          IFS=$'; ' read -r -a not_httponly <<< $(echo $(awk -F"=" '{print$1}' <<< $(awk -F" " '{print$2}' <<< $(grep -iav httponly $TMPFILE))))
+          IFS=$'; ' read -r -a not_httponly <<< $(awk -F"=" '{print$1}' <<< $(awk -F" " '{print$2}' <<< $(grep -iav httponly $TMPFILE)))
           if [[ -v not_httponly ]]; then
                not_httponly_cookies=$(printf '%s,' "${not_httponly[@]}")
                fileout "cookie_not_httponly" "INFO" "The cookie(s) with name(s) '${not_httponly_cookies::-1}' does not have the httponly flag set."


### PR DESCRIPTION
This PR adds the functionality to print the Cookie names, which do not have the HttpOnly or secure flag set, in the output file.