### PR TITLE
Fix issuer check for Let's Encrypt (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8710,7 +8710,7 @@ certificate_info() {
      fi
      # We adjust the thresholds by %50 for LE certificates, relaxing warnings for those certificates.
      # . instead of \' because it does not break syntax highlighting in vim
-     if [[ "$issuer_CN" =~ ^Let.s\ Encrypt\ Authority ]] ; then
+     if [[ "$issuer_O" =~ ^Let.s\ Encrypt ]] ; then
           days2warn2=$((days2warn2 / 2))
           days2warn1=$((days2warn1 / 2))
      fi


### PR DESCRIPTION
Fixes #1816 for 3.0 by a proper halving of the dates