### PR TITLE
Print errors to stderr

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22328,7 +22328,7 @@ parse_cmd_line() {
                     [[ $? -eq 0 ]] && shift
                     case "$MASS_TESTING_MODE" in
                          serial|parallel) ;;
-                         *)   tmln_magenta "\nmass testing mode can be either \"serial\" or \"parallel\""
+                         *)   tmln_magenta "\nmass testing mode can be either \"serial\" or \"parallel\"" 1>&2
                               help 1
                     esac
                     ;;
@@ -22343,7 +22343,7 @@ parse_cmd_line() {
                     [[ $? -eq 0 ]] && shift
                     case "$WARNINGS" in
                          batch|off) ;;
-                         *)   tmln_magenta "\nwarnings can be either \"batch\", or \"off\""
+                         *)   tmln_magenta "\nwarnings can be either \"batch\", or \"off\"" 1>&2
                               help 1
                     esac
                     ;;
@@ -22361,7 +22361,7 @@ parse_cmd_line() {
                     [[ $? -eq 0 ]] && shift
                     case $DEBUG in
                          [0-6]) ;;
-                         *)   tmln_magenta_term "\nunrecognized debug value \"$1\", must be between 0..6" 1>&2
+                         *)   tmln_magenta "\nunrecognized debug value \"$1\", must be between 0..6" 1>&2
                               help 1
                     esac
                     ;;
@@ -22584,7 +22584,7 @@ parse_cmd_line() {
                          no-rfc|no-iana) DISPLAY_CIPHERNAMES="openssl-only" ;;
                          openssl) DISPLAY_CIPHERNAMES="openssl" ;;
                          rfc|iana) DISPLAY_CIPHERNAMES="rfc" ;;
-                         *)   tmln_warning "\nmapping can only be \"no-openssl\", \"no-iana\"(\"no-rfc\"), \"openssl\" or \"iana\"(\"rfc\")"
+                         *)   tmln_warning "\nmapping can only be \"no-openssl\", \"no-iana\"(\"no-rfc\"), \"openssl\" or \"iana\"(\"rfc\")" 1>&2;
                               help 1 ;;
                     esac
                     ;;


### PR DESCRIPTION
In `parse_cmd_line()` error messages are usually printed to stderr, but in three places the messages are printed to stdout. This PR modifies those three lines so that they also print to stderr.

The PR also replaces a call to a non-existent function, `tmln_magenta_term`, with a call to `tmln_magenta`.