### PR TITLE
[Rating] simple DH group length

### DIFF
--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -145,7 +145,7 @@ in `/etc/hosts`.  The use of the switch is only useful if you either can't or ar
 
 `--phone-out` Checking for revoked certificates via CRL and OCSP is not done per default. This switch instructs testssl.sh to query external -- in a sense of the current run -- URIs. By using this switch you acknowledge that the check might have privacy issues, a download of several megabytes (CRL file) may happen and there may be network connectivity problems while contacting the endpoint which testssl.sh doesn't handle. PHONE_OUT is the environment variable for this which needs to be set to true if you want this.
 
-`--add-ca <cafile>` enables you to add your own CA(s) for trust chain checks. `cafile` can be a single path or multiple paths as a comma separated list of root CA files. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates is issued by internal CAs. Alternatively 
+`--add-ca <cafile>` enables you to add your own CA(s) for trust chain checks. `cafile` can be a single path or multiple paths as a comma separated list of root CA files. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates is issued by internal CAs. Alternatively
 ADDTL_CA_FILES is the environment variable for this.
 
 
@@ -404,7 +404,6 @@ As of writing, these checks are missing:
 * Zombie POODLE - should be graded **F** if vulnerable
 * All remaining old Symantec PKI certificates are distrusted - should be graded **T**
 * Symantec certificates issued before June 2016 are distrusted - should be graded **T**
-* ! A reading of DH params - should give correct points in `set_key_str_score()`
 * Anonymous key exchange - should give **0** points in `set_key_str_score()`
 * Exportable key exchange - should give **40** points in `set_key_str_score()`
 * Weak key (Debian OpenSSL Flaw) - should give **0** points in `set_key_str_score()`

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -145,8 +145,7 @@ in `/etc/hosts`.  The use of the switch is only useful if you either can't or ar
 
 `--phone-out` Checking for revoked certificates via CRL and OCSP is not done per default. This switch instructs testssl.sh to query external -- in a sense of the current run -- URIs. By using this switch you acknowledge that the check might have privacy issues, a download of several megabytes (CRL file) may happen and there may be network connectivity problems while contacting the endpoint which testssl.sh doesn't handle. PHONE_OUT is the environment variable for this which needs to be set to true if you want this.
 
-`--add-ca <cafile>` enables you to add your own CA(s) for trust chain checks. `cafile` can be a single path or multiple paths as a comma separated list of root CA files. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates is issued by internal CAs. Alternatively
-ADDTL_CA_FILES is the environment variable for this.
+`--add-ca <cafile>` enables you to add your own CA(s) for trust chain checks. `cafile` can be a single path or multiple paths as a comma separated list of root CA files. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates is issued by internal CAs. Alternatively ADDTL_CA_FILES is the environment variable for this.
 
 
 ### SINGLE CHECK OPTIONS

--- a/testssl.sh
+++ b/testssl.sh
@@ -1035,36 +1035,29 @@ set_grade_warning() {
 set_key_str_score() {
      local type=$1
      local size=$2
+     local type_output
 
      "$do_rating" || return 0
 
-<<<<<<< HEAD
-     if [[ $type == EC ]]; then
-          if [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -gt 40 ]]; then
-=======
-     # TODO: We need to get the size of DH params (follows the same table as the "else" clause)
-     # For now, verifying the key size will do...
+     [[ $type == DHE ]] && type_output="DH key exchange parameters" || type_output="key"
+
      if [[ $type == EC || $type == EdDSA ]]; then
-          if [[ $size -lt 110 ]] && [[ $KEY_EXCH_SCORE -gt 20 ]]; then
-               let KEY_EXCH_SCORE=20
-               set_grade_cap "F" "Using an insecure key"
-          elif [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -gt 40 ]]; then
->>>>>>> upstream/3.1dev
+          if [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -gt 40 ]]; then
                let KEY_EXCH_SCORE=40
-               set_grade_cap "F" "Using an insecure key"
+               set_grade_cap "F" "Using an insecure $type_output"
           elif [[ $size -lt 163 ]] && [[ $KEY_EXCH_SCORE -gt 80 ]]; then
                let KEY_EXCH_SCORE=80
