### PR TITLE
Update GREASE reference

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -334,7 +334,7 @@ Security headers (X\-Frame\-Options, X\-XSS\-Protection, Expect\-CT,\.\.\. , CSP
 \fB\-\-c, \-\-client\-simulation\fR This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site\. For the latter case the protocol, cipher and curve is displayed, also if there\'s Forward Secrecy\. testssl\.sh uses a handselected set of clients which are retrieved by the SSLlabs API\. The output is aligned in columns when combined with the \fB\-\-wide\fR option\. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS\.
 .
 .P
-\fB\-g, \-\-grease\fR checks several server implementation bugs like tolerance to size limitations and GREASE, see https://www\.ietf\.org/archive/id/draft\-ietf\-tls\-grease\-01\.txt \. This check doesn\'t run per default\.
+\fB\-g, \-\-grease\fR checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701\. This check doesn\'t run per default\.
 .
 .SS "VULNERABILITIES"
 \fB\-U, \-\-vulnerable, \-\-vulnerabilities\fR Just tests all (of the following) vulnerabilities\. The environment variable \fBVULN_THRESHLD\fR determines after which value a separate headline for each vulnerability is being displayed\. Default is \fB1\fR which means if you check for two vulnerabilities, only the general headline for vulnerabilities section is displayed \-\- in addition to the vulnerability and the result\. Otherwise each vulnerability or vulnerability section gets its own headline in addition to the output of the name of the vulnerabilty and test result\. A vulnerability section is comprised of more than one check, e\.g\. the renegotiation vulnerability check has two checks, so has Logjam\.

--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -824,6 +824,9 @@ RFC 8143: Using Transport Layer Security (TLS) with Network News Transfer Protoc
 RFC 8446: The Transport Layer Security (TLS) Protocol Version 1\.3
 .
 .IP "\(bu" 4
+RFC 8701: Applying Generate Random Extensions And Sustain Extensibility (GREASE) to TLS Extensibility
+.
+.IP "\(bu" 4
 W3C CSP: Content Security Policy Level 1\-3
 .
 .IP "\(bu" 4

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -303,7 +303,7 @@ Also for multiple server certificates are being checked for as well as for the c
 
 <p><code>--c, --client-simulation</code>     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the <code>--wide</code> option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.</p>
 
-<p><code>-g, --grease</code> checks several server implementation bugs like tolerance to size limitations and GREASE, see https://www.ietf.org/archive/id/draft-ietf-tls-grease-01.txt . This check doesn't run per default.</p>
+<p><code>-g, --grease</code> checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701. This check doesn't run per default.</p>
 
 <h3 id="VULNERABILITIES">VULNERABILITIES</h3>
 

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -593,6 +593,7 @@ This is to prevent giving out a misleading or wrong grade.</p>
 <li>RFC 7919: Negotiated Finite Field Diffie-Hellman Ephemeral Parameters for Transport Layer Security</li>
 <li>RFC 8143: Using Transport Layer Security (TLS) with Network News Transfer Protocol (NNTP)</li>
 <li>RFC 8446: The Transport Layer Security (TLS) Protocol Version 1.3</li>
+<li>RFC 8701: Applying Generate Random Extensions And Sustain Extensibility (GREASE) to TLS Extensibility</li>
 <li>W3C CSP: Content Security Policy Level 1-3</li>
 <li>TLSWG Draft: The Transport Layer Security (TLS) Protocol Version 1.3</li>
 </ul>

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -491,6 +491,7 @@ Please note that for plain TLS-encrypted ports you must not specify the protocol
 * RFC 7919: Negotiated Finite Field Diffie-Hellman Ephemeral Parameters for Transport Layer Security
 * RFC 8143: Using Transport Layer Security (TLS) with Network News Transfer Protocol (NNTP)
 * RFC 8446: The Transport Layer Security (TLS) Protocol Version 1.3
+* RFC 8701: Applying Generate Random Extensions And Sustain Extensibility (GREASE) to TLS Extensibility
 * W3C CSP: Content Security Policy Level 1-3
 * TLSWG Draft: The Transport Layer Security (TLS) Protocol Version 1.3
 

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -215,7 +215,7 @@ Also for multiple server certificates are being checked for as well as for the c
 
 `--c, --client-simulation`     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the `--wide` option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.
 
-`-g, --grease` checks several server implementation bugs like tolerance to size limitations and GREASE, see https://www.ietf.org/archive/id/draft-ietf-tls-grease-01.txt . This check doesn't run per default.
+`-g, --grease` checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701. This check doesn't run per default.
 
 
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -17718,7 +17718,7 @@ run_tls_truncation() {
 }
 
 # Test for various server implementation errors that aren't tested for elsewhere.
-# Inspired by https://datatracker.ietf.org/doc/draft-ietf-tls-grease.
+# Inspired by RFC 8701.
 run_grease() {
      local -i success
      local bug_found=false
@@ -17729,7 +17729,7 @@ run_grease() {
      local ciph list temp curve_found
      local -i i j rnd alpn_list_len extn_len debug_level=""
      local -i ret=0
-     # Note: The following values were taken from https://datatracker.ietf.org/doc/draft-ietf-tls-grease.
+     # Note: The following values were taken from RFC 8701.
      # These arrays may need to be updated if the values change in the final version of this document.
      local -a -r grease_cipher_suites=( "0a,0a" "1a,1a" "2a,2a" "3a,3a" "4a,4a" "5a,5a" "6a,6a" "7a,7a" "8a,8a" "9a,9a" "aa,aa" "ba,ba" "ca,ca" "da,da" "ea,ea" "fa,fa" )
      local -a -r grease_supported_groups=( "0a,0a" "1a,1a" "2a,2a" "3a,3a" "4a,4a" "5a,5a" "6a,6a" "7a,7a" "8a,8a" "9a,9a" "aa,aa" "ba,ba" "ca,ca" "da,da" "ea,ea" "fa,fa" )
@@ -17823,7 +17823,7 @@ run_grease() {
      DEBUG="$debug_level"
 
      # Check that server ignores unrecognized extensions
-     # see https://datatracker.ietf.org/doc/draft-ietf-tls-grease
+     # see RFC 8701
      if "$normal_hello_ok" && [[ "$proto" != "00" ]]; then
           # Try multiple different randomly-generated GREASE extensions,
           # but make final test use zero-length extension value, just to
@@ -17934,7 +17934,7 @@ run_grease() {
      fi
 
      # Check that server ignores unrecognized cipher suite values
-     # see https://datatracker.ietf.org/doc/draft-ietf-tls-grease
+     # see RFC 8701
      if "$normal_hello_ok"; then
           list=""
           for ciph in "${grease_cipher_suites[@]}"; do
@@ -17952,7 +17952,7 @@ run_grease() {
 
      # Check that servers that support ECDHE cipher suites ignore
      # unrecognized named group values.
-     # see https://datatracker.ietf.org/doc/draft-ietf-tls-grease
+     # see RFC 8701
      if [[ "$proto" != "00" ]]; then
           # Send a ClientHello that lists all of the ECDHE cipher suites
           tls_sockets "$proto" "$ecdhe_ciphers, 00,ff" "ephemeralkey"
@@ -17999,7 +17999,7 @@ run_grease() {
 
      # Check that servers that support the ALPN extension ignore
      # unrecognized ALPN values.
-     # see https://datatracker.ietf.org/doc/draft-ietf-tls-grease
+     # see RFC 8701
      if "$normal_hello_ok" && [[ -z $STARTTLS ]] && [[ "$proto" != "00" ]]; then
           for alpn_proto in $ALPN_PROTOs; do
                alpn+=",$(printf "%02x" ${#alpn_proto}),$(string_to_asciihex "$alpn_proto")"


### PR DESCRIPTION
The GEASE Internet Draft is now RFC 8701. This PR updates the references.