### PR TITLE
Fix printing percent characters

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -501,17 +501,16 @@ html_reserved(){
 
 html_out() {
      "$do_html" || return 0
-     [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]] && printf -- "%b" "${1//%/%%}" >> "$HTMLFILE"
-     # here and other printf's: a little bit of sanitizing with bash internal search&replace -- otherwise printf will hiccup at '%'. '--' and %b do the rest.
+     [[ -n "$HTMLFILE" ]] && [[ ! -d "$HTMLFILE" ]] && printf -- "%b" "$1" >> "$HTMLFILE"
 }
 
 # This is intentionally the same.
-safe_echo()  { printf -- "%b" "${1//%/%%}"; }
-tm_out()     { printf -- "%b" "${1//%/%%}"; }
-tmln_out()   { printf -- "%b" "${1//%/%%}\n"; }
+safe_echo()  { printf -- "%b" "$1"; }
+tm_out()     { printf -- "%b" "$1"; }
+tmln_out()   { printf -- "%b" "$1\n"; }
 
-out()   { printf -- "%b" "${1//%/%%}"; html_out "$(html_reserved "$1")"; }
-outln() { printf -- "%b" "${1//%/%%}\n"; html_out "$(html_reserved "$1")\n"; }
+out()   { printf -- "%b" "$1"; html_out "$(html_reserved "$1")"; }
+outln() { printf -- "%b" "$1\n"; html_out "$(html_reserved "$1")\n"; }
 
 #TODO: Still no shell injection safe but if just run it from the cmd line: that's fine
 


### PR DESCRIPTION
As noted in #1481, testssl.sh has a problem with printing percent ('%') characters.

At one point, the function out() was implemented as `/usr/bin/printf -- "${1//%/%%}"`. When this was the case, any '%' needed to be replaced with '%%' since '$1' was being used as the format string. This was changed, however, by https://github.com/drwetter/testssl.sh/commit/8a2fe5915a8d4f70ba423f98eff02a6646935aa9. Since the format string is now "%b" rather than '$1', the replacement is not needed anymore. Instead, the replacement now causes any '%' to be printed to be duplicated.

This problem does not happen very often, but does sometimes occur when a '%' character appears in a URI, such as in an HTTP redirect, a certificate revocation list, or an OCSP URI.