### PR TITLE
Fix #1662

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8647,7 +8647,7 @@ certificate_info() {
           outok=false
      fi
      if "$outok"; then
-          fileout "${jsonID}${json_postfix}" "INFO" "cert_ext_keyusage"
+          fileout "${jsonID}${json_postfix}" "INFO" "$cert_ext_keyusage"
      fi
 
      out "$indent"; pr_bold " Serial / Fingerprints        "


### PR DESCRIPTION
This commit fixes #1662 by changing the fileout to use the value of $cert_ext_keyusage rather than the string "cert_ext_keyusage".