### PR TITLE
Fix bug in setting DISPLAY_CIPHERNAMES

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17931,7 +17931,7 @@ get_install_dir() {
      fi
 
      if [[ ! -r "$CIPHERS_BY_STRENGTH_FILE" ]]; then
-          DISPLAY_CIPHERNAMES="no-rfc"
+          DISPLAY_CIPHERNAMES="openssl-only"
           debugme echo "$CIPHERS_BY_STRENGTH_FILE"
           prln_warning "\nATTENTION: No cipher mapping file found!"
           outln "Please note from 2.9 on $PROG_NAME needs files in \"\$TESTSSL_INSTALL_DIR/etc/\" to function correctly."


### PR DESCRIPTION
The permitted values for `$DISPLAY_CIPHERNAMES` are "rfc-only", "openssl-only", "openssl", and "rfc". However, `get_install_dir()` incorrectly sets `$DISPLAY_CIPHERNAMES` to "no-rfc" if it cannot find the `$CIPHERS_BY_STRENGTH_FILE`. ("no-rfc" is the string users would specify at the command line for the `--mapping` option, but not the value that `$DISPLAY_CIPHERNAMES` is set to internally).