### PR TITLE
Client simulation per default as wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
 * Added environment variable for amount of attempts for ssl renegotiation check
 * Added --user-agent argument to support using a custom User Agent
 * Added --overwrite argument to support overwriting output files without warning
-* Headerflag X-XSS-Protection is labeled as INFO 
+* Headerflag X-XSS-Protection is now labeled as INFO
+* Client simulation runs in wide mode which is even better readable
 
 ### Features implemented / improvements in 3.0
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -4814,21 +4814,19 @@ run_client_simulation() {
      outln
      debugme echo
 
-     if "$WIDE"; then
-          if [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]]; then
-               out " Browser                      Protocol  Cipher Suite Name (OpenSSL)       "
-               ( "$using_sockets" || "$HAS_DH_BITS") && out "Forward Secrecy"
-               outln
-               out "--------------------------------------------------------------------------"
-          else
-               out " Browser                      Protocol  Cipher Suite Name (IANA/RFC)                      "
-               ( "$using_sockets" || "$HAS_DH_BITS") && out "Forward Secrecy"
-               outln
-               out "------------------------------------------------------------------------------------------"
-          fi
-          ( "$using_sockets" || "$HAS_DH_BITS") && out "----------------------"
+     if [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]]; then
+          out " Browser                      Protocol  Cipher Suite Name (OpenSSL)       "
+          ( "$using_sockets" || "$HAS_DH_BITS") && out "Forward Secrecy"
           outln
+          out "--------------------------------------------------------------------------"
+     else
+          out " Browser                      Protocol  Cipher Suite Name (IANA/RFC)                      "
+          ( "$using_sockets" || "$HAS_DH_BITS") && out "Forward Secrecy"
+          outln
+          out "------------------------------------------------------------------------------------------"
      fi
+     ( "$using_sockets" || "$HAS_DH_BITS") && out "----------------------"
+     outln
      if ! "$using_sockets"; then
           # We can't use the connectivity checker here as of now the openssl reply is always empty (reason??)
           save_max_ossl_fail=$MAX_OSSL_FAIL
@@ -4938,27 +4936,23 @@ run_client_simulation() {
                               cipher="$(openssl2rfc "$cipher")"
                               [[ -z "$cipher" ]] && cipher=$(get_cipher $TMPFILE)
                          fi
-                         out "$proto "
-                         "$WIDE" && out "  "
+                         out "$proto   "
                          if [[ "$COLOR" -le 2 ]]; then
                               out "$cipher"
                          else
                               pr_cipher_quality "$cipher"
                          fi
-                         if "$WIDE"; then
-                              if [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]]; then
-                                   for (( j=${#cipher}; j < 34; j++ )); do
-                                        out " "
-                                   done
-                              else
-                                   for (( j=${#cipher}; j < 50; j++ )); do
-                                        out " "
-                                   done
-                              fi
+                         if [[ "$DISPLAY_CIPHERNAMES" =~ openssl ]]; then
+                              for (( j=${#cipher}; j < 34; j++ )); do
+                                   out " "
+                              done
+                         else
+                              for (( j=${#cipher}; j < 50; j++ )); do
+                                   out " "
+                              done
                          fi
                          if [[ -n "$what_dh" ]]; then
                               [[ -n "$curve" ]] && curve="($curve)"
-                              "$WIDE" || out ", "
                               if [[ "$what_dh" == ECDH ]]; then
                                    pr_ecdh_quality "$bits" "$(printf -- "%-12s" "$bits bit $what_dh") $curve"
                               else
@@ -4966,7 +4960,6 @@ run_client_simulation() {
                               fi
                          else
                               if "$HAS_DH_BITS" || ( "$using_sockets" && [[ -n "${handshakebytes[i]}" ]] ); then
-                                   "$WIDE" || out ", "
                                    out "No FS"
                               fi
                          fi


### PR DESCRIPTION
... in order to be consistent with run_server_preference().

The wide formatting of other tests need some inspection and
off the top off my head are not as perfectly formatted so that
they should not run per default in wide mode.