### PR TITLE
Don't penalize rating for CAs which aren't in the Java store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Don't use external pwd anymore
 * STARTTLS: XMPP server support
 * Rating (SSL Labs, not complete)
+* Don't penalize missing trust in rating when CA not in Java store
 * Added support for certificates with EdDSA signatures and pubilc keys
 
 ### Features implemented / improvements in 3.0


### PR DESCRIPTION
This fixes #1648.

Java store doesn't seem to be as complete. No downgrading of trust rating
to T but we still need to raise a red flag for some Java clients