### PR TITLE
Fix #1665

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8942,7 +8942,7 @@ certificate_info() {
      out "$indent"; pr_bold " ETS/\"eTLS\""
      out ", visibility info  "
      jsonID="cert_eTLS"
-     etsi_etls_visibility_info "$jsonID" "$spaces" "$HOSTCERT" "$cert_txt"
+     etsi_etls_visibility_info "${jsonID}${json_postfix}" "$spaces" "$HOSTCERT" "$cert_txt"
      # *Currently* this is even listed as a vulnerability (CWE-310, CVE-2019-919), see
      # https://nvd.nist.gov/vuln/detail/CVE-2019-9191, https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9191
      # For now we leave this here. We may want to change that later or add infos to other sections (FS & vulnerability)


### PR DESCRIPTION
This commit fixes #1665 by adding the certificate number to the JSON identifier for cert_eTLS.