### PR TITLE
Disable ANSI codes for italic when TERM == screen

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -597,7 +597,9 @@ pr_bold()       { tm_bold "$1"; [[ "$COLOR" -ne 0 ]] && html_out "<span style=\"
 prln_bold()     { pr_bold "$1" ; outln; }
 
 NO_ITALICS=false
-if [[ $SYSTEM == OpenBSD ]]; then
+if [[ $TERM == screen ]]; then
+     NO_ITALICS=true
+elif [[ $SYSTEM == OpenBSD ]]; then
      NO_ITALICS=true
 elif [[ $SYSTEM == FreeBSD ]]; then
      if [[ ${SYSTEMREV%\.*} -le 9 ]]; then


### PR DESCRIPTION
... otherwise it is being printed in reverse, see #1928.
Same as #1946 but for the 3.0 branch.