### PR TITLE
Fix missing bind-tools in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache bash procps drill git coreutils libidn curl bind-utils && \
+    apk add --no-cache bash procps drill git coreutils libidn curl bind-tools && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \
     ln -s /home/testssl/testssl.sh /usr/local/bin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache bash procps drill git coreutils libidn curl && \
+    apk add --no-cache bash procps drill git coreutils libidn curl bind-utils && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \
     ln -s /home/testssl/testssl.sh /usr/local/bin/ && \


### PR DESCRIPTION
Name resolution not working in docker image, due to base image not including bind-tools package.
Updates the Dockerfile to install bind-tools to re-enable name resolution