### PR TITLE
Remove non-printables in rDNS when pretty printing JSON (fixes #1506)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1092,7 +1092,7 @@ fileout_json_finding() {
                     \"ip\"              : \"$NODEIP\",
                     \"port\"            : \"$PORT\",
                     \"rDNS\"            : \"$rDNS\",
-                    \"service\"         : \"$finding\"," >> "$JSONFILE"
+                    \"service\"         : \"$finding\"," | tr -dc '[:print:]' >> "$JSONFILE"
                $do_mx_all_ips && echo -e "                    \"hostname\"        : \"$NODE\","  >> "$JSONFILE"
           else
                ("$FIRST_FINDING" && echo -n "                            {" >> "$JSONFILE") || echo -n ",{" >> "$JSONFILE"


### PR DESCRIPTION
In some rare cases when results are pretty printed in JSON format,
non-printable characters, e.g., control characters, appear in rDNS
output (see #1506). Simple data sanitization solves this.

**NOTE**: this PR does not explain why such error happens in first place, so it is rather a workaround than a proper solution.