### PR TITLE
add codepoints for RFC7905, ChaCha20-Poly1305

### DIFF
--- a/openssl-iana.mapping.html
+++ b/openssl-iana.mapping.html
@@ -430,6 +430,15 @@ xB9  TLS_RSA_PSK_WITH_NULL_SHA384
 <tr><td> [0xcc14]</td><td>   ECDHE-ECDSA-CHACHA20-POLY1305-OLD</td><td> ECDH     </td><td>   ChaCha20-Poly1305</td><td>    </td><td> TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256_OLD</td></tr>
 <tr><td> [0xcc15]</td><td>   DHE-RSA-CHACHA20-POLY1305-OLD    </td><td> DH       </td><td>   ChaCha20-Poly1305</td><td>    </td><td> TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256_OLD</td></tr>
 
+<!-- RFC7905, ChaCha20-Poly1305 -->
+<tr><td> [0xcca8]</td><td>   ECDHE-RSA-CHACHA20-POLY1305 </td><td> ECDH     </td><td>   ChaCha20-Poly1305</td><td> 256  </td><td> TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+<tr><td> [0xcca9]</td><td>   ECDHE-ECDSA-CHACHA20-POLY1305 </td><td> ECDH     </td><td>   ChaCha20-Poly1305</td><td> 256  </td><td> TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+<tr><td> [0xccaa]</td><td>   DHE-RSA-CHACHA20-POLY1305 </td><td> DH     </td><td>   ChaCha20-Poly1305</td><td> 256 </td><td> TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+<tr><td> [0xccab]</td><td>   PSK-CHACHA20-POLY1305 </td><td> PSK </td><td>   ChaCha20-Poly1305</td><td> 256 </td><td> TLS_PSK_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+<tr><td> [0xccac]</td><td>   ECDHE-PSK-CHACHA20-POLY1305 </td><td> ECDH/PSK </td><td>   ChaCha20-Poly1305</td><td> 256  </td><td> TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+<tr><td> [0xccad]</td><td>   DHE-PSK-CHACHA20-POLY1305 </td><td> DH/PSK </td><td>   ChaCha20-Poly1305</td><td> 256 </td><td> TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+<tr><td> [0xccae]</td><td>   RSA-PSK-CHACHA20-POLY1305 </td><td> RSA/PSK </td><td>   ChaCha20-Poly1305</td><td> 256 </td><td> TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256</td></tr>
+
 <tr><td> [0xff00]</td><td>   GOST-MD5                     </td><td> RSA      </td><td>   GOST89  </td><td>  256    </td><td>TLS_GOSTR341094_RSA_WITH_28147_CNT_MD5</td></tr>
 <tr><td> [0xff01]</td><td>   GOST-GOST94                  </td><td> RSA      </td><td>   GOST89  </td><td>  256    </td><td>TLS_RSA_WITH_28147_CNT_GOST94</td></tr>
 <tr><td> [0xff02]</td><td>   GOST-GOST89MAC               </td><td> RSA      </td><td>   GOST89  </td><td>  256    </td></tr>


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7905 has the code points for ChaCha20-Poly1305, which testssl.sh does verify/report, but the conversion table doesn't currently include.

This PR adds these entries.