### PR TITLE
update censys.io link on line number 16622

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -16619,7 +16619,7 @@ run_drown() {
                if [[ -n "$cert_fingerprint_sha2" ]]; then
                     outln "$spaces make sure you don't use this certificate elsewhere with SSLv2 enabled services"
                     out "$spaces "
-                    pr_url "https://censys.io/ipv4?q=$cert_fingerprint_sha2"
+                    pr_url "https://censys.io/certificates/$cert_fingerprint_sha2"
                     outln " could help you to find out"
                     fileout "${jsonID}_hint" "INFO" "Make sure you don't use this certificate elsewhere with SSLv2 enabled services, see https://censys.io/ipv4?q=$cert_fingerprint_sha2" "$cve" "$cwe"
                else


### PR DESCRIPTION
Now, link is currently pointing to certificate. previously, link was pointing to ipv4/portion folder on censys.io site
this change will solve issue number 1562 -> https://github.com/drwetter/testssl.sh/issues/1562