### PR TITLE
Remove lite cyan color for http header

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3223,7 +3223,7 @@ run_security_headers() {
                case "$svrty" in
                     OK) pr_svrty_good "$header" ;;
                     LOW) pr_svrty_low "$header" ;;
-                    INFO) pr_litecyan "$header" ;;
+                    INFO) out "$header" ;;
                esac
                # Include $header when determining where to insert line breaks, but print $header
                # separately.


### PR DESCRIPTION
While we are not sure yet how we deal with "other" colors and different
backgrounds users can have, I'll remove the light cyan here until we
settle on a standard. (other=not yellow,reds,brown,greens)