### PR TITLE
Avoid external "/bin/pwd"

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7293,7 +7293,7 @@ extract_certificates() {
 
      # Place the server's certificate in $HOSTCERT and any intermediate
      # certificates that were provided in $TEMPDIR/intermediatecerts.pem
-     savedir=$(pwd -P); cd $TEMPDIR
+     savedir="$PWD"; cd $TEMPDIR
      # http://backreference.org/2010/05/09/ocsp-verification-with-openssl/
      if [[ "$version" == ssl2 ]]; then
           awk -v n=-1 '/Server certificate/ {start=1}
@@ -18035,9 +18035,9 @@ find_openssl_binary() {
 
      openssl_location="$(type -p $OPENSSL)"
      [[ -n "$GIT_REL" ]] && \
-          cwd="$(pwd -P)" || \
+          cwd="$PWD" || \
           cwd="$RUN_DIR"
-     if [[ "$openssl_location" =~ $(pwd -P)/bin ]]; then
+     if [[ "$openssl_location" == ${PWD}/bin ]]; then
           OPENSSL_LOCATION="\$PWD/bin/$(basename "$openssl_location")"
      elif [[ "$openssl_location" =~ $cwd ]] && [[ "$cwd" != '.' ]]; then
           OPENSSL_LOCATION="${openssl_location%%$cwd}"

--- a/testssl.sh
+++ b/testssl.sh
@@ -7293,7 +7293,7 @@ extract_certificates() {
 
      # Place the server's certificate in $HOSTCERT and any intermediate
      # certificates that were provided in $TEMPDIR/intermediatecerts.pem
-     savedir=$(pwd); cd $TEMPDIR
+     savedir=$(pwd -P); cd $TEMPDIR
      # http://backreference.org/2010/05/09/ocsp-verification-with-openssl/
      if [[ "$version" == ssl2 ]]; then
           awk -v n=-1 '/Server certificate/ {start=1}
@@ -18035,9 +18035,9 @@ find_openssl_binary() {
 
      openssl_location="$(type -p $OPENSSL)"
      [[ -n "$GIT_REL" ]] && \
-          cwd="$(/bin/pwd)" || \
+          cwd="$(pwd -P)" || \
           cwd="$RUN_DIR"
-     if [[ "$openssl_location" =~ $(/bin/pwd)/bin ]]; then
+     if [[ "$openssl_location" =~ $(pwd -P)/bin ]]; then
           OPENSSL_LOCATION="\$PWD/bin/$(basename "$openssl_location")"
      elif [[ "$openssl_location" =~ $cwd ]] && [[ "$cwd" != '.' ]]; then
           OPENSSL_LOCATION="${openssl_location%%$cwd}"


### PR DESCRIPTION
.. as it may not be available everywhere, see #1521 (NixOS).
    
This commit replaces all instances from pwd or /bin/pwd by $PWD.  It is a bash internal and the fastest. Also it adds some quotes to PWD a it may contain white spaces in the future (there was a check for it that it won't)
