### PR TITLE
Make Shell Scripts' Shebang more consistent and portable

### DIFF
--- a/utils/ccs-injection.bash
+++ b/utils/ccs-injection.bash
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 
 # POC bash socket implementation of CCS Injection vulnerability in OpenSSL (CVE-2014-0224), 
 # see https://www.openssl.org/news/secadv_20140605.txt

--- a/utils/checkcert.sh
+++ b/utils/checkcert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 
 
 # on the command line:

--- a/utils/docker-nginx.tls13-earlydata.start.sh
+++ b/utils/docker-nginx.tls13-earlydata.start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 image="rsnow/nginx"
 docker pull $image

--- a/utils/heartbleed.bash
+++ b/utils/heartbleed.bash
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash
 
 # POC bash socket implementation of heartbleed (CVE-2014-0160), see also http://heartbleed.com/
 # Author: Dirk Wetter, GPLv2 see https://testssl.sh/LICENSE.txt 

--- a/utils/hexstream2cipher.sh
+++ b/utils/hexstream2cipher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 hs="$1"
 len=${#hs}

--- a/utils/hexstream2curves.sh
+++ b/utils/hexstream2curves.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 hs="$1"
 len=${#hs}

--- a/utils/make-openssl111.sh
+++ b/utils/make-openssl111.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  vim:tw=90:ts=5:sw=5
 #

--- a/utils/resume.sh
+++ b/utils/resume.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # simple check for seesion resumption 1) by SID, 2) by tickets
 # Author: Dirk Wetter, GPLv2 see https://testssl.sh/LICENSE.txt

--- a/utils/ticketbleed.bash
+++ b/utils/ticketbleed.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Fast and reliable POC bash socket implementation of ticketbleed (CVE-2016-9244), see also http://ticketbleed.com/
 # Author: Dirk Wetter, GPLv2 see https://testssl.sh/LICENSE.txt


### PR DESCRIPTION
Some of them were `#!/bin/bash`, for the portability and consistency, they should be `#!/usr/bin/env bash` just like the script `testssl.sh` itself, shouldn't they 😄 