### PR TITLE
Implement $HAS_SIGALGS

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -307,6 +307,7 @@ HAS_SSL3=false
 HAS_TLS13=false
 HAS_X448=false
 HAS_X25519=false
+HAS_SIGALGS=false
 HAS_PKUTIL=false
 HAS_PKEY=false
 HAS_NO_SSL2=false
@@ -7542,7 +7543,7 @@ get_server_certificate() {
      CERTIFICATE_LIST_ORDERING_PROBLEM=false
      if [[ "$1" =~ "tls1_3" ]]; then
           [[ $(has_server_protocol "tls1_3") -eq 1 ]] && return 1
-          if "$HAS_TLS13"; then
+          if "$HAS_TLS13" && "$HAS_SIGALGS"; then
                if [[ "$1" =~ "tls1_3_RSA" ]]; then
                     $OPENSSL s_client $(s_client_options "$STARTTLS $BUGS -showcerts -connect $NODEIP:$PORT $PROXY $SNI -tls1_3 -tlsextdebug -status -msg -sigalgs PSS+SHA256:PSS+SHA384") </dev/null 2>$ERRFILE >$TMPFILE
                elif [[ "$1" =~ "tls1_3_ECDSA" ]]; then
@@ -18264,6 +18265,7 @@ find_openssl_binary() {
      HAS_TLS13=false
      HAS_X448=false
      HAS_X25519=false
+     HAS_SIGALGS=false
      HAS_NO_SSL2=false
      HAS_NOSERVERNAME=false
      HAS_CIPHERSUITES=false
@@ -18310,6 +18312,10 @@ find_openssl_binary() {
      $OPENSSL genpkey -algorithm X25519 2>&1 | grep -aq "not found" || \
           HAS_X25519=true
 
+     if "$HAS_TLS13"; then
+          $OPENSSL s_client -tls1_3 -sigalgs PSS+SHA256:PSS+SHA384 -connect invalid. 2>&1 | grep -aiq "unknown option" || \
+               HAS_SIGALGS=true
+     fi
      $OPENSSL s_client -no_ssl2 -connect invalid. 2>&1 | grep -aiq "unknown option" || \
           HAS_NO_SSL2=true
 
@@ -18684,6 +18690,7 @@ HAS_SSL3: $HAS_SSL3
 HAS_TLS13: $HAS_TLS13
 HAS_X448: $HAS_X448
 HAS_X25519: $HAS_X25519
+HAS_SIGALGS: $HAS_SIGALGS
 HAS_NO_SSL2: $HAS_NO_SSL2
 HAS_SPDY: $HAS_SPDY
 HAS_ALPN: $HAS_ALPN


### PR DESCRIPTION
The "-sigalgs" option is used in `get_server_certificate()` to obtain certificates the server uses with TLS 1.3. `get_server_certificate()` is currently designed to use $OPENSSL, if $OPENSSL supports TLS 1.3.

LibreSSL 3.1.{0,1} has added client support for TLS 1.3, but does not support the "-sigalgs" option. So, this commit determines whether the "-sigalgs" option is supported, and if it isn't, then uses tls_sockets().