### PR TITLE
Fix compression detection variable syntax in run_breach()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -16446,7 +16446,7 @@ run_breach() {
                     elif [[ "$detected_compression" =~ no_compression ]]; then
                          has_compression+=("$c:no")
                          debugme echo "has_compression: $c: no"
-                    elif [[ -n "detected_compression" ]]; then
+                    elif [[ -n "$detected_compression" ]]; then
                          has_compression+=("$c:yes")
                          debugme echo "has_compression: $c: yes"
                     else


### PR DESCRIPTION
The `$` symbol of the variable seems to be missing.

cc #1636