### PR TITLE
Adjust pr_cipher_quality ratings

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5948,7 +5948,7 @@ pr_cipher_quality() {
                # We have an OpenSSL name and can't convert it to the RFC name which is rarely
                # the case, see "prepare_arrays()" and "./etc/cipher-mapping.txt"
                case "$cipher" in
-                    *NULL*|EXP*|ADH*|AECDH*)
+                    *NULL*|EXP*|ADH*|AECDH*|*anon*)
                          pr_svrty_critical "$text"
                          return 1
                          ;;
@@ -5983,7 +5983,7 @@ pr_cipher_quality() {
                          pr_svrty_best "$text"
                          return 7
                          ;; #best ones
-                    *AES*SHA*|*CAMELLIA*SHA*|*SEED*SHA*)
+                    *AES*SHA*|*CAMELLIA*SHA*|*SEED*SHA*|*CBC*)
                          pr_svrty_low "$text"
                          return 4
                          ;;

--- a/testssl.sh
+++ b/testssl.sh
@@ -5948,7 +5948,7 @@ pr_cipher_quality() {
                # We have an OpenSSL name and can't convert it to the RFC name which is rarely
                # the case, see "prepare_arrays()" and "./etc/cipher-mapping.txt"
                case "$cipher" in
-                    *NULL*|EXP*|ADH*)
+                    *NULL*|EXP*|ADH*|AECDH*)
                          pr_svrty_critical "$text"
                          return 1
                          ;;
@@ -5956,8 +5956,26 @@ pr_cipher_quality() {
                          pr_svrty_high "$text"
                          return 2
                          ;;
-                    AES256-GCM-SHA384|AES128-GCM-SHA256|AES256-CCM|AES128-CCM|ARIA256-GCM-SHA384|ARIA128-GCM-SHA256)
+                    AES256-GCM-SHA384|AES128-GCM-SHA256|AES256-CCM*|AES128-CCM*|ARIA256-GCM-SHA384|ARIA128-GCM-SHA256)
                          # RSA kx and e.g. GCM isn't certainly the best
+                         pr_svrty_good "$text"
+                         return 6
+                         ;;
+                    *CBC3*|*3DES*|*IDEA*)
+                         pr_svrty_medium "$text"
+                         return 3
+                         ;;
+                    *DES*)
+                         pr_svrty_high "$text"
+                         return 2
+                         ;;
+                    PSK-*GCM*|PSK-*CCM*|RSA-PSK-*GCM*|RSA-PSK-CHACHA20-POLY1305|PSK-CHACHA20-POLY1305|PSK-ARIA*-GCM-SHA*|RSA-PSK-ARIA*-GCM-SHA*)
+                         # PSK kx and e.g. GCM isn't certainly the best
+                         pr_svrty_good "$text"
+                         return 6
+                         ;;
+                    DH-*GCM*|ECDH-*GCM*)
+                         # static DH or ECDH kx and GCM isn't certainly the best
                          pr_svrty_good "$text"
                          return 6
                          ;;
@@ -5965,11 +5983,7 @@ pr_cipher_quality() {
                          pr_svrty_best "$text"
                          return 7
                          ;; #best ones
-                    *CBC3*|*SEED*|*3DES*|*IDEA*)
-                         pr_svrty_medium "$text"
-                         return 3
-                         ;;
-                    ECDHE*AES*|DHE*AES*SHA*|*CAMELLIA*SHA)
+                    *AES*SHA*|*CAMELLIA*SHA*|*SEED*SHA*)
                          pr_svrty_low "$text"
                          return 4
                          ;;
@@ -6000,27 +6014,22 @@ pr_cipher_quality() {
                pr_svrty_high "$text"
                return 2
                ;;
-          *CBC3*|*SEED*|*3DES*|*IDEA*)
+          *CBC3*|*3DES*|*IDEA*)
                pr_svrty_medium "$text"
                return 3
                ;;
-          TLS_RSA_*)
-               if [[ "$cipher" =~ CBC ]]; then
-                    pr_svrty_low "$text"
-                    return 4
-               else
-                    pr_svrty_good "$text"
-                    # RSA kx and e.g. GCM isn't certainly the best
-                    return 6
-               fi
+          *CBC*)
+               pr_svrty_low "$text"
+               return 4
+               ;;
+          TLS_RSA_*|TLS_DH_*|TLS_ECDH_*|TLS_PSK_WITH_*)
+               pr_svrty_good "$text"
+               # RSA, or static DH, ECDH, or PSK kx and e.g. GCM isn't certainly the best
+               return 6
                ;;
           *GCM*|*CCM*|*CHACHA20*)
                pr_svrty_best "$text"
                return 7
-               ;;
-          *ECDHE*AES*CBC*|*DHE*AES*SHA*|*RSA*AES*SHA*|*CAMELLIA*SHA*)
-               pr_svrty_low "$text"
-               return 4
                ;;
           *)
                out "$text"

--- a/testssl.sh
+++ b/testssl.sh
@@ -5969,7 +5969,7 @@ pr_cipher_quality() {
                          pr_svrty_high "$text"
                          return 2
                          ;;
-                    PSK-*GCM*|PSK-*CCM*|RSA-PSK-*GCM*|RSA-PSK-CHACHA20-POLY1305|PSK-CHACHA20-POLY1305|PSK-ARIA*-GCM-SHA*|RSA-PSK-ARIA*-GCM-SHA*)
+                    PSK-*GCM*|PSK-*CCM*|RSA-PSK-*GCM*|RSA-PSK-CHACHA20-POLY1305|PSK-CHACHA20-POLY1305)
                          # PSK kx and e.g. GCM isn't certainly the best
                          pr_svrty_good "$text"
                          return 6


### PR DESCRIPTION
This PR makes several changes to the way that ciphers are rated by `pr_cipher_quality`:

* It upgrades SEED ciphers to be considered as strong as the corresponding AES ciphers.

* It downgrades ciphers that use AEAD, but that use a non-FS key exchange (TLS_DH_\*, TLS_ECDH_\*, TLS_PSK_WITH_\*) from best to good, thus giving them the same rating as AEAD ciphers that use static RSA (TLS_RSA_\*).

* It downgrades some CBC ciphers to low (4) that are currently rated as neither good nor bad (5).

* It modifies the ratings created using OpenSSL names to provide the same ratings as those created using RFC names.

One issue that is not addressed by the PR is the GOST ciphers. `pr_cipher_quality` doesn't really handle the GOST ciphers at the moment and so their ratings are somewhat arbitrary.

This PR also does not make any changes to `run_cipherlists`. A next step could be to change `run_cipherlists` so that its ratings are the same as `pr_cipher_quality`. At the least, this would involve separating the AEAD ciphers into those that offer FS and those that do not. I don't know whether any other changes would be required.