### PR TITLE
fix #1757: manpage: --c has one dash to much

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -333,7 +333,7 @@ Security headers (X\-Frame\-Options, X\-XSS\-Protection, Expect\-CT,\.\.\. , CSP
 .IP "" 0
 .
 .P
-\fB\-\-c, \-\-client\-simulation\fR This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site\. For the latter case the protocol, cipher and curve is displayed, also if there\'s Forward Secrecy\. testssl\.sh uses a handselected set of clients which are retrieved by the SSLlabs API\. The output is aligned in columns when combined with the \fB\-\-wide\fR option\. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS\.
+\fB\-c, \-\-client\-simulation\fR This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site\. For the latter case the protocol, cipher and curve is displayed, also if there\'s Forward Secrecy\. testssl\.sh uses a handselected set of clients which are retrieved by the SSLlabs API\. The output is aligned in columns when combined with the \fB\-\-wide\fR option\. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS\.
 .
 .P
 \fB\-g, \-\-grease\fR checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701\. This check doesn\'t run per default\.

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -304,7 +304,7 @@ Also for multiple server certificates are being checked for as well as for the c
 </ul>
 
 
-<p><code>--c, --client-simulation</code>     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the <code>--wide</code> option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.</p>
+<p><code>-c, --client-simulation</code>     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the <code>--wide</code> option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.</p>
 
 <p><code>-g, --grease</code> checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701. This check doesn't run per default.</p>
 

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -216,7 +216,7 @@ Also for multiple server certificates are being checked for as well as for the c
 * Decodes BIG IP F5 non-encrypted cookies
 * Security headers (X-Frame-Options, X-XSS-Protection, Expect-CT,... , CSP headers). Nonsense is not yet detected here.
 
-`--c, --client-simulation`     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the `--wide` option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.
+`-c, --client-simulation`     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the `--wide` option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.
 
 `-g, --grease` checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701. This check doesn't run per default.
 


### PR DESCRIPTION
Minor documentation fix. Double-checked everything in order to get all occurrences of ```--c``` . Will submit a backport for v3.0, too.