### PR TITLE
tls_sockets() return value

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -12809,7 +12809,7 @@ parse_tls_serverhello() {
                [[ $tls_content_type != 16 ]] && [[ $tls_content_type != 17 ]]; then
                debugme tmln_warning "Content type other than alert, handshake, change cipher spec, or application data detected."
                [[ $DEBUG -ge 1 ]] && tmpfile_handle ${FUNCNAME[0]}.txt
-               return 8
+               return 1
           elif [[ "${tls_protocol:0:2}" != 03 ]]; then
                debugme tmln_warning "Protocol record_version.major is not 03."
                [[ $DEBUG -ge 1 ]] && tmpfile_handle ${FUNCNAME[0]}.txt


### PR DESCRIPTION
There is one place in `parse_tls_serverhello()` that returns 8 if the server's response is not well-formed TLS. However, there is no code in testssl.sh that is prepared to handle this return value. Every function except `run_protocols()` only distinguishes between 0, 2, and everything else. `run_protocols()`, however, gets confused if `tls_sockets()` returns a value that it is not expecting. So, this commit changes `parse_tls_serverhello()` to return 1 whenever the server's response can not be parsed.