### PR TITLE
Better Dockerfile: doesn't require "git clone"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM alpine:3.11
 
-RUN apk update && apk upgrade && apk add --no-cache bash procps drill git coreutils libidn curl
-
-RUN addgroup testssl
-RUN adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl
-
-RUN ln -s /home/testssl/testssl.sh /usr/local/bin/
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache bash procps drill git coreutils libidn curl && \
+    addgroup testssl && \
+    adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \
+    ln -s /home/testssl/testssl.sh /usr/local/bin/ && \
+    mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
 
 USER testssl
 WORKDIR /home/testssl/
 
-RUN git clone --depth=1 https://github.com/drwetter/testssl.sh.git .
+COPY --chown=testssl:testssl etc/. /home/testssl/etc/
+COPY --chown=testssl:testssl bin/. /home/testssl/bin/
+COPY --chown=testssl:testssl testssl.sh  /home/testssl/
 
 ENTRYPOINT ["testssl.sh"]
 

--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ Or if you have cloned this repo you also can just ``cd`` to the INSTALLDIR and r
 docker build .
 ```
 
-followed by ``docker exec -ti <ID> <your_cmd_line>`` where ``ID`` is the identifier in the last line from the build command like
+followed by ``docker run -ti <ID> <your_cmd_line>`` where ``ID`` is the identifier in the last line from the build command like
 
 ```
  ---> 889fa2f99933


### PR DESCRIPTION
.. see also #1559.

It "mkdirs" the needed etc and bin directories first, then copies
stuff over. It also reduces a few layers.

Also it corrects a mistake in the Readme.md (docker exec --> run)

Thanks for the discussion @Alex131089