### PR TITLE
Rate RSA e=1 as CRITICAL

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8535,9 +8535,14 @@ certificate_info() {
                  cert_spki_info="$(strip_leading_space "$cert_spki_info")"
                  cert_spki_info="${cert_spki_info%%[[:space:]]*}"
                  if [[ -n "$cert_spki_info" ]]; then
-                      out " (exponent is $cert_spki_info)"
+                      if [[ $cert_spki_info -eq 1 ]]; then
+                           out " (exponent is "; pr_svrty_critical "$cert_spki_info"; out ")"
+                           json_rating="CRITICAL"
+                           set_grade_cap "F" "RSA certificate uses exponent of 1"
+                      else
+                           out " (exponent is $cert_spki_info)"
+                      fi
                       json_msg+=" (exponent is $cert_spki_info)"
-                      [[ $cert_spki_info -eq 1 ]] && set_grade_cap "F" "RSA certificate uses exponent of 1"
                  fi
                  ;;
           "EC")  cert_spki_info="${cert_txt##*Subject Public Key Info:}"


### PR DESCRIPTION
PR #1619 set the grade cap to 'F' if the server has a certificate with an RSA public key with e=1. However, it did not change the rating in the JSON/CSV output. This commit changes the cert_keySize rating to CRITICAL for an RSA key with e=1, regardless of the size of the modulus. It also uses `pr_svrty_critical()` to print the exponent in this case.