### PR TITLE
[Rating] STARTTLS output styling

### DIFF
--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -407,6 +407,10 @@ As of writing, these checks are missing:
 * Exportable key exchange - should give **40** points in `set_key_str_score()`
 * Weak key (Debian OpenSSL Flaw) - should give **0** points in `set_key_str_score()`
 
+#### STARTTLS
+This program rates STARTTLS connections, exactly according to the specification. However, this program adds a grade warning about STARTTLS is being used. This is not apart of the rating specification, and limits the grade a STARTTLS connection can have, to a maximum of `A-`.
+
+
 #### Implementing new grades caps or -warnings
 To implement a new grading cap, simply call the `set_grade_cap()` function, with the grade and a reason:
 ```bash

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -407,9 +407,6 @@ As of writing, these checks are missing:
 * Exportable key exchange - should give **40** points in `set_key_str_score()`
 * Weak key (Debian OpenSSL Flaw) - should give **0** points in `set_key_str_score()`
 
-#### STARTTLS
-This program rates STARTTLS connections, exactly according to the specification. However, this program adds a grade warning about STARTTLS is being used. This is not apart of the rating specification, and limits the grade a STARTTLS connection can have, to a maximum of `A-`.
-
 #### Implementing new grades caps or -warnings
 To implement a new grading cap, simply call the `set_grade_cap()` function, with the grade and a reason:
 ```bash

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -410,7 +410,6 @@ As of writing, these checks are missing:
 #### STARTTLS
 This program rates STARTTLS connections, exactly according to the specification. However, this program adds a grade warning about STARTTLS is being used. This is not apart of the rating specification, and limits the grade a STARTTLS connection can have, to a maximum of `A-`.
 
-
 #### Implementing new grades caps or -warnings
 To implement a new grading cap, simply call the `set_grade_cap()` function, with the grade and a reason:
 ```bash
@@ -423,14 +422,14 @@ set_grade_warning "Documentation is always right"
 #### Implementing a new check which contains grade caps
 When implementing a new check (be it vulnerability or not) that sets grade caps, the `set_rating_state()` has to be updated (i.e. the `$do_mycheck` variable-name has to be added to the loop, and `$nr_enabled` if-statement has to be incremented)
 
-The `set_rating_state()` automatically disables ratinng, if all the required checks are *not* enabled.
+The `set_rating_state()` automatically disables rating, if all the required checks are *not* enabled.
 This is to prevent giving out a misleading or wrong grade.
 
 #### Implementing a new revision
 When a new revision of the rating specification comes around, the following has to be done:
 * New grade caps has to be either:
   1. Added to the script wherever relevant, or
-  2. Added to the above list of missing checks (if *i.* is not possible)
+  2. Added to the above list of missing checks (if above is not possible)
 * New grade warnings has to be added wherever relevant
 * The revision output in `run_rating()` function has to updated
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -20802,14 +20802,7 @@ run_rating() {
      pr_headlineln " Rating (experimental) "
      outln
 
-     if [[ -n "$STARTTLS_PROTOCOL" ]]; then
-          pr_bold " Grade                        "; pr_svrty_critical "T"
-          outln   " - STARTTLS encryption is opportunistic"
-          outln   "                                  (Further details would lead to a false sense of security)"
-          fileout "grade" "CRITICAL" "T"
-          fileout "grade_cap_reasons" "INFO" "No more details shown as it would lead to a false sense of security"
-          return 0
-     fi
+     [[ -n "$STARTTLS_PROTOCOL" ]] && set_grade_warning "STARTTLS encryption is opportunistic. The grade is very insignificant"
 
      # Sort the reasons. This is just nicer to read in genereal
      IFS=$'\n' sorted_reasons=($(sort -ru <<<"${GRADE_CAP_REASONS[*]}"))
@@ -20912,7 +20905,7 @@ run_rating() {
 
           pr_bold " Final Score                  "; outln $final_score
 
-          # get score, and somehow do something about the GRADE_CAP
+          # Calculate the pre-cap grade
           if [[ $final_score -ge 80 ]]; then
                pre_cap_grade="A"
           elif [[ $final_score -ge 65 ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -20802,7 +20802,7 @@ run_rating() {
      pr_headlineln " Rating (experimental) "
      outln
 
-     [[ -n "$STARTTLS_PROTOCOL" ]] && set_grade_warning "STARTTLS encryption is opportunistic. The grade is very insignificant"
+     [[ -n "$STARTTLS_PROTOCOL" ]] && set_grade_cap "T" "Encryption via STARTTLS is not mandatory (opportunistic). This leads to a false sense of security"
 
      # Sort the reasons. This is just nicer to read in genereal
      IFS=$'\n' sorted_reasons=($(sort -ru <<<"${GRADE_CAP_REASONS[*]}"))


### PR DESCRIPTION
As shortly discussed in #1656, rating STARTTLS connections should be consistent with non-STARTTLS connections, in both UI and fileout (csv/json) output.

This lists all the reasons for grade caps and warnings, and calculates an actual grade. This does however limit the score to `A-` (meaning that `A+` is impossible to get, using STARTTLS)

BEFORE:
![image](https://user-images.githubusercontent.com/7879747/85173292-6ccaf180-b262-11ea-9f83-822b4ef6562c.png)
AFTER:
![image](https://user-images.githubusercontent.com/7879747/85173309-794f4a00-b262-11ea-8c5a-0153db506b0b.png)
