### PR TITLE
Improved SSL/TLS portdetection in nmap greppable files (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -18988,7 +18988,7 @@ nmap_to_plain_file() {
      local target_fname=""
      local oneline=""
      local ip hostdontcare round_brackets ports_specs starttls
-     local tmp port host_spec protocol dontcare dontcare1
+     local tmp port host_spec protocol ssl_hint dontcare dontcare1
      #FIXME: IPv6 is missing here
 
      # Ok, since we are here we are sure to have an nmap file. To avoid questions we make sure it's the right format too
@@ -19029,11 +19029,15 @@ nmap_to_plain_file() {
           while read -r oneline; do
                # 25/open/tcp//smtp//<banner>/,
                [[ "$oneline" =~ '/open/tcp/' ]] || continue                # no open tcp for this port on this IP --> move on
-               IFS=/ read -r port dontcare protocol dontcare1 <<< "$oneline"
-               starttls="$(ports2starttls $port)"
-               [[ $? -eq 1 ]] && continue                                  # nmap got a port but we don't know how to speak to
-               [[ "$DEBUG" -ge 1 ]] && echo "${starttls}$host_spec:$port"
-               echo "${starttls}${host_spec}:${port}" >>"$target_fname"
+               IFS=/ read -r port dontcare protocol ssl_hint dontcare1 <<< "$oneline"
+               if [[ "$ssl_hint" =~ ^(ssl|https) ]] || [[ "$dontcare1" =~ ^(ssl|https) ]]; then
+                    echo "${host_spec}:${port}" >>"$target_fname"
+               else
+                    starttls="$(ports2starttls $port)"
+                    [[ $? -eq 1 ]] && continue                             # nmap got a port but we don't know how to speak to
+                    [[ "$DEBUG" -ge 1 ]] && echo "${starttls}$host_spec:$port"
+                    echo "${starttls}${host_spec}:${port}" >>"$target_fname"
+               fi
           done < <(tr ',' '\n' <<< "$ports_specs")
      done < "$FNAME"
      [[ "$DEBUG" -ge 1 ]] && echo

--- a/utils/gmap2testssl.sh
+++ b/utils/gmap2testssl.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-#set -e
-
 # Utility which converts grepable nmap outout to testssl's file input
 # It is just borrowed from testssl.sh
 # License see testssl.sh
@@ -105,7 +103,7 @@ nmap_to_plain_file () {
      local target_fname=""
      local oneline=""
      local ip hostdontcare round_brackets ports_specs starttls
-     local tmp port host_spec protocol dontcare dontcare1
+     local tmp port host_spec protocol ssl_hint dontcare dontcare1
 
      # Ok, since we are here we are sure to have an nmap file. To avoid questions we make sure it's the right format too
      if [[ "$(head -1 "$fname")" =~ ( -oG )(.*) ]] || [[ "$(head -1 "$fname")" =~ ( -oA )(.*) ]] ; then
@@ -162,7 +160,7 @@ nmap_to_plain_file () {
 FNAME="$1"
 [[ ! -e $FNAME ]] && echo "$FNAME not readable" && exit 2
 
-nmap_to_plain_file $FNAME
+nmap_to_plain_file "$FNAME"
 
 exit $?
 


### PR DESCRIPTION
As mentioned in #1931 the port detection for nmap greppable files
leaves space for improvements.

Ths PR adds a pattern detection of ssl and https in the forth or fifth
parameter of an open port, so those ports will be added to a scan when
a nmap greppable output file is supplied as input to testssl.sh .

Also it does minor code adjustments to utils/gmap2testssl.sh .

Same as #1938, only for 3.0, see #1941