### PR TITLE
Include cipher quality in JSON and CSV

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4378,7 +4378,7 @@ ciphers_by_strength() {
                outln "${sigalg[i]}"
                id="cipher$proto"
                id+="_${normalized_hexcode[i]}"
-               fileout "$id" "INFO" "$proto_text  $(neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}" "${export2[i]}") $available"
+               fileout "$id" "$(get_cipher_quality_severity "${ciph[i]}")" "$proto_text  $(neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}" "${export2[i]}") $available"
           fi
      done
 
@@ -6204,6 +6204,26 @@ get_cipher_quality() {
      esac
 }
 
+# Output the severity level associated with the cipher in $1.
+get_cipher_quality_severity() {
+     local cipher="$1"
+     local -i quality
+
+     [[ -z "$1" ]] && return 0
+
+     get_cipher_quality "$cipher"
+     quality=$?
+     case $quality in
+          1) tm_out "CRITICAL" ;;
+          2) tm_out "HIGH" ;;
+          3) tm_out "MEDIUM" ;;
+          4) tm_out "LOW" ;;
+          5) tm_out "INFO" ;;
+          6|7) tm_out "OK" ;;
+     esac
+     return $quality
+}
+
 # Print $2 based on the quality of the cipher in $1. If $2 is empty, just print $1.
 # The return value is an indicator of the quality of the cipher in $1:
 #   0 = $1 is empty
@@ -7051,7 +7071,7 @@ cipher_pref_check() {
                     neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}" "${export2[i]}" "true"
                     outln "${sigalg[i]}"
                     id="cipher-${proto}_${normalized_hexcode[i]}"
-                    fileout "$id" "INFO" "$proto_text  $(neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}" "${export2[i]}")"
+                    fileout "$id" "$(get_cipher_quality_severity "${ciph[i]}")" "$proto_text  $(neat_list "${normalized_hexcode[i]}" "${ciph[i]}" "${kx[i]}" "${enc[i]}" "${export2[i]}")"
                done
           else
                outln


### PR DESCRIPTION
run_cipherlists() checks for support for different groups of ciphers, but does not indicate which ciphers in each group are supported. So, for example, if the JSON file indicates that there is a problem with severity level "HIGH" because the "LOW" ciphers are available, there is no clear indication of which of these ciphers are supported by the server.

If run_server_preference() is run with "--color 3", then there will be a visual indication (via color) of the ciphers the server supports that are considered bad, but this information does not appear in the JSON (or CSV) output. The JSON (or CSV) output will include information about every cipher that is supported, but the severity level is always "INFO".

This PR addresses this problem by changing the fileout() calls in ciphers_by_strength() and cipher_pref_check() that output each supported cipher individually so that the "severity" argument is an indication of the quality of the cipher. With this, information about which bad ciphers are supported can easily be found in the JSON/CSV output.