### PR TITLE
Fix printing of unrecognized option

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21693,7 +21693,7 @@ parse_cmd_line() {
                (--) shift
                     break
                     ;;
-               (-*) tmln_warning "0: unrecognized option \"$1\"" 1>&2;
+               (-*) tmln_warning "$0: unrecognized option \"$1\"" 1>&2;
                     help 1
                     ;;
                (*)  break


### PR DESCRIPTION
When testssl.sh is called with an unknown option it prints something like:

     0: unrecognized option "--option"

It should be printing the name of the program rather than "0". This PR fixes that.