### PR TITLE
Modified ssl renegotiation attempts to be variable, default 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Added support for certificates with EdDSA signatures and pubilc keys
 * --add-ca can also now be a directory with \*.pem files
 * Warning of 398 day limit for certificates issued after 2020/9/1
+* Added environment variable for amount of attempts for ssl renegotiation check
 
 ### Features implemented / improvements in 3.0
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,7 +40,8 @@ Full contribution, see git log.
   - NetBSD fixes
 
 * Jim Blankendaal
-  - maximum certificate lifespan of 398 days 
+  - maximum certificate lifespan of 398 days
+  - ssl renegotiation amount variable
 
 * Frank Breedijk
   - Detection of insecure redirects

--- a/testssl.sh
+++ b/testssl.sh
@@ -16076,23 +16076,22 @@ run_renego() {
                fi
                case "$sec_client_renego" in
                     0)   # We try again if server is HTTP. This could be either a node.js server or something else.
-			 # Mitigations (default values) for:
-                         # 	- node.js allows 3x R and then blocks. So then 4x should be tested. 
-			 #	- F5 BIG-IP ADS allows 5x R and then blocks. So then 6x should be tested.
+                         # Mitigations (default values) for:
+                         # - node.js allows 3x R and then blocks. So then 4x should be tested.
+                         # - F5 BIG-IP ADS allows 5x R and then blocks. So then 6x should be tested.
                          # This way we save a couple seconds as we weeded out the ones which are more robust
-			 # Amount of times tested before breaking is set in SSL_RENEG_ATTEMPTS.
+                         # Amount of times tested before breaking is set in SSL_RENEG_ATTEMPTS.
                          if [[ $SERVICE != HTTP ]]; then
                               pr_svrty_medium "VULNERABLE (NOT ok)"; outln ", potential DoS threat"
                               fileout "$jsonID" "MEDIUM" "VULNERABLE, potential DoS threat" "$cve" "$cwe" "$hint"
                          else
-			      (for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep 1; done) | \
+                              (for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep 1; done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY") >$TMPFILE 2>>$ERRFILE
                               case $? in
-				   0) pr_svrty_high "VULNERABLE (NOT ok)"; outln ", DoS threat ($ssl_reneg_attempts attempts)"
+                                   0) pr_svrty_high "VULNERABLE (NOT ok)"; outln ", DoS threat ($ssl_reneg_attempts attempts)"
                                       fileout "$jsonID" "HIGH" "VULNERABLE, DoS threat" "$cve" "$cwe" "$hint"
                                       ;;
-                                   1) pr_svrty_good "not vulnerable (OK)"
-				      outln " -- mitigated (disconnect within $ssl_reneg_attempts)"
+                                   1) pr_svrty_good "not vulnerable (OK)"; outln " -- mitigated (disconnect within $ssl_reneg_attempts)"
                                       fileout "$jsonID" "OK" "not vulnerable, mitigated" "$cve" "$cwe"
                                       ;;
                                    *) prln_warning "FIXME (bug): $sec_client_renego ($ssl_reneg_attempts tries)"


### PR DESCRIPTION
See #1070 for original check and code by @poupas.

Made the SSL Client initiated renegotiation into a variable amount that can be set with an environment variable. Also, please consider this change to set default to 6 attempts.

Original was 4 attempts since node.js blocks after 3 attempts. I found that a lot of servers of customers I run into are blocking after 5 attempts. For example F5 BIG-IP recommends 5 renegotiations: https://support.f5.com/csp/article/K50023125

