### PR TITLE
Trying to reduced the runtime of travis

### DIFF
--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -17,7 +17,7 @@ use Data::Dumper;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $check2run_smtp="--protocols --standard --fs --server-preference --headers --vulnerable --each-cipher -q --ip=one --color 0";
+my $check2run_smtp="--protocols --standard --fs --server-preference --headers --vulnerable -q --ip=one --color 0";
 my $check2run="-q --ip=one --color 0";
 my $uri="";
 my $socket_out="";
@@ -60,12 +60,14 @@ $socket_out = `./testssl.sh $check2run -t pop3 $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
+# commented out, bc of travis' limits
+#
+#printf "\n%s\n", "STARTTLS POP3 unit tests via OpenSSL --> $uri ...";
 # unlink "tmp.json";
-printf "\n%s\n", "STARTTLS POP3 unit tests via OpenSSL --> $uri ...";
-$openssl_out = `./testssl.sh --ssl-native $check2run -t pop3 $uri 2>&1`;
+#$openssl_out = `./testssl.sh --ssl-native $check2run -t pop3 $uri 2>&1`;
 # $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
+#unlike($openssl_out, qr/$openssl_regex_bl/, "");
+#$tests++;
 
 
 $uri="imap.gmx.net:143";
@@ -93,11 +95,13 @@ $socket_out = `./testssl.sh $check2run -t xmpp $uri 2>&1`;
 unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
 
-printf "\n%s\n", "STARTTLS XMPP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `./testssl.sh --ssl-native $check2run -t xmpp $uri 2>&1`;
+# commented out, bc of travis' limits
+#
+#printf "\n%s\n", "STARTTLS XMPP unit tests via OpenSSL --> $uri ...";
+#$openssl_out = `./testssl.sh --ssl-native $check2run -t xmpp $uri 2>&1`;
 # $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
+#unlike($openssl_out, qr/$openssl_regex_bl/, "");
+#$tests++;
 
 # $uri="jabber.ccc.de:5269";
 # printf "\n%s\n", "Quick STARTTLS XMPP S2S unit tests via sockets --> $uri ...";
@@ -118,13 +122,15 @@ $socket_out =~ s/ error querying OCSP responder .*\n//g;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-printf "\n%s\n", "STARTTLS FTP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `./testssl.sh --ssl-native $check2run -t ftp $uri 2>&1`;
+# commented out, bc of travis' limits
+#
+# printf "\n%s\n", "STARTTLS FTP unit tests via OpenSSL --> $uri ...";
+# $openssl_out = `./testssl.sh --ssl-native $check2run -t ftp $uri 2>&1`;
 # $openssl_json = json('tmp.json');
 # OCSP stapling fails sometimes with: 'offered, error querying OCSP responder (ERROR: No Status found)'
-$openssl_out =~ s/ error querying OCSP responder .*\n//g;
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
+# $openssl_out =~ s/ error querying OCSP responder .*\n//g;
+# unlike($openssl_out, qr/$openssl_regex_bl/, "");
+# $tests++;
 
 
 # https://ldapwiki.com/wiki/Public%20LDAP%20Servers
@@ -146,11 +152,13 @@ $socket_out = `./testssl.sh $check2run -t nntp $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-printf "\n%s\n", "STARTTLS NNTP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `./testssl.sh --ssl-native $check2run -t nntp $uri 2>&1`;
+# commented out, bc of travis' limits
+#
+#printf "\n%s\n", "STARTTLS NNTP unit tests via OpenSSL --> $uri ...";
+#$openssl_out = `./testssl.sh --ssl-native $check2run -t nntp $uri 2>&1`;
 # $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
+#unlike($openssl_out, qr/$openssl_regex_bl/, "");
+#$tests++;
 
 
 # IRC: missing

--- a/t/23_client_simulation.t
+++ b/t/23_client_simulation.t
@@ -53,12 +53,14 @@ $socket_out = `./testssl.sh $check2run -t smtp $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
+# commented out, bc of travis' limits
+#
 # unlink "tmp.json";
-printf "\n%s\n", "STARTTLS: Client simulations unit test via OpenSSL --> $uri ...";
-$openssl_out = `./testssl.sh --ssl-native $check2run -t smtp $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
+#printf "\n%s\n", "STARTTLS: Client simulations unit test via OpenSSL --> $uri ...";
+#$openssl_out = `./testssl.sh --ssl-native $check2run -t smtp $uri 2>&1`;
+## $openssl_json = json('tmp.json');
+#unlike($openssl_out, qr/$openssl_regex_bl/, "");
+#$tests++;
 
 done_testing($tests);
 unlink "tmp.json";

--- a/t/31_isJSON_valid.t
+++ b/t/31_isJSON_valid.t
@@ -9,7 +9,7 @@ use JSON;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $check2run ="--ip=one -q --color 0";
+my $check2run ="--ip=one --ids-friendly -q --color 0";
 my $uri="";
 my $json="";
 my $out="";
