### PR TITLE
Refactor `apk` usage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache bash procps drill git coreutils libidn curl && \
+    apk add bash procps drill git coreutils libidn curl && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \
     ln -s /home/testssl/testssl.sh /usr/local/bin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.11
 RUN apk update && \
     apk upgrade && \
     apk add bash procps drill git coreutils libidn curl && \
+    rm -rf /var/cache/apk/* && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \
     ln -s /home/testssl/testssl.sh /usr/local/bin/ && \


### PR DESCRIPTION
Here are two changes:

1. Remove `--no-cache` for `apk` in Dockerfile
2. Clean up apk cache in Dockerfile after packages installed

These will make the build faster and the built image smaller.

The details are in the commit message.