### PR TITLE
Fix reading SSLv2 socket

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14300,7 +14300,7 @@ sslv2_sockets() {
      local cipher_suites="$1"
      local client_hello len_client_hello
      local len_ciph_suites_byte len_ciph_suites
-     local server_hello sock_reply_file2
+     local server_hello sock_reply_file2 foo
      local -i response_len server_hello_len
      local parse_complete=false
 
@@ -14355,7 +14355,8 @@ sslv2_sockets() {
           if [[ -s "$SOCK_REPLY_FILE" ]]; then
                server_hello=$(hexdump -v -e '16/1 "%02X"' "$SOCK_REPLY_FILE")
                server_hello_len=$((2 + $(hex2dec "${server_hello:1:3}") ))
-               response_len=$(count_chars "$SOCK_REPLY_FILE")
+               foo="$(wc -c "$SOCK_REPLY_FILE")"
+               response_len="${foo% *}"
                for (( 1; response_len < server_hello_len; 1 )); do
                     sock_reply_file2=${SOCK_REPLY_FILE}.2
                     mv "$SOCK_REPLY_FILE" "$sock_reply_file2"
@@ -14367,10 +14368,12 @@ sslv2_sockets() {
                     [[ ! -s "$SOCK_REPLY_FILE" ]] && break
                     cat "$SOCK_REPLY_FILE" >> "$sock_reply_file2"
                     mv "$sock_reply_file2" "$SOCK_REPLY_FILE"
-                    response_len=$(count_chars "$SOCK_REPLY_FILE")
+                    foo="$(wc -c "$SOCK_REPLY_FILE")"
+                    response_len="${foo% *}"
                done
           fi
      fi
+
      debugme echo "reading server hello... "
      if [[ "$DEBUG" -ge 4 ]]; then
           hexdump -C "$SOCK_REPLY_FILE" | head -6


### PR DESCRIPTION
This fixes #1779. There was a problem introduced in
3cd1273439595603100e199422e03aa83c5fd862 which counted
the size of the file name rather than the size of the
socket reply.

The helper function count_chars() is now not used anymore.
It maybe useful in the future though.