### PR TITLE
Redirect printf error output to /dev/null

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2071,7 +2071,7 @@ service_detection() {
                fi
           else
                # SNI is not standardized for !HTTPS but fortunately for other protocols s_client doesn't seem to care
-               printf "$GET_REQ11" | $OPENSSL s_client $(s_client_options "$1 -quiet $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE &
+               printf "$GET_REQ11" 2>/dev/null | $OPENSSL s_client $(s_client_options "$1 -quiet $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE &
                wait_kill $! $HEADER_MAXSLEEP
                was_killed=$?
           fi


### PR DESCRIPTION
When scanning a URL which includes a percentage character,  one of the printf calls generates an error.  I have fixed this issue by redirecting stderr to /dev/null.

Example of the bug:
When calling testssl.sh with: 

./testssl.sh https://bruzzzla.de/index.php?test=% 

the following error occures:
/testssl.sh: line 2074: printf: `H': invalid format character

This PR fixes the issue.
