### PR TITLE
Ensure certain regex patterns work as expected and aren't localized (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -269,6 +269,7 @@ declare -r UA_SNEAKY="Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Fi
 
 ########### Initialization part, further global vars just being declared here
 #
+LC_COLLATE=en_US.UTF-8                  # ensures certain regex patterns work as expected and aren't localized, see #1860
 PRINTF=""                               # which external printf to use. Empty presets the internal one, see #1130
 IKNOW_FNAME=false
 FIRST_FINDING=true                      # is this the first finding we are outputting to file?


### PR DESCRIPTION
Same as PR #1865.

This PR is trying to address an issue where probably newer bash versions treat
regexes differently in other locales. W is with a swedish locale just a variant
of V (#1860) see also e.g.

https://collation-charts.org/opensolaris/opensolaris.2008.05.sv_SE.UTF-8.html
https://www.sqlservercentral.com/forums/topic/order-by-name-not-works#post-1644177