### PR TITLE
upd alpine to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
because error with libuv required for other packages. For example: 
Error relocating /usr/bin/node: uv_fs_lutime