-               set_grade_cap "B" "Using a weak key"
+               set_grade_cap "B" "Using a weak $type_output"
           elif [[ $size -lt 225 ]] && [[ $KEY_EXCH_SCORE -gt 90 ]]; then
                let KEY_EXCH_SCORE=90
           fi
      else
           if [[ $size -lt 1024 ]] && [[ $KEY_EXCH_SCORE -gt 40 ]]; then
                let KEY_EXCH_SCORE=40
-               set_grade_cap "F" "Using an insecure key / DH key exchange parameters"
+               set_grade_cap "F" "Using an insecure $type_output"
           elif [[ $size -lt 2048 ]] && [[ $KEY_EXCH_SCORE -gt 80 ]]; then
                let KEY_EXCH_SCORE=80
-               set_grade_cap "B" "Using a weak key / DH key exchange parameters"
+               set_grade_cap "B" "Using a weak $type_output"
           elif [[ $size -lt 4096 ]] && [[ $KEY_EXCH_SCORE -gt 90 ]]; then
                let KEY_EXCH_SCORE=90
           fi
@@ -8520,7 +8513,7 @@ certificate_info() {
                fi
                out " bits"
 
-               set_key_str_score "$short_keyAlgo" "$cert_keysize" # TODO: should be $dh_param_size
+               set_key_str_score "$short_keyAlgo" "$cert_keysize"
           elif [[ $cert_key_algo =~ RSA ]] || [[ $cert_key_algo =~ rsa ]] || [[ $cert_key_algo =~ dsa ]] || \
                [[ $cert_key_algo =~ dhKeyAgreement ]] || [[ $cert_key_algo == X9.42\ DH ]]; then
                if [[ "$cert_keysize" -le 512 ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -1039,7 +1039,7 @@ set_key_str_score() {
 
      "$do_rating" || return 0
 
-     [[ $type == DHE ]] && type_output="temporal DH key (DH parameters)" || type_output="key"
+     [[ $type == DHE ]] && type_output="ephemeral DH key (DH parameters)" || type_output="key"
 
      if [[ $type == EC || $type == EdDSA ]]; then
           if [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -1039,25 +1039,23 @@ set_key_str_score() {
 
      "$do_rating" || return 0
 
-     [[ $type == DHE ]] && type_output="ephemeral DH key (DH parameters)" || type_output="key"
-
      if [[ $type == EC || $type == EdDSA ]]; then
-          if [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
+          if [[ $size -lt 110 ]] && [[ $KEY_EXCH_SCORE -gt 20 ]]; then
+               let KEY_EXCH_SCORE=20
+          elif [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
                let KEY_EXCH_SCORE=40
-               set_grade_cap "F" "Using an insecure $type_output"
           elif [[ $size -lt 163 ]] && [[ $KEY_EXCH_SCORE -ge 80 ]]; then
                let KEY_EXCH_SCORE=80
-               set_grade_cap "B" "Using a weak $type_output"
           elif [[ $size -lt 225 ]] && [[ $KEY_EXCH_SCORE -ge 90 ]]; then
                let KEY_EXCH_SCORE=90
           fi
      else
-          if [[ $size -lt 1024 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
+          if [[ $size -lt 512 ]] && [[ $KEY_EXCH_SCORE -ge 20 ]]; then
+               let KEY_EXCH_SCORE=20
+          elif [[ $size -lt 1024 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
                let KEY_EXCH_SCORE=40
-               set_grade_cap "F" "Using an insecure $type_output"
           elif [[ $size -lt 2048 ]] && [[ $KEY_EXCH_SCORE -ge 80 ]]; then
                let KEY_EXCH_SCORE=80
-               set_grade_cap "B" "Using a weak $type_output"
           elif [[ $size -lt 4096 ]] && [[ $KEY_EXCH_SCORE -ge 90 ]]; then
                let KEY_EXCH_SCORE=90
           fi
@@ -20880,6 +20878,12 @@ run_rating() {
           pr_bold " Protocol Support "; out "(weighted)  "; outln "$c1_score ($c1_wscore)"
 
           ## Category 2
+          if [[ $KEY_EXCH_SCORE -le 40 ]]; then
+               set_grade_cap "F" "Using an insecure public key and/or ephemeral key"
+          elif [[ $KEY_EXCH_SCORE -le 80 ]]; then
+               set_grade_cap "B" "Using a weak public key and/or ephemeral key"
+          fi
+
           let c2_score=$KEY_EXCH_SCORE
           let c2_wscore=$c2_score*30/100
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -1039,26 +1039,26 @@ set_key_str_score() {
 
      "$do_rating" || return 0
 
-     [[ $type == DHE ]] && type_output="DH key exchange parameters" || type_output="key"
+     [[ $type == DHE ]] && type_output="temporal DH key (DH parameters)" || type_output="key"
 
      if [[ $type == EC || $type == EdDSA ]]; then
-          if [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -gt 40 ]]; then
+          if [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
                let KEY_EXCH_SCORE=40
                set_grade_cap "F" "Using an insecure $type_output"
-          elif [[ $size -lt 163 ]] && [[ $KEY_EXCH_SCORE -gt 80 ]]; then
+          elif [[ $size -lt 163 ]] && [[ $KEY_EXCH_SCORE -ge 80 ]]; then
                let KEY_EXCH_SCORE=80
                set_grade_cap "B" "Using a weak $type_output"
-          elif [[ $size -lt 225 ]] && [[ $KEY_EXCH_SCORE -gt 90 ]]; then
+          elif [[ $size -lt 225 ]] && [[ $KEY_EXCH_SCORE -ge 90 ]]; then
                let KEY_EXCH_SCORE=90
           fi
      else
-          if [[ $size -lt 1024 ]] && [[ $KEY_EXCH_SCORE -gt 40 ]]; then
+          if [[ $size -lt 1024 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
                let KEY_EXCH_SCORE=40
                set_grade_cap "F" "Using an insecure $type_output"
-          elif [[ $size -lt 2048 ]] && [[ $KEY_EXCH_SCORE -gt 80 ]]; then
+          elif [[ $size -lt 2048 ]] && [[ $KEY_EXCH_SCORE -ge 80 ]]; then
                let KEY_EXCH_SCORE=80
                set_grade_cap "B" "Using a weak $type_output"
-          elif [[ $size -lt 4096 ]] && [[ $KEY_EXCH_SCORE -gt 90 ]]; then
+          elif [[ $size -lt 4096 ]] && [[ $KEY_EXCH_SCORE -ge 90 ]]; then
                let KEY_EXCH_SCORE=90
           fi
      fi

--- a/testssl.sh
+++ b/testssl.sh
@@ -1035,12 +1035,11 @@ set_grade_warning() {
 set_key_str_score() {
      local type=$1
      local size=$2
-     local type_output
 
      "$do_rating" || return 0
 
      if [[ $type == EC || $type == EdDSA ]]; then
-          if [[ $size -lt 110 ]] && [[ $KEY_EXCH_SCORE -gt 20 ]]; then
+          if [[ $size -lt 110 ]] && [[ $KEY_EXCH_SCORE -ge 20 ]]; then
                let KEY_EXCH_SCORE=20
           elif [[ $size -lt 123 ]] && [[ $KEY_EXCH_SCORE -ge 40 ]]; then
                let KEY_EXCH_SCORE=40
@@ -1064,7 +1063,7 @@ set_key_str_score() {
 }
 
 # Sets the best and worst bit size key, used to grade Category 3 (Cipher Strength)
-# This function itself doesn't actually set a score; its just in the name to keep it logical (score == grading function)
+# This function itself doesn't actually set a score; its just in the name to keep it logical (score == rating function)
 # arg1: a bit size
 set_ciph_str_score() {
      local size=$1


### PR DESCRIPTION
A simple implementation, that rates the DH group length in `run_logjam()`.
This could probably be implemented in the `pr_dh_quality()` function too, however that seems excessive.

I did remove the lowest key size check, for readability. When capped at an F, the score isn't calculated anyway, so the additional check is unnecessary.

The previous grade_caps where guesses. The rating spec does not differ from known or unknown groups.. only the group size matters.