### PR TITLE
Make Shell Scripts' Shebang more consistent

### DIFF
--- a/utils/docker-debian10.tls13only.start.sh
+++ b/utils/docker-debian10.tls13only.start.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 # no early data, but TLS 1.3 with debian:buster (sid simlar in Feb 2019)
 

--- a/utils/gmap2testssl.sh
+++ b/utils/gmap2testssl.sh
@@ -1,4 +1,6 @@
-#/bin/sh -e
+#!/usr/bin/env bash
+
+set -e
 
 # utility which converts grepable nmap outout to testssl's file input
 

--- a/utils/make-openssl.sh
+++ b/utils/make-openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script compiles the "bad openssl" version, 1.0.2 supporting legacy
 # cryptography for Linux, FreeBSD and Darwin.


### PR DESCRIPTION
Consider most of the scripts use bash in the project, should maybe just
use it, instead of /bin/sh in all the scripts.