### PR TITLE
Less aggresive TLS_FALLBACK_SCVS checks

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -16183,7 +16183,6 @@ run_tls_fallback_scsv() {
      if [[ "$OPTIMAL_PROTO" == -ssl2 ]]; then
           prln_svrty_critical "No fallback possible, SSLv2 is the only protocol"
           fileout "$jsonID" "CRITICAL" "SSLv2 is the only protocol"
-          set_grade_cap "A" "Does not support TLS_FALLBACK_SCSV"
           return 0
      fi
      for p in tls1_2 tls1_1 tls1 ssl3; do
@@ -16212,7 +16211,6 @@ run_tls_fallback_scsv() {
           "ssl3")
                prln_svrty_high "No fallback possible, SSLv3 is the only protocol"
                fileout "$jsonID" "HIGH" "only SSLv3 supported"
-               set_grade_cap "A" "Does not support TLS_FALLBACK_SCSV"
                return 0
                ;;
           *)   if [[ $(has_server_protocol tls1_3) -eq 0 ]]; then
@@ -16220,7 +16218,6 @@ run_tls_fallback_scsv() {
                     # then assume it does not support SSLv3, even if SSLv3 cannot be tested.
                     pr_svrty_good "No fallback possible (OK)"; outln ", TLS 1.3 is the only protocol"
                     fileout "$jsonID" "OK" "only TLS 1.3 supported"
-                    set_grade_cap "A" "Does not support TLS_FALLBACK_SCSV"
                elif [[ $(has_server_protocol tls1_3) -eq 1 ]] && \
                     ( [[ $(has_server_protocol ssl3) -eq 1 ]] || "$HAS_SSL3" ); then
                     # TLS 1.3, TLS 1.2, TLS 1.1, TLS 1, and SSLv3 are all not supported.
@@ -16234,7 +16231,6 @@ run_tls_fallback_scsv() {
                     # it is very likely that SSLv3 is the only supported protocol.
                     pr_svrty_high "NOT ok, no fallback possible"; outln ", TLS 1.3, 1.2, 1.1 and 1.0 not supported"
                     fileout "$jsonID" "HIGH" "TLS 1.3, 1.2, 1.1, 1.0 not supported"
-                    set_grade_cap "A" "Does not support TLS_FALLBACK_SCSV"
                else
                     # TLS 1.2, TLS 1.1, and TLS 1 are not supported, but can't tell whether TLS 1.3 is supported.
                     # This could be a TLS 1.3 only server, an SSLv3 only server (if SSLv3 support cannot be tested),
@@ -16242,7 +16238,6 @@ run_tls_fallback_scsv() {
                     # since this could either be good or bad.
                     outln "No fallback possible, TLS 1.2, TLS 1.1, and TLS 1 not supported"
                     fileout "$jsonID" "INFO" "TLS 1.2, TLS 1.1, and TLS 1 not supported"
-                    set_grade_cap "A" "Does not support TLS_FALLBACK_SCSV"
                fi
                return 0
      esac
@@ -16287,7 +16282,6 @@ run_tls_fallback_scsv() {
                     ;;
           esac
           fileout "$jsonID" "OK" "no protocol below $high_proto_str offered"
-          set_grade_cap "A" "Does not support TLS_FALLBACK_SCSV"
           return 0
      fi
      case "$low_proto" in


### PR DESCRIPTION
We assume that "no fallback possible" (due to lack of protocols), is okay.
TestSSL does not check actual support, if it isn't available due to lack of protocols.

EDIT: This is also what Qualys does (though its poorly documented):
`Downgrade attack prevention | Unknown (requires support for at least two protocols, excl. SSL2)`
(From random recent best: https://www.ssllabs.com/ssltest/analyze.html?d=www.x%2dbankgallery.com)

A random A+ rating on Qualys (recent best), gives this:
```
Calculating grades (experimental)

Grading specs, not complete  SSL Labs's 'SSL Server Rating Guide' (version 2009q from 2020-01-30)
Specification documentation  https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide
Protocol Support (weighted)  100 (30)
Key Exchange     (weighted)  90 (27)
Cipher Strength  (weighted)  90 (36)
Final Score                  93
Grade                        A+
```
And an internal server that does not support it:
```
Calculating grades (experimental)

Grading specs, not complete  SSL Labs's 'SSL Server Rating Guide' (version 2009q from 2020-01-30)
Specification documentation  https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide
Protocol Support (weighted)  85 (25)
Key Exchange     (weighted)  90 (27)
Cipher Strength  (weighted)  90 (36)
Final Score                  88
Grade                        C
Grade cap reasons            Grade capped to C. Vulnerable to POODLE
                             Grade capped to A. Does not support TLS_FALLBACK_SCSV
```