### PR TITLE
Relaxing permissions for ~ /home/testssl/** in Dockerfile to fix a bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ COPY --chown=testssl:testssl etc/. /home/testssl/etc/
 COPY --chown=testssl:testssl bin/. /home/testssl/bin/
 COPY --chown=testssl:testssl testssl.sh  /home/testssl/
 
+# enable using docker run --user uid:gid ...
+RUN chmod o+rx /home/testssl/testssl.sh \
+    && chmod o+r /home/testssl/etc/* \
+    && chmod o+r /home/testssl/bin/* \
+    && chmod o+x /home/testssl/bin/openssl.Linux.*
+
+
 ENTRYPOINT ["testssl.sh"]
 
 CMD ["--help"]


### PR DESCRIPTION
Previously running this container with other user id's resulted in
```
standard_init_linux.go:228: exec user process caused: permission denied
```

This should help with https://github.com/docker-mailserver/docker-mailserver/pull/2110

Info @wt-io-it