### PR TITLE
Fix Shellcheck SC2197

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2392,7 +2392,7 @@ match_httpheader_key() {
           pr_svrty_medium " ${nr}x"
           outln " -- checking first one only"
           out "$spaces"
-          HEADERVALUE="$(fgrep -Fai "$key:" $HEADERFILE | head -1)"
+          HEADERVALUE="$(grep -Fai "$key:" $HEADERFILE | head -1)"
           HEADERVALUE="${HEADERVALUE#*:}"
           HEADERVALUE="$(strip_lf "$HEADERVALUE")"
           HEADERVALUE="$(strip_leading_space "$HEADERVALUE")"


### PR DESCRIPTION
This PR fixes one Shellcheck issue:
```
In testssl_3.1dev_20200208.sh line 2395:
          HEADERVALUE="$(fgrep -Fai "$key:" $HEADERFILE | head -1)"
                         ^-- SC2197: fgrep is non-standard and deprecated. Use grep -F instead.
```
fgrep -F is just redundant.