### PR TITLE
Provide the correct branch to Dockerhub builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN ln -s /home/testssl/testssl.sh /usr/local/bin/
 USER testssl
 WORKDIR /home/testssl/
 
-RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git .
+RUN git clone -b 3.0 --depth=1 https://github.com/drwetter/testssl.sh.git .
 
 ENTRYPOINT ["testssl.sh"]
 


### PR DESCRIPTION
... and at the same time allow correct local builds --
the default branch is 3.1dev at the moment.

It still clones the repo from github which isn't
needed. A pure copy command would be the best. However
it might cause other problems.

See also #1559