### PR TITLE
Fix #1699

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1229,7 +1229,7 @@ fileout_pretty_json_banner() {
 fileout_banner() {
      if "$JSONHEADER"; then
           # "$do_json" &&                    # here we maybe should add a banner, too
-          "$do_pretty_json" && (printf "%s\n" "$(fileout_pretty_json_banner)") >> "$JSONFILE"
+          "$do_pretty_json" && FIRST_FINDING=true && (printf "%s\n" "$(fileout_pretty_json_banner)") >> "$JSONFILE"
      fi
 }
 


### PR DESCRIPTION
This PR fixes #1699 by setting `FIRST_FINDING` to true in `fileout_banner()` if `$do_json_pretty` is true.

When `$do_json_pretty` is true, `fileout_banner()` calls `fileout_pretty_json_banner()`, which starts a new section in the JSON file. Setting `FIRST_FINDING` to true ensures that a comma is not placed before the first entry in this new section. This is the same as is done in other places when a new section is started: `fileout_section_header()` and `fileout_insert_warning()`.