### PR TITLE
Check server's response

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -12793,7 +12793,8 @@ parse_tls_serverhello() {
                     [[ $DEBUG -ge 1 ]] && tmpfile_handle ${FUNCNAME[0]}.txt
                     return 3
                fi
-          elif [[ $tls_content_type != 14 ]] && [[ $tls_content_type != 15 ]] && \
+          fi
+          if [[ $tls_content_type != 14 ]] && [[ $tls_content_type != 15 ]] && \
                [[ $tls_content_type != 16 ]] && [[ $tls_content_type != 17 ]]; then
                debugme tmln_warning "Content type other than alert, handshake, change cipher spec, or application data detected."
                [[ $DEBUG -ge 1 ]] && tmpfile_handle ${FUNCNAME[0]}.txt


### PR DESCRIPTION
There is code at the beginning of `parse_tls_serverhello()` that checks whether the server's response appears to consist of a sequence of messages of the form \<protocol\>\<content type\>\<content\>. However, at the moment the check is only performed if `$do_starttls` is false. This commit changes `parse_tls_serverhello()` so that the check is always performed.