### PR TITLE
Ensure certain regex patterns work as expected and aren't localized

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -234,6 +234,7 @@ SSL_RENEG_ATTEMPTS=${SSL_RENEG_ATTEMPTS:-6}       # number of times to check SSL
 
 ########### Initialization part, further global vars just being declared here
 #
+LC_COLLATE=en_US.UTF-8                  # ensures certain regex patterns work as expected and aren't localized, see #1860
 SYSTEM2=""                              # currently only being used for WSL = bash on windows
 PRINTF=""                               # which external printf to use. Empty presets the internal one, see #1130
 CIPHERS_BY_STRENGTH_FILE=""


### PR DESCRIPTION
see #1860 .

This PR is trying to address an issue where probably newer bash versions treat regexes differently  in other locales, W is just a variant of V see also e.g.

https://collation-charts.org/opensolaris/opensolaris.2008.05.sv_SE.UTF-8.html
https://www.sqlservercentral.com/forums/topic/order-by-name-not-works#post-1644177