### PR TITLE
Fix $SHOW_SIGALGO

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6993,7 +6993,11 @@ cipher_pref_check() {
                     ! "${ciphers_found2[i]}" && ciphers_to_test+=", ${hexcode[i]}"
                done
                [[ -z "$ciphers_to_test" ]] && break
-               tls_sockets "$proto_hex" "${ciphers_to_test:2}, 00,ff" "ephemeralkey"
+               if "$wide" && "$SHOW_SIGALGO"; then
+                    tls_sockets "$proto_hex" "${ciphers_to_test:2}, 00,ff" "all"
+               else
+                    tls_sockets "$proto_hex" "${ciphers_to_test:2}, 00,ff" "ephemeralkey"
+               fi
                [[ $? -ne 0 ]] && break
                cipher=$(get_cipher "$TEMPDIR/$NODEIP.parse_tls_serverhello.txt")
                for (( i=0; i < nr_ciphers; i++ )); do
@@ -17006,7 +17010,7 @@ run_beast(){
                          ! "${ciphers_found[i]}" && ciphers_to_test+=", ${hexcode[i]}"
                     done
                     [[ -z "$ciphers_to_test" ]] && break
-                    if "$SHOW_SIGALGO"; then
+                    if "$WIDE" && "$SHOW_SIGALGO"; then
                          tls_sockets "$proto_hex" "${ciphers_to_test:2}, 00,ff" "all"
                     else
                          tls_sockets "$proto_hex" "${ciphers_to_test:2}, 00,ff" "ephemeralkey"


### PR DESCRIPTION
This PR fixes two issues related to $SHOW_SIGALGO.

First, `cipher_pref_check()` does not show the signature algorithm if any of the ciphers were found using `tls_sockets()`, since the call to `tls_sockets()` does not specify that the server's certificate should be extracted.

Second, in `run_beast()` the call to `tls_sockets()` indicates that the server's certificate should be extracted if "$SHOW_SIGALGO" is true, even if "$WIDE" is false. While this does not cause any problems, extracting the certificate is a waste of effort if "$WIDE" is false, since the signature algorithm is not shown in that case.