### PR TITLE
Added support for custom user agent

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -229,7 +229,7 @@ else
      MEASURE_TIME=${MEASURE_TIME:-false}
 fi
 DISPLAY_CIPHERNAMES="openssl"           # display OpenSSL ciphername (but both OpenSSL and RFC ciphernames in wide mode)
-declare -r UA_STD="TLS tester from $SWURL"
+declare UA_STD="TLS tester from $SWURL"
 declare -r UA_SNEAKY="Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0"
 
 ########### Initialization part, further global vars just being declared here
@@ -19207,6 +19207,7 @@ tuning / connect options (most also can be preset via environment variables):
                                    b) arg "one" means: just test the first DNS returns (useful for multiple IPs)
      -n, --nodns <min|none>        if "none": do not try any DNS lookups, "min" queries A, AAAA and MX records
      --sneaky                      leave less traces in target logs: user agent, referer
+     --user-agent                  set a custom user agent instead of the standard user agent
      --ids-friendly                skips a few vulnerability checks which may cause IDSs to block the scanning IP
      --phone-out                   allow to contact external servers for CRL download and querying OCSP responder
      --add-ca <CA files|CA dir>    path to <CAdir> with *.pem or a comma separated list of CA files to include in trust check
@@ -21907,6 +21908,10 @@ parse_cmd_line() {
                     ;;
                --sneaky)
                     SNEAKY=true
+                    ;;
+               --user-agent|--user-agent=*)
+                    UA_STD="$(parse_opt_equal_sign "$1" "$2")"
+                    [[ $? -eq 0 ]] && shift
                     ;;
                -q|--quiet)
                     QUIET=true

--- a/testssl.sh
+++ b/testssl.sh
@@ -19207,7 +19207,7 @@ tuning / connect options (most also can be preset via environment variables):
                                    b) arg "one" means: just test the first DNS returns (useful for multiple IPs)
      -n, --nodns <min|none>        if "none": do not try any DNS lookups, "min" queries A, AAAA and MX records
      --sneaky                      leave less traces in target logs: user agent, referer
-     --user-agent                  set a custom user agent instead of the standard user agent
+     --user-agent <user agent>     set a custom user agent instead of the standard user agent
      --ids-friendly                skips a few vulnerability checks which may cause IDSs to block the scanning IP
      --phone-out                   allow to contact external servers for CRL download and querying OCSP responder
      --add-ca <CA files|CA dir>    path to <CAdir> with *.pem or a comma separated list of CA files to include in trust check


### PR DESCRIPTION
First stab at adding support... it seemed a bit too complicated to try and add UA_CUSTOM everywhere and try to then add checks to deal with in all the places where checks for SNEAKY were set or not, so I chose to just update UA_STD instead.  I wasn't sure if you were declaring all variables as read-only, but after seeing some where you didn't I figured this would be the easiest way to work in support.

Tested the script running and confirmed I was able to see the user-agent in logging reflect what I put on the command-line.

I'm ready for abuse/flogging/feedback.