### PR TITLE
Fix typo in Strong grade Ciphers AEAD docs

### DIFF
--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -240,7 +240,7 @@ ADDITIONAL_CA_FILES is the environment variable for this.</p>
 <li><code>LOW</code> (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'</li>
 <li><code>3DES + IDEA Ciphers</code>: '3DES:IDEA:!aNULL:!ADH'</li>
 <li><code>Average grade Ciphers</code>: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'</li>
-<li><code>Strong grade Ciphers</code> (AEAD): 'AESGCM:CHACHA20:AESGCM:CamelliaGCM:AESCCM8:AESCCM'</li>
+<li><code>Strong grade Ciphers</code> (AEAD): 'AESGCM:CHACHA20:ARIAGCM:CamelliaGCM:AESCCM8:AESCCM'</li>
 </ul>
 
 


### PR DESCRIPTION
Thanks for an awesome tool.
<li><code>Strong grade Ciphers</code> (AEAD): 'AESGCM:CHACHA20:AESGCM:CamelliaGCM:AESCCM8:AESCCM'</li>
The Strong AEAD ciphers on line 243 above don't make sense. I suspect a copy paste bug. The 2nd AESGCM should be ARIAGCM no?
Sorry I haven't checked the code to see if the same issue is in the code or if this was just a documentation glitch.