### PR TITLE
Introducing --overwrite option

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -496,7 +496,10 @@ whole 9 yards
 \fB\-\-severity <severity>\fR For CSV and both JSON outputs this will only add findings to the output file if a severity is equal or higher than the \fBseverity\fR value specified\. Allowed are \fB<LOW|MEDIUM|HIGH|CRITICAL>\fR\. WARN is another level which translates to a client\-side scanning error or problem\. Thus you will always see them in a file if they occur\.
 .
 .P
-\fB\-\-append\fR Normally, if an output file already exists and it has a file size greater zero, testssl\.sh will prompt you to manually remove the file exit with an error\. \fB\-\-append\fR however will append to this file, without a header\. The environment variable APPEND does the same\. Be careful using this switch/variable\. A complementary option which overwrites an existing file doesn\'t exist per design\.
+\fB\-\-append\fR Normally, if an output file already exists and it has a file size greater zero, testssl\.sh will prompt you to manually remove the file and then exit with an error\. \fB\-\-append\fR however will append to this file, without a header\. The environment variable APPEND does the same\. Be careful using this switch/variable\.
+.
+.P
+\fB\-\-overwrite\fR Normally, if an output file already exists and it has a file size greater zero, testssl\.sh will not allow you to overwrite this file\. This option will do that \fBwithout any warning\fR\. The environment variable OVERWRITE does the same\. Be careful, you have been warned!
 .
 .P
 \fB\-\-outprefix <fname_prefix>\fR Prepend output filename prefix \fIfname_prefix\fR before \'${NODE}\-\'\. You can use as well the environment variable FNAME_PREFIX\. Using this any output files will be named \fB<fname_prefix>\-${NODE}\-p${port}${YYYYMMDD\-HHMM}\.<format>\fR when no file name of the respective output option was specified\. If you do not like the separator \'\-\' you can as well supply a \fB<fname_prefix>\fR ending in \'\.\', \'_\' or \',\'\. In this case or if you already supplied \'\-\' no additional \'\-\' will be appended to \fB<fname_prefix>\fR\.

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -415,7 +415,10 @@ Rating automatically gets disabled, to not give a wrong or misleading grade, whe
 
 <p><code>--severity &lt;severity></code> For CSV and both JSON outputs this will only add findings to the output file if a severity is equal or higher than the <code>severity</code> value specified. Allowed are <code>&lt;LOW|MEDIUM|HIGH|CRITICAL></code>. WARN is another level which translates to a client-side scanning error or problem. Thus you will always see them in a file if they occur.</p>
 
-<p><code>--append</code> Normally, if an output file already exists and it has a file size greater zero, testssl.sh will prompt you to manually remove the file exit with an error. <code>--append</code> however will append to this file, without a header. The environment variable APPEND does the same. Be careful using this switch/variable. A complementary option which overwrites an existing file doesn't exist per design.</p>
+<p><code>--append</code> Normally, if an output file already exists and it has a file size greater zero, testssl.sh will prompt you to manually remove the file and exit with an error. <code>--append</code> however will append to this file, without a header. The environment variable APPEND does the same. Be careful using this switch/variable. A complementary option which overwrites an existing file doesn't exist per design.</p>
+
+<p><code>--overwrite</code> Normally, if an output file already exists and it has a file size greater zero, testssl.sh will not allow you to overwrite this file. This option will do that <b>without any warning</b>. The environment variable OVERWRITE does the same. Be careful, you have been warned!</p>
+
 
 <p><code>--outprefix &lt;fname_prefix></code> Prepend output filename prefix <var>fname_prefix</var> before '${NODE}-'. You can use as well the environment variable FNAME_PREFIX. Using this any output files will be named <code>&lt;fname_prefix>-${NODE}-p${port}${YYYYMMDD-HHMM}.&lt;format></code> when no file name of the respective output option was specified. If you do not like the separator '-' you can as well supply a <code>&lt;fname_prefix></code> ending in '.',  '_' or ','. In this case or if you already supplied '-' no additional '-' will be appended to <code>&lt;fname_prefix></code>.</p>
 

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -327,7 +327,9 @@ Rating automatically gets disabled, to not give a wrong or misleading grade, whe
 
 `--severity <severity>` For CSV and both JSON outputs this will only add findings to the output file if a severity is equal or higher than the `severity` value specified. Allowed are `<LOW|MEDIUM|HIGH|CRITICAL>`. WARN is another level which translates to a client-side scanning error or problem. Thus you will always see them in a file if they occur.
 
-`--append` Normally, if an output file already exists and it has a file size greater zero, testssl.sh will prompt you to manually remove the file exit with an error. `--append` however will append to this file, without a header. The environment variable APPEND does the same. Be careful using this switch/variable. A complementary option which overwrites an existing file doesn't exist per design.
+`--append` Normally, if an output file already exists and it has a file size greater zero, testssl.sh will prompt you to manually remove the file and exit with an error. `--append` however will append to this file, without a header. The environment variable APPEND does the same. Be careful using this switch/variable. A complementary option which overwrites an existing file doesn't exist per design.
+
+`--overwrite` Normally, if an output file already exists and it has a file size greater zero, testssl.sh will not allow you to overwrite this file. This option will do that **without any warning**. The environment variable OVERWRITE does the same. Be careful, you have been warned!
 
 `--outprefix <fname_prefix>` Prepend output filename prefix <fname_prefix> before '${NODE}-'. You can use as well the environment variable FNAME_PREFIX. Using this any output files will be named `<fname_prefix>-${NODE}-p${port}${YYYYMMDD-HHMM}.<format>` when no file name of the respective output option was specified. If you do not like the separator '-' you can as well supply a `<fname_prefix>` ending in '.',  '_' or ','. In this case or if you already supplied '-' no additional '-' will be appended to `<fname_prefix>`.
 


### PR DESCRIPTION
Sometimes it is needed to overwrite existing output files.This has been requested in the past (#927). For safety reasons
it was not implemented.

However I realized that it could be useful. It requires some responsible usage though.

Code added, help() and manpages added -- warnings added too.