### PR TITLE
Fixes the search for a non-executable socat binary

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19195,7 +19195,7 @@ find_socat() {
      if [[ $? -ne 0 ]]; then
           return 1
      else
-          if [[ -x $result ]] && $result -V | grep -iaq 'socat version' ; then
+          if [[ -x $result ]] && $result -V 2>&1 | grep -iaq 'socat version' ; then
                SOCAT=$result
                return 0
           fi


### PR DESCRIPTION
... otherwise there would be an ugly screen output. This commit squashes the error message on the screen.