### PR TITLE
Literal HT character issue in JSON output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1170,10 +1170,18 @@ fileout_section_footer() {
      SECTION_FOOTER_NEEDED=false
 }
 
+sanitize_json_string() {
+     local str="$1"
+     str=${str//	/\\t} # \t (tab)
+
+     echo -n "$str"
+}
+
+
 fileout_json_print_parameter() {
      local parameter="$1"
      local filler="$2"
-     local value="$3"
+     local value=$(sanitize_json_string "$3")
      local not_last="$4"
      local spaces=""
 


### PR DESCRIPTION
Fixes issue with values which include literal horizontal tabulation (HT). HT cannot be in JSON and scan of e.g. `rr.cesnet.cz` produces an invalid JSON file, because of HTs in header value. New function `sanitize_json_string()` substitutes HT with \t. There might be other characters that should be escaped as "[https://stackoverflow.com/a/11495576](https://stackoverflow.com/a/11495576)" suggests.