### PR TITLE
Correct `exit` using, the exit status should be 0~255

### DIFF
--- a/utils/00_unittest_baseline.sh
+++ b/utils/00_unittest_baseline.sh
@@ -28,7 +28,7 @@ check_result() {
 
      remove_quotes
      json_result="$(awk '/id.*'"${1}"'/,/finding.*$/' $FILE)"
-     [[ -z $json_result ]] && exit -1
+     [[ -z $json_result ]] && exit 1
      # is4lines?
      finding_value="$(awk -F':' '/finding/ { print $2" "$3" "$4 }' <<< "$json_result")"
      if [[ $# -eq 2 ]]; then

--- a/utils/curves.bash
+++ b/utils/curves.bash
@@ -62,8 +62,8 @@ HN="$1"
 [ -z "$HN" ] && HN=testssl.sh
 find_openssl_binary 
 
-ERRFILE=$(mktemp /tmp/curve_tester.R.XXXXXX) || exit -6
-TMPFILE=$(mktemp /tmp/curve_tester.T.XXXXXX) || exit -6
+ERRFILE=$(mktemp /tmp/curve_tester.R.XXXXXX) || exit 6
+TMPFILE=$(mktemp /tmp/curve_tester.T.XXXXXX) || exit 6
 
 
 for curve in $($OPENSSL ecparam -list_curves | awk -F':' '/:/ { print $1 }'); do

--- a/utils/generate_static_cipher_lists.sh
+++ b/utils/generate_static_cipher_lists.sh
@@ -96,7 +96,7 @@ get_mapping_file() {
 
      if [[ ! -r "$CIPHERS_BY_STRENGTH_FILE" ]] ; then
           outln "\nATTENTION: No cipher mapping file found!"
-          exit -2
+          exit 2
      fi
 
      while read TLS_CIPHER_HEXCODE[TLS_NR_CIPHERS] n TLS_CIPHER_OSSL_NAME[TLS_NR_CIPHERS] TLS_CIPHER_RFC_NAME[TLS_NR_CIPHERS] TLS_CIPHER_SSLVERS[TLS_NR_CIPHERS] TLS_CIPHER_KX[TLS_NR_CIPHERS] TLS_CIPHER_AUTH[TLS_NR_CIPHERS] TLS_CIPHER_ENC[TLS_NR_CIPHERS] mac TLS_CIPHER_EXPORT[TLS_NR_CIPHERS]; do


### PR DESCRIPTION
According to the POSIX Programmer's Manual, the exit status specified by
the unsigned decimal integer. If n is specified, but its value is not
between 0 and 255 inclusively, the exit status is undefined.

By cross reference the usage between different scripts in this project,
it looks like we could simply remove the `-` before the number.