### PR TITLE
Added check for certificate validity longer than 398 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Don't penalize missing trust in rating when CA not in Java store
 * Added support for certificates with EdDSA signatures and pubilc keys
 * --add-ca can also now be a directory with \*.pem files
+* Warning of 398 day limit for certificates issued after 2020/9/1
 
 ### Features implemented / improvements in 3.0
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -39,6 +39,9 @@ Full contribution, see git log.
 * Christoph Badura
   - NetBSD fixes
 
+* Jim Blankendaal
+  - maximum certificate lifespan of 398 days 
+
 * Frank Breedijk
   - Detection of insecure redirects
   - JSON and CSV output

--- a/testssl.sh
+++ b/testssl.sh
@@ -136,7 +136,7 @@ declare -r PROG_NAME="$(basename "$0")"
 declare -r RUN_DIR="$(dirname "$0")"
 declare -r SYSTEM="$(uname -s)"
 declare -r SYSTEMREV="$(uname -r)"
-HNAME="$(hostname)"
+HNAME="$(uname -n)"
 HNAME="${HNAME%%.*}"
 declare CMDLINE
 CMDLINE_PARSED=""                                 # This makes sure we don't let early fatal() write into files when files aren't created yet
@@ -8351,6 +8351,7 @@ certificate_info() {
      local caa_node="" all_caa="" caa_property_name="" caa_property_value=""
      local response=""
      local yearstart yearend clockstart clockend y m d
+     local gt_398=false gt_398warn=false
      local gt_825=false gt_825warn=false
      local badocsp=1 
 
@@ -9109,6 +9110,26 @@ certificate_info() {
           out "$spaces"
           prln_svrty_medium ">= 5 years is too long"
           fileout "cert_validityPeriod${json_postfix}" "MEDIUM" "$((diffseconds / (3600 * 24) )) days"
+     elif [[ $diffseconds -ge $((3600 * 24 * 398 + 1)) ]]; then
+     # Also "official" certificates issued from september 1st 2020 (1598918400) aren't supposed
+     # to be valid longer than 398 days which is 34387200 in epoch seconds
+          gt_398=true
+          if "$HAS_OPENBSDDATE"; then
+               if [[ 20200901 -le ${yearstart//-/} ]]; then
+                    gt_398warn=true
+               fi
+          elif [[ $(parse_date "$startdate" "+%s" $'%F %H:%M') -ge 1598918400 ]]; then
+               gt_398warn=true
+          fi
+          # Now, the verdict, depending on the issuing date
+          out "$spaces"
+          if "$gt_398warn" && "$gt_398"; then
+               prln_svrty_medium "> 398 days issued after 2020/09/01 is too long"
+               fileout "cert_validityPeriod${json_postfix}" "MEDIUM" "$((diffseconds / (3600 * 24) )) > 398 days"
+          elif "$gt_398"; then
+               outln ">= 398 days certificate life time but issued before 2020/09/01"
+               fileout "cert_validityPeriod${json_postfix}" "INFO" "$((diffseconds / (3600 * 24) )) =< 398 days"
+          fi
      elif [[ $diffseconds -ge $((3600 * 24 * 825 + 1)) ]]; then
      # Also "official" certificates issued from March 1st, 2018 (1517353200) aren't supposed
      # to be valid longer than 825 days which is 1517353200 in epoch seconds

--- a/testssl.sh
+++ b/testssl.sh
@@ -9150,7 +9150,7 @@ certificate_info() {
                outln ">= 825 days certificate life time but issued before 2018/03/01"
                fileout "cert_validityPeriod${json_postfix}" "INFO" "$((diffseconds / (3600 * 24) )) =< 825 days"
           fi
-    else
+     else
           # All is fine with valididy period
           # We ignore for now certificates < 2018/03/01. On the screen we only show debug info
           [[ "$DEBUG" -ge 1 ]] && outln "${spaces}DEBUG: all is fine with total certificate life time"

--- a/testssl.sh
+++ b/testssl.sh
@@ -8351,6 +8351,7 @@ certificate_info() {
      local caa_node="" all_caa="" caa_property_name="" caa_property_value=""
      local response=""
      local yearstart yearend clockstart clockend y m d
+     local gt_398=false gt_398warn=false
      local gt_825=false gt_825warn=false
      local badocsp=1 
 
@@ -9109,6 +9110,26 @@ certificate_info() {
           out "$spaces"
           prln_svrty_medium ">= 5 years is too long"
           fileout "cert_validityPeriod${json_postfix}" "MEDIUM" "$((diffseconds / (3600 * 24) )) days"
+     elif [[ $diffseconds -ge $((3600 * 24 * 398 + 1)) ]]; then
+     # Also "official" certificates issued from september 1st 2020 (1598918400) aren't supposed
+     # to be valid longer than 398 days which is 34387200 in epoch seconds
+          gt_398=true
+          if "$HAS_OPENBSDDATE"; then
+               if [[ 20200901 -le ${yearstart//-/} ]]; then
+                    gt_398warn=true
+               fi
+          elif [[ $(parse_date "$startdate" "+%s" $'%F %H:%M') -ge 1598918400 ]]; then
+               gt_398warn=true
+          fi
+          # Now, the verdict, depending on the issuing date
+          out "$spaces"
+          if "$gt_398warn" && "$gt_398"; then
+               prln_svrty_medium "> 398 days issued after 2020/09/01 is too long"
+               fileout "cert_validityPeriod${json_postfix}" "MEDIUM" "$((diffseconds / (3600 * 24) )) > 398 days"
+          elif "$gt_398"; then
+               outln ">= 398 days certificate life time but issued before 2020/09/01"
+               fileout "cert_validityPeriod${json_postfix}" "INFO" "$((diffseconds / (3600 * 24) )) =< 398 days"
+          fi
      elif [[ $diffseconds -ge $((3600 * 24 * 825 + 1)) ]]; then
      # Also "official" certificates issued from March 1st, 2018 (1517353200) aren't supposed
      # to be valid longer than 825 days which is 1517353200 in epoch seconds
@@ -9129,7 +9150,7 @@ certificate_info() {
                outln ">= 825 days certificate life time but issued before 2018/03/01"
                fileout "cert_validityPeriod${json_postfix}" "INFO" "$((diffseconds / (3600 * 24) )) =< 825 days"
           fi
-     else
+    else
           # All is fine with valididy period
           # We ignore for now certificates < 2018/03/01. On the screen we only show debug info
           [[ "$DEBUG" -ge 1 ]] && outln "${spaces}DEBUG: all is fine with total certificate life time"


### PR DESCRIPTION
Added check for certificate validity longer than 398 days as more browsers and CA's are implementing this. See for example: https://blog.mozilla.org/security/2020/07/09/reducing-tls-certificate-lifespans-to-398-days/

Copied and modified from the existing check for 825 days validity. 