### PR TITLE
Ignore FreeBSD & macOS OpenSSL binary in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+bin/openssl.Darwin.*
+bin/openssl.FreeBSD.*


### PR DESCRIPTION
There is no need to add non-Linux binary in the Dockerfile here.

This change will make the Docker image smaller.