### PR TITLE
Default to dual stack if both A/AAAA records are available.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ You can download testssl.sh branch 3.3dev just by cloning this git repository:
 
     git clone --depth 1 https://github.com/testssl/testssl.sh.git --branch 3.3dev
 
-3.3dev is the latest development branch which evolved from 3.2 stable. We're trying not to do big experiments in the dev branch, however the point of development ist that there will be changes and changes might need a bit time to mature.
+3.3dev is the latest development branch which evolved from 3.2 stable. We're trying not to do big experiments in the dev branch, however the point of development is that there will be changes and changes might need a bit time to mature.
 
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -58,21 +58,31 @@ Update notifications can be found at [github](https://github.com/testssl/testssl
 
 ### Installation
 
-You can download testssl.sh branch 3.2 just by cloning this git repository:
+You can download testssl.sh branch 3.3dev just by cloning this git repository:
 
-    git clone --depth 1 https://github.com/testssl/testssl.sh.git
+    git clone --depth 1 https://github.com/testssl/testssl.sh.git --branch 3.3dev
 
-3.2 is the latest stable branch which evolved from 3.1dev. In June 2025 there was a last bugfix release for the former stable version named old-stable, which is 3.0.10. Please use 3.2 **now**, as 3.0.x will not get any updates.
+3.3dev is the latest development branch which evolved from 3.2 stable. We're trying not to do big experiments in the dev branch, however the point of development ist that there will be changes and changes might need a bit time to mature.
+
+
 
 #### Docker
 
+
+
 Testssl.sh has minimal requirements. As stated you don't have to install or build anything. You can just run it from the pulled/cloned directory. Still if you don't want to pull the GitHub repo to your directory of choice you can pull a container from dockerhub and run it:
+
+<!--
+
+#FIXME: 3.3dev @ dockerhib to be created
 
 ```
 docker run --rm -ti  drwetter/testssl.sh <your_cmd_line>
 ```
 
 or from GHCR (GitHub Container Registry which supports more platforms: linux/amd64, linux/386, linux/arm64, linux/arm/v7, linux/arm/v6, linux/ppc64le):
+
+-->
 
 ```
 docker run --rm -it ghcr.io/testssl/testssl.sh <your_cmd_line>
@@ -84,7 +94,10 @@ Or if you have cloned this repo you also can just ``cd`` to the INSTALLDIR and r
 docker build . -t imagefoo && docker run --rm -t imagefoo testssl.net
 ```
 
-For more please consult [Dockerfile.md](https://github.com/testssl/testssl.sh/blob/3.2/Dockerfile.md).
+For more please consult [Dockerfile.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Dockerfile.md).
+
+
+
 
 ### No Warranty
 
@@ -94,7 +107,8 @@ Testssl.sh is intended to be used as a standalone CLI tool. While we tried to ap
 
 ### Status
 
-Given the current manpower we only support n-1 versions. We started a 3.3.dev branch where further development takes place before 3.4 becomes the stable version and 3.2 becomes old-stable. As said, 3.0.x became EOL.
+Given the current manpower we only support n-1 versions. You're looking at the 3.3.dev branch where further development takes place before 3.4 becomes the stable version and 3.2 becomes old-stable. If you are hestitant with respect to changes, you need to use 3.2. The version 3.0.10 was the last one, there will not be any updates.
+
 
 ### Documentation
 


### PR DESCRIPTION
Patch to test IPv6 by default if the target host has AAAA records available via DNS.
IPv4 will still be tested by default if the target host has A records available via DNS.
If a host is dual stack and has both A/AAAA records and the "one" option has not been specified, both protocols and all addresses will be tested by default.
Add options -only4 and -only6 to force single-stack testing.

Default behaviour was to detect multiple IP addresses from a single FQDN and display all of them, but only test IPv4 addresses by default and ignore the IPv6. This patch changes the behaviour to test ALL addresses by default unless the user explicitly chooses otherwise.

**Rationale:**

If a user specifies a hostname they probably want to test all the addresses it resolves to in order to be thorough and identify any configuration anomalies, if they only wanted to test a subset of the addresses they would likely use the "one" option to just test one of them.

Qualys/SSLLabs SSLTest by default tests all addresses, and will report any errors encountered.
Any modern operating system will favour IPv6 when available, and only fall back to IPv4 if IPv6 is not available for whatever reason.

Ignoring the IPv6 addresses by default results in incomplete test results. SSL configuration may differ on IPv6. Because no errors are displayed, users may overlook this and assume the results given are complete.

If the system running ssltest.sh is unable to reach the IPv6 addresses, it will display errors (usually network unreachable) when trying to connect. This alerts the user to the fact that there is a problem with their ability to properly test the selected target, allowing them to investigate and either be aware of the limitations or correct them.
The same errors would occur if some of the targets are down, or if the user runs ssltest from an IPv6-only host against an IPv4 target etc.
A similar error will occur if the user has an old version of OpenSSL which is unable to support IPv6. As above, it is better that the user is made aware of the limitation so they can make an informed decision on how to proceed.

**Before:**
A user testing dual stack targets is performing incomplete scans and may not be aware they are doing so. While this is documented, users often don't read the documentation and are likely to blindly trust the output without thoroughly inspecting it, especially when this behaviour is different to other similar tools.

**After:**
A user with an IPv4-only host testing dual stack targets will see connection errors in the default state related to their own lack of IPv6 connectivity. This will make them aware that they are unable to perform thorough tests of the target, and have the choice to either proceed with incomplete testing using the -only4 option or perform testing from somewhere which is able to reach all of the targets.
The same results would be returned, but the user would be alerted to the fact that the results might not be complete.

A user with a dual stack host will perform thorough tests of all target addresses.

**Single stack testing:**

Previously it was possible to only test IPv4, but not possible to only test IPv6 on a dual stack host. This patch adds such an option.

**Other:**

IPv6-only networks are relatively common now, for instance many mobile networks use DNS64/NAT64, under this setup the behaviour of only testing IPv4 addresses would fail completely. DNS64 detection may be a desirable addition here, as it would alert users of such configuration. The possibility also exists to force testing the IPv4 addresses via the NAT64 prefix, while testing the IPv6 addresses directly. Without NAT64 awareness, the output could be misleading and incomplete as DNS64 synthesizes IPv6 addresses where none exist.

