### PR TITLE
Fix for non compliant DNS PTR records

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19209,7 +19209,7 @@ determine_ip_addresses() {
 
 determine_rdns() {
      local saved_openssl_conf="$OPENSSL_CONF"
-     local nodeip=""
+     local nodeip="" rdns="" line=""
 
      [[ -n "$NODNS" ]] && rDNS="(instructed to minimize DNS queries)" && return 0   # PTR records were not asked for
      local nodeip="$(tr -d '[]' <<< $NODEIP)"     # for DNS we do not need the square brackets of IPv6 addresses
@@ -19231,10 +19231,15 @@ determine_rdns() {
           rDNS=$(strip_lf "$(nslookup -type=PTR $nodeip 2>/dev/null | grep -v 'canonical name =' | grep 'name = ' | awk '{ print $NF }' | sed 's/\.$//')")
      fi
      OPENSSL_CONF="$saved_openssl_conf"      # see https://github.com/drwetter/testssl.sh/issues/134
-     rDNS="$(echo $rDNS)"
-     # remove chars which under weird circumstances can show up here
-     rDNS=${rDNS// /}
-     rDNS=${rDNS//;/}
+     # First, rDNS can contain multilines due to multiple PTR DNS records, though this is not recommended.
+     # So we use a loop to check for each FQDN returned. There we remove chars which under weird
+     # circumstances (see #1506) can show up here. The blacklist is taken from RFC 1912 ("Allowable characters in a
+     # label for a host name are only ASCII, letters, digits, and the `-' character")
+     while read -r line; do
+          line="$(tr -dc '[a-zA-Z0-9-_.]' <<< "$line")"
+          [[ -z "$rdns" ]] && rdns="$line" || rdns="$rdns $line"
+     done <<< "$rDNS"
+     rDNS="$rdns"
      [[ -z "$rDNS" ]] && rDNS="--"
      return 0
 }


### PR DESCRIPTION
This commit addresses two bugs: #1506 and #1508.

First, the variable rDNS can contain multiple lines due to multiple PTR DNS
records, though this is not recommended.  In those cases the multiple PTR DNS
were concatenated on the screen, without any blank.

Secondly - depending on the name server entries and on the output of the DNS
binaries used it can contain non-printable characters or characters which are
printable but later on interpreted on the output device (\032 was mentioned
in #1506) which on the screen was interpreted as octal 32 (decimal 26 = ▒,
try echo "\032"), so basically a terminal escape sequence was smuggled
from the DNS server to the screen of the users. In JSON pretty output we
had also this escape sequence which was fine for ``jsonlint`` but caused ``jq``
to hiccup.

Fix: we use a loop to check for each FQDN returned. There we remove chars which
under those circumstances can show up. The blacklist is mostly taken from RFC 1912
("Allowable characters in a label for a host name are only ASCII, letters, digits,
and the `-' character").