### PR TITLE
Fix #1662 in 3.0 branch

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8373,7 +8373,7 @@ certificate_info() {
           outok=false
      fi
      if "$outok"; then
-          fileout "${jsonID}${json_postfix}" "INFO" "cert_ext_keyusage"
+          fileout "${jsonID}${json_postfix}" "INFO" "$cert_ext_keyusage"
      fi
 
      out "$indent"; pr_bold " Serial / Fingerprints        "


### PR DESCRIPTION
This PR fixes #1662 in the 3.0 branch by changing the fileout to use the value of $cert_ext_keyusage rather than the string "cert_ext_keyusage".