### PR TITLE
Trying to address no STARTTLS offerings (WIP)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10363,7 +10363,7 @@ starttls_mysql_dialog() {
      x00, x00, x00, x00, x00, x00, x00, x00,
      x00, x00, x00, x00, x00, x00, x00"
      socksend "${login_request}" 0
-     starttls_just_read 1                    && debugme echo "read succeeded"
+     starttls_just_read 1                    "read succeeded"
      # 1 is the timeout value which only MySQL needs. Note, there seems no response whether STARTTLS
      # succeeded. We could try harder, see https://github.com/openssl/openssl/blob/master/apps/s_client.c
      # but atm this seems sufficient as later we will fail if there's no STARTTLS.


### PR DESCRIPTION
As noted in #1536 if the server side doesn't show STARTTLS testssl.sh should exit and label it accordingly.

This is an attempt to address that. It does that by using an early exit using ``fatal().`

For this to achieve the starttls*dialog() functions were changed so that a return value from ``starttls_full_read()`` of 3, signalling the STARTTLS pattern wasn't found is passed back to
the parent ``fd_socket()``.

Furthermore:
  * ``starttls*dialog()`` functions' debug statements were moved into ``starttls_full_read()`` / ``starttls_just_send()``
  * ``starttls_full_read()`` + ``starttls_just_send()`` were improved for readability and debugging
  * minor bugs were squashed (e.g. ``fd_socket()``'s return values =!0 always  were referring to STARTTLS also when no STARTTLS was requested)

This was tested (negative + test and positive) for FTP and SMTP which worked as expected. For IMAP this needs to be done. The POP3 server side doesn't seem to advertise STARTTLS (TBC), for
NNTP I haven't bothered to look at it.

XMPP and postgreSQL use ``starttls_io()`` which need to be changed as well.

