### PR TITLE
Fix redundant message (BREACH) when client certificate required

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -16399,8 +16399,9 @@ run_breach() {
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for BREACH (HTTP compression) vulnerability " && outln
      pr_bold " BREACH"; out " ($cve)                    "
      if [[ "$CLIENT_AUTH" == required ]]; then
-          outln "cannot be tested (server side requires x509 authentication)"
-          fileout "$jsonID" "INFO" "was not tested, server side requires x509 authentication" "$cve" "$cwe"
+          prln_warning "client x509-based authentication prevents this from being tested"
+          fileout "$jsonID" "WARN" "client x509-based authentication prevents this from being tested" "$cve" "$cwe"
+          return 7
      fi
 
      [[ -z "$url" ]] && url="/"


### PR DESCRIPTION
same as #1916.

Fixes #1915