@@ -44,7 +44,7 @@ $tests++;
 
 
 #3
-# This testss.sh run deliberately does NOT work as travis-ci.org blocks port 25 egress.
+# This testssl.sh run deliberately does NOT work as travis-ci.org blocks port 25 egress.
 # but the output should be fine. The idea is to have a unit test for a failed connection.
 printf "%s\n", ".. plain JSON for a failed run: '--mx $uri' ...";
 $out = `./testssl.sh --ssl-native --openssl-timeout=10 $check2run --jsonfile tmp.json --mx $uri`;

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -15,7 +15,7 @@ my $out="";
 my $html="";
 my $debughtml="";
 my $edited_html="";
-my $check2run="--ip=one --color 0 --htmlfile tmp.html";
+my $check2run="--ip=one --ids-friendly --color 0 --htmlfile tmp.html";
 my $diff="";
 die "Unable to open $prg" unless -f $prg;
 

--- a/t/33_isJSON_severitylevel_valid.t
+++ b/t/33_isJSON_severitylevel_valid.t
@@ -21,7 +21,7 @@ unlink 'tmp.json';
 
 #1
 pass(" .. running testssl.sh against badssl.com to create a JSON report with severity level equal greater than LOW (may take 2~3 minutes)"); $tests++;
-$out = `./testssl.sh -S -e -U --jsonfile tmp.json --severity LOW --color 0 badssl.com`;
+$out = `./testssl.sh -S -e -U --ids-friendly --jsonfile tmp.json --severity LOW --color 0 badssl.com`;
 $json = json('tmp.json');
 unlink 'tmp.json';
 $found = 0;
@@ -36,7 +36,7 @@ is($found,0,"We should not have any finding with INFO level"); $tests++;
 
 #2
 pass(" .. running testssl.sh against badssl.com to create a JSON-PRETTY report with severity level equal greater than LOW (may take 2~3 minutes)"); $tests++;
-$out = `./testssl.sh -S -e -U --jsonfile-pretty tmp.json --severity LOW --color 0 badssl.com`;
+$out = `./testssl.sh -S -e -U --ids-friendly --jsonfile-pretty tmp.json --severity LOW --color 0 badssl.com`;
 $json_pretty = json('tmp.json');
 unlink 'tmp.json';
 $found = 0;

--- a/t/51_badssl.com.t
+++ b/t/51_badssl.com.t
@@ -14,7 +14,7 @@ my (
 );
 # OK
 pass("Running testssl.sh against badssl.com to create a baseline (may take 2~3 minutes)"); $tests++;
-my $okout = `./testssl.sh -S -e --freak --logjam --drown --rc4 --sweet32 --breach --crime --jsonfile tmp.json --color 0 badssl.com`;
+my $okout = `./testssl.sh -S -e --freak --logjam --drown --rc4 --sweet32 --breach --winshock --crime --jsonfile tmp.json --color 0 badssl.com`;
 my $okjson = json('tmp.json');
 unlink 'tmp.json';
 cmp_ok(@$okjson,'>',10,"We have more then 10 findings"); $tests++;

--- a/t/61_diff_testsslsh.t
+++ b/t/61_diff_testsslsh.t
@@ -18,7 +18,7 @@ my $tests = 0;
 my $prg="./testssl.sh";
 my $master_socket_csv="./t/baseline_data/default_testssl.csvfile";
 my $socket_csv="tmp.csv";
- my $check2run="-p -s -P --fs -h -U -c -q --ip=one --color 0 --csvfile $socket_csv";
+my $check2run="-p -s -P --fs -h -U -c -q --ip=one --color 0 --csvfile $socket_csv";
 #my $check2run="-p --color 0 --csvfile $socket_csv";
 my $uri="testssl.sh";
 my $diff="";
@@ -49,8 +49,8 @@ $master_socket_csv=~ s/HTTP_clock_skew.*\n//g;
 # Compare the differences to the master file -- and print differences if there were detected.
 # Filtering takes place later, so if there will be a difference detected it'll also show HTTP_clock_skew :-(
 #
-cmp_ok($socket_csv, "eq", $master_socket_csv, "Check whether CSV output matches master file from $uri") and
-     printf "\n%s\n", "$diff";
+cmp_ok($socket_csv, "eq", $master_socket_csv, "Check whether CSV output matches master file from $uri") or
+     diag ("\n%s\n", "$diff");
 
 $tests++;
 


### PR DESCRIPTION
Often in the past travis was hitting a limit (50min?).

This is a try to make reasonable cuts to the unit tests:

- For STARTTLS some checks with OPenSSL are skipped
- For JSON and HTML outputs --ids-friendly was added assumming we
  don't change the output of ticketbleed, CCSI, HeartBleed and ROBOT any more.
- There's also not point to run those checks against badssl
- for  the diff check we switch to 'or diag' to display a dfifference