### PR TITLE
 WIP: Extended run_server_preference()

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -46,10 +46,10 @@ Any OpenSSL or LibreSSL version is needed as a helper\. Unlike previous versions
 2) standard cipher categories to give you upfront an idea for the ciphers supported
 .
 .P
-3) checks forward secrecy: ciphers and elliptical curves
+3) server's cipher preferences (server order)
 .
 .P
-4) server preferences (server order)
+4) forward secrecy: ciphers and elliptical curves
 .
 .P
 5) server defaults (certificate info, TLS extensions, session information)
@@ -61,10 +61,7 @@ Any OpenSSL or LibreSSL version is needed as a helper\. Unlike previous versions
 7) vulnerabilities
 .
 .P
-8) testing each of 370 preconfigured ciphers
-.
-.P
-9) client simulation
+8) client simulation
 .
 .SH "OPTIONS AND PARAMETERS"
 Options are either short or long options\. Any long or short option requiring a value can be called with or without an equal sign\. E\.g\. \fBtestssl\.sh \-t=smtp \-\-wide \-\-openssl=/usr/bin/openssl <URI>\fR (short options with equal sign) is equivalent to \fBtestssl\.sh \-\-starttls smtp \-\-wide \-\-openssl /usr/bin/openssl <URI>\fR (long option without equal sign)\. Some command line options can also be preset via ENV variables\. \fBWIDE=true OPENSSL=/usr/bin/openssl testssl\.sh \-\-starttls=smtp <URI>\fR would be the equivalent to the aforementioned examples\. Preference has the command line over any environment variables\.

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -123,9 +123,9 @@ linked OpenSSL binaries for major operating systems are supplied in <code>./bin/
 
 <p>2) standard cipher categories to give you upfront an idea for the ciphers supported</p>
 
-<p>3) checks forward secrecy: ciphers and elliptical curves</p>
+<p>3) server's cipher preferences (server order)</p>
 
-<p>4) server preferences (server order)</p>
+<p>4) forward secrecy: ciphers and elliptical curves</p>
 
 <p>5) server defaults (certificate info, TLS extensions, session information)</p>
 
@@ -133,9 +133,7 @@ linked OpenSSL binaries for major operating systems are supplied in <code>./bin/
 
 <p>7) vulnerabilities</p>
 
-<p>8) testing each of 370 preconfigured ciphers</p>
-
-<p>9) client simulation</p>
+<p>8) client simulation</p>
 
 <h2 id="OPTIONS-AND-PARAMETERS">OPTIONS AND PARAMETERS</h2>
 

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -42,9 +42,9 @@ linked OpenSSL binaries for major operating systems are supplied in `./bin/`.
 
 2) standard cipher categories to give you upfront an idea for the ciphers supported
 
-3) checks forward secrecy: ciphers and elliptical curves
+3) server's cipher preferences (server order?)
 
-4) server preferences (server order)
+4) forward secrecy: ciphers and elliptical curves
 
 5) server defaults (certificate info, TLS extensions, session information)
 
@@ -52,9 +52,7 @@ linked OpenSSL binaries for major operating systems are supplied in `./bin/`.
 
 7) vulnerabilities
 
-8) testing each of 370 preconfigured ciphers
-
-9) client simulation
+8) client simulation
 
 
 ## OPTIONS AND PARAMETERS


### PR DESCRIPTION
This is a working branch for @dcooper16's PR #1580. 

Aim is eventually to ``run server_preference()`` in wide mode. This PR is supposed to help to get this finalized an merged into 3.1dev


### Details from #1580:

This PR extends `run_server_preference()` to list every cipher supported by each protocol even in cases in which the server does not enforce a preference order.

For protocols where the server enforces a cipher order the list of supported ciphers is ordered by server preference (as now). For protocols where the server does not enforce a cipher order, the ciphers are listed by encryption strength (as `run_cipher_per_proto()` does).

In order to implement this, `ciphers_by_strength()` was extended to offer a non-wide mode.

This PR is currently marked as a work-in-progress since the output needs improvement:

- The section is labelled "Cipher order" even if the server does not enforce a cipher order.
- In wide mode, the text explaining for which protocols ciphers are ordered by server order versus strength may not be clear.
- In non-wide mode, there is no indicator at all of which ordering is being used for each protocol.
- I am not sure whether the JSON/CSV output (particularly the labels) are the best for automated processing (different labels for the list of supported ciphers depending on which way they are ordered).

[Details from #1580  (done)]