### PR TITLE
Fix basicauth bug where a newline is added to the user:password string before encoding

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19606,7 +19606,7 @@ determine_service() {
                ua="$UA_SNEAKY" || \
                ua="$UA_STD"
           if [[ -n "$BASICAUTH" ]]; then
-               basicauth_header="Authorization: Basic $($OPENSSL base64 <<< "$BASICAUTH" 2>/dev/null)\r\n"
+               basicauth_header="Authorization: Basic $(echo -n "$BASICAUTH" | $OPENSSL base64 2>/dev/null)\r\n"
           fi
           GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n${basicauth_header}Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
           # returns always 0:

--- a/testssl.sh
+++ b/testssl.sh
@@ -19606,7 +19606,7 @@ determine_service() {
                ua="$UA_SNEAKY" || \
                ua="$UA_STD"
           if [[ -n "$BASICAUTH" ]]; then
-               basicauth_header="Authorization: Basic $(echo -n "$BASICAUTH" | $OPENSSL base64 2>/dev/null)\r\n"
+               basicauth_header="Authorization: Basic $(safe_echo "$BASICAUTH" | $OPENSSL base64 2>/dev/null)\r\n"
           fi
           GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n${basicauth_header}Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
           # returns always 0:


### PR DESCRIPTION
I have found a bug in the implementation of the basicauth feature which was probably introduced in commit https://github.com/drwetter/testssl.sh/pull/1452/commits/4603d924be47959a8734b5245ed8a4a1b3fd38df. 

The problem here is that the command "openssl base64 <<< $BASICAUTH" adds a newline at the end of the string which results in a differen base64 encoding.

Example:

openssl base64 <<< "user:password" -> dXNlcjpwYXNzd29yZAo=

However, it should rather look like the following.

echo -n "user:password" | openssl base64 -> dXNlcjpwYXNzd29yZA==

I don't see a better solution without using the "echo" command here. If you have better suggestions, let me know.

Best regards

Manuel