### PR TITLE
Add xxd to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 RUN apk update && \
     apk upgrade && \
-    apk add bash procps drill git coreutils libidn curl socat openssl && \
+    apk add bash procps drill git coreutils libidn curl socat openssl xxd && \
     rm -rf /var/cache/apk/* && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \


### PR DESCRIPTION
xxd is not a strict requirement and a fallback logic exists to handle its absence. However it is in general more performant and helpful in debugging as well which is desirable in many situations like ci/cd pipelines. See commit 3756cdc for details