### PR TITLE
Fix run_logjam() in --ssl-native mode

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -16413,15 +16413,13 @@ run_logjam() {
           tls_sockets "03" "$exportdh_cipher_list_hex, 00,ff"
           sclient_success=$?
           [[ $sclient_success -eq 2 ]] && sclient_success=0
+          [[ $sclient_success -eq 0 ]] && vuln_exportdh_ciphers=true
      elif [[ $nr_supported_ciphers -ne 0 ]]; then
           $OPENSSL s_client $(s_client_options "$STARTTLS $BUGS -cipher $exportdh_cipher_list -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE </dev/null
           sclient_connect_successful $? $TMPFILE
-          sclient_success=$?
+          [[ $? -eq 0 ]] && vuln_exportdh_ciphers=true
           debugme grep -Ea "error|failure" $ERRFILE | grep -Eav "unable to get local|verify error"
      fi
-     [[ $sclient_success -eq 0 ]] && \
-          vuln_exportdh_ciphers=true || \
-          vuln_exportdh_ciphers=false
 
      if [[ $DEBUG -ge 2 ]]; then
           if "$using_sockets"; then


### PR DESCRIPTION
This PR fixes a problem with `run_logjam()` when run in `--ssl-native` mode. If $OPENSSL does not support any DH export ciphers, then no test for such cipher is performed. However, the results of "test" is still checked, leading to testssl.sh incorrectly reporting that the server supports DH EXPORT ciphers.

Note that while this PR gets rid of the false positive (if the server really doesn't support DH EXPORT ciphers), the output is still misleading:
```
 LOGJAM (CVE-2015-4000), experimental      Local problem: /usr/bin/openssl doesn't have any DH EXPORT ciphers configured
                                           not vulnerable (OK): no DH EXPORT ciphers, no DH key detected with <= TLS 1.2
```
Since testssl.sh can't test for DH EXPORT ciphers, it reports "no DH EXPORT ciphers" even if the server really does support these ciphers.