### PR TITLE
Use locally scoped counter in hex2binary

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2066,7 +2066,7 @@ fi
 # key) or a text string (e.g., ASCII-encoded text).
 hex2binary() {
      local s="$1"
-     local -i len remainder
+     local -i i len remainder
 
      len=${#s}
      [[ $len%2 -ne 0 ]] && return 1


### PR DESCRIPTION
In [the commit 3756cdc](https://github.com/drwetter/testssl.sh/commit/3756cdcb38e95e7f31f90fbd53e95d020faae55a), `xxd` was introduced and works as intended. However, in absence of `xxd` like in the official docker image for `testssl`, the test never finishes and remains tuck in TLS handshake at:

```
 Testing robust forward secrecy (FS) -- omitting Null Authentication/Encryption, 3DES, RC4
  Elliptic curves offered:     prime256v1 secp384r1 secp521r1 X25519 X448
  ...
  ```
  
  It looks like the local scope definition was removed unintentionally, using a locally scoped counter works fine.
  
  Please take a look!