### PR TITLE
[WIP] Add MTA-STS 

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7515,7 +7515,7 @@ sub_mta_sts() {
           pr_svrty_low "invalid"
           # Append to every element a string, here: '|'. n would work as well but we'd need $spaces.
           # Catch is also for the last, so maybe we should avoid arrays
-          # Hint is from http://web.archive.org/web/20101114051536/http://codesnippets.joyent.com/posts/show/1826
+          # Hint is from https://web.archive.org/web/20101114051536/http://codesnippets.joyent.com/posts/show/1826
           failreason_mtasts_rec=( "${failreason_mtasts_rec[@]/%/ | }" )
           fileout "${jsonID}_txtrecord" "LOW" "invalid _mta-sts TXT record $mta_sts_record $(printf '%s | ' "{failreason_mtasts_rec[@]}")"
           outln " _mta-sts TXT record '${mta_sts_record}'\n${spaces}   $(printf '%s' "${failreason_mtasts_rec[@]}")"

--- a/testssl.sh
+++ b/testssl.sh
@@ -7421,6 +7421,7 @@ sub_mta_sts() {
 
      if [[ -z "$mta_sts_record" ]]; then
           failreason_mtasts_rec="no record"
+          mta_sts_record_ok=false
      else
           if [[ $(count_char_occurence "$mta_sts_record" ';') -ne 2 ]]; then
                failreason_mtasts_rec+=("number of ; should be 2")
@@ -7442,6 +7443,7 @@ sub_mta_sts() {
                fi
           fi
      fi
+set +x
 
      policy="$(safe_echo "GET /.well-known/mta-sts.txt HTTP/1.1\r\nHost: mta-sts.$domain\r\nUser-Agent: $useragent\r\nAccept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n" | $OPENSSL s_client $(s_client_options "-quiet -ign_eof -connect mta-sts.$domain:443 $PROXY -servername mta-sts.$domain") 2>$ERRFILE)"
      # here also the openssl return val needs to be checked
@@ -7504,7 +7506,7 @@ sub_mta_sts() {
      # now the verdicts
      if "$mta_sts_record_ok"; then
           pr_svrty_good "valid"
-          outln " _mta-sts TXT record \'$mta_sts_record\'"
+          outln " _mta-sts TXT record '$mta_sts_record'"
           # quotes!
           fileout "${jsonID}_txtrecord" "OK" "valid _mta-sts TXT record $mta_sts_record"
      elif [[ -z "$mta_sts_record" ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -7394,23 +7394,19 @@ sub_mta_sts() {
                     domain=${NODE#*.}
                     mta_sts_record="$(get_txt_record _mta-sts.$domain)"
                fi
-               if [[ -z "$mta_sts_record" ]]; then
-                    # unset to signal we didn't have success
-                    domain=""
-               fi
           else
                echo "#FIXME"
                echo "NODE: $NODE / URI: $URI / CMDLINE: ${CMDLINE[@]}"
           fi
      fi
+
      # 2+ level of subdomains?
      # we check only for the TXT record in subdomains and give up if there's nothing??
      # Possible that TXT record for domain overrides sub domain. if so: when ?
-     # error: ./testssl.sh -S --mx gmail.com --> no _mta-sts TXT record
-     # --mx does this test for every single MX. We need to save the values
+     # - ./testssl.sh -S --mx gmail.com --> no _mta-sts TXT record ?
+     # -  --mx does this for every single MX. As the values are domain specific: global array?
 
-
-     [[ -z "mta_sts_record" ]] && mta_sts_record="$(get_txt_record _mta-sts.$domain)"
+     [[ -z "$mta_sts_record" ]] && mta_sts_record="$(get_txt_record _mta-sts.$domain)"
      # echo "$mta_sts_record"; echo
 
      mta_sts_record_ok=true
@@ -7457,7 +7453,7 @@ sub_mta_sts() {
                fi
           done
 
-          # we use at most 10 spaces. ToDo: look into the policy
+          # we use at most 10 spaces. ToDo: check with RFC wrt to the format of the policy
           if "$policy_ok"; then
                if [[ ! "$policy" =~ version[\ ]{0,10}:[\ ]{0,10}STSv1 ]]; then
                     failreason_policy+=("version should be STSv1 ")
@@ -7468,7 +7464,7 @@ sub_mta_sts() {
                     policy_ok=false
                fi
                if [[ ! "$policy" =~ mode[\ ]{0,10}:[\ ]{0,10}(enforce|testing) ]]; then
-                    failreason_policy+=("policy is neither testing or enforce")
+                    failreason_policy+=("policy should be either testing or enforce")
                     policy_ok=false
                fi
                if [[ "$policy" =~ mode[\ ]{0,10}:[\ ]{0,10}testing ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -7362,6 +7362,7 @@ tls_time() {
 }
 
 # rfc8461, rfc8460
+#
 sub_mta_sts() {
      local mta_sts_record=""
      local policy=""
@@ -7387,7 +7388,7 @@ sub_mta_sts() {
      if [[ "${CMDLINE[@]}" =~ \ --mx\  ]]; then
           domain="$URI"
      elif [[ fqdnparts -eq 2 ]] && [[ "$NODE" == ${URI%:*} ]]; then
-          # remove the port an check whether bot are the same when there's no subdomain
+          # remove the port and check whether bot are the same when there's no subdomain
           domain="$NODE"
      else
           # What's left now is a sub.domain.tld or sub.sub.domain.tld or ...
@@ -7443,10 +7444,11 @@ sub_mta_sts() {
                fi
           fi
      fi
-set +x
 
      policy="$(safe_echo "GET /.well-known/mta-sts.txt HTTP/1.1\r\nHost: mta-sts.$domain\r\nUser-Agent: $useragent\r\nAccept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n" | $OPENSSL s_client $(s_client_options "-quiet -ign_eof -connect mta-sts.$domain:443 $PROXY -servername mta-sts.$domain") 2>$ERRFILE)"
-     # here also the openssl return val needs to be checked
+     # echo "${PIPESTATUS[0]} ${PIPESTATUS[1]} ${PIPESTATUS[2]}"
+     # set -o pipefail? --> https://unix.stackexchange.com/questions/14270/get-exit-status-of-process-thats-piped-to-another
+    # here also the openssl return val needs to be checked
 
      policy="$(print_after_blankline "$policy")"
      # echo "$policy"; echo
@@ -7463,7 +7465,7 @@ set +x
                fi
           done
 
-          # we use at most 10 spaces. ToDo: check with RFC wrt to the format of the policy
+          #TODO: check with RFC wrt to the format of the policy
           if "$policy_ok"; then
                if [[ ! "$policy" =~ version:[\ ]+STSv1 ]]; then
                     failreason_policy+=("version should be STSv1 ")
@@ -7527,13 +7529,13 @@ set +x
      if "$policy_ok"; then
           if [[ $policy_mode == testing ]]; then
                out "\"none\" is a valid policy but why are you using it?"
-               fileout "${jsonID}_policy" "INFO" "none is valid but not a helpful policy  at https://mta-sts.$domain/.well-known/mta-sts.txt"
+               fileout "${jsonID}_policy" "INFO" "none is valid but not a helpful policy at https://mta-sts.$domain/.well-known/mta-sts.txt"
           elif [[ $policy_mode == testing ]]; then
                out "valid but not enforced"
-               fileout "${jsonID}_policy" "INFO" "valid but not enforced policy  at https://mta-sts.$domain/.well-known/mta-sts.txt"
+               fileout "${jsonID}_policy" "INFO" "valid but not enforced policy at https://mta-sts.$domain/.well-known/mta-sts.txt"
           else
                pr_svrty_good "valid and enforced"
-               fileout "${jsonID}_policy" "OK" "valid and enforced policy  at https://mta-sts.$domain/.well-known/mta-sts.txt"
+               fileout "${jsonID}_policy" "OK" "valid and enforced policy at https://mta-sts.$domain/.well-known/mta-sts.txt"
           fi
           outln " policy https://mta-sts.$domain/.well-known/mta-sts.txt"
      elif [[ -z "$policy" ]]; then
@@ -7550,11 +7552,11 @@ set +x
      out "$spaces"
 
      if "$smtp_tls_record_ok"; then
-          outln "found (optional) TLS RPT TXT record '$smtp_tls_record'"
+          outln "found optional TLS RPT TXT record '$smtp_tls_record'"
           fileout "${jsonID}_tlsrpt" "INFO" "optional TLS-RPT TXT record '$smtp_tls_record'"
      else
           outln "No TLS RPT record"
-          fileout "${jsonID}_tlsrpt" "INFO" "no or invalid (optional) TLS RPT record '$smtp_tls_record'"
+          fileout "${jsonID}_tlsrpt" "INFO" "no or invalid optional TLS RPT record '$smtp_tls_record'"
      fi
 
      return 0


### PR DESCRIPTION
This PR adds an implementation of MTA-STS (RFC 8461), see also issue #1073

Currently it's a WIP.

What doesn't work
- <s>test a hostname which is not equal to domainname</s>
-  <s>test a hostname which has no mx record</s>
- <s>file output</s>
- <s>any</s> compliance parsing of TLS RPT TXT record + .well-known/mta-sts.txt
- <s>when no TXT records or .well-known/mta-sts.txt are there</s>
- <s>colored screen output</s>

Needed:
 - More testing and errors to be addressed.
 - sub.sub.domain.tld probably doesn't work
 - --mx does a check for every single MX instead of keeping the results
 - Policy delegation (CNAME?) --> Not tested yet
 - A simple unit test would be great. Anybody?

There's a new stub function for DANE too.

Besides: to avoid confusion I changed all GET requests over HTTPS from ``tm_out`` to ``safe_echo``. It's actually exactly the same only the name is different but it seems more appropriate here.