### PR TITLE
[Rating] Clearer grade cap reasons

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7204,7 +7204,7 @@ determine_trust() {
                     out "$code"
                fi
                fileout "${jsonID}${json_postfix}" "CRITICAL" "failed $code. $addtl_warning"
-               set_grade_cap "T" "Issues with certificate $code"
+               set_grade_cap "T" "Issues with the chain of trust $code"
           else
                # is one ok and the others not ==> display the culprit store
                if "$some_ok"; then
@@ -7223,7 +7223,7 @@ determine_trust() {
                                    out "$code"
                               fi
                               notok_was="${certificate_file[i]} $code $notok_was"
-                              set_grade_cap "T" "Issues with certificate $code"
+                              set_grade_cap "T" "Issues with chain of trust $code"
                          fi
                     done
                     #pr_svrty_high "$notok_was "


### PR DESCRIPTION
fixes #1655 
It now looks like this, which makes clears up some confusion:
```
 Rating (experimental) 

 Rating specs (not complete)  SSL Labs's 'SSL Server Rating Guide' (version 2009q from 2020-01-30)
 Specification documentation  https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide
 Protocol Support (weighted)  0 (0)
 Key Exchange     (weighted)  0 (0)
 Cipher Strength  (weighted)  0 (0)
 Final Score                  0
 Overall Grade                T
 Grade cap reasons            Grade capped to T. Issues with the chain of trust (expired)
                              Grade capped to T. Certificate expired
                              Grade capped to B. TLS 1.1 offered
                              Grade capped to B. TLS 1.0 offered
                              Grade capped to A. Problems with HTTP Public Key Pinning (HPKP)
                              Grade capped to A. HSTS max-age is too short

 Done 2020-06-18 21:11:48 [  70s] -->> 81.169.166.184:443 (borken.testssl.sh) <<--
```

I want to extend this PR, to make the rating output consistent with STARTTLS too. I have a few options in mind:
1. Change the current check to `set_grade_cap "t" "STARTTLS encryption is opportunistic. Rating it would be misleading"`
This would still list other grade cap reasons, however, no calculations would be performed.
2. Like above, but clear the `$GRADE_CAP_REASONS` first, so no other grade caps would be shown.
3. Change the current check to `grade_cap_warning "STARTTLS encryption is opportunistic. The grade is worth very little"`
This _would_ calculate an actual grade, with the above text yellow printed. A proper rating can help a admin configure proper TLS. We should just warn very clearly that STARTTLS is opportunistic.
(would also make the best grade possible an A-). Here is an example:
![image](https://user-images.githubusercontent.com/7879747/85064373-029b4980-b19b-11ea-89f9-a3c3d6de0bf7.png)


For all 3, this would clear out a chunk of duplicate code; and the "UI" would be consistent with non-STARTTLS ratings :)