### PR TITLE
Fix #1961

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20983,8 +20983,6 @@ determine_service() {
                ftp|smtp|lmtp|pop3|imap|xmpp|xmpp-server|telnet|ldap|postgres|mysql|nntp)
                     STARTTLS="-starttls $protocol"
                     if [[ "$protocol" == xmpp ]] || [[ "$protocol" == xmpp-server ]]; then
-                         # for XMPP, openssl has a problem using -connect $NODEIP:$PORT. thus we use -connect $NODE:$PORT instead!
-                         NODEIP="$NODE"
                          if [[ -n "$XMPP_HOST" ]]; then
                               if ! "$HAS_XMPP"; then
                                    fatal "Your $OPENSSL does not support the \"-xmpphost\" option" $ERR_OSSLBIN
@@ -20998,10 +20996,17 @@ determine_service() {
                                         prln_warning " IP address doesn't work for XMPP, trying PTR record $rDNS"
                                         # remove trailing .
                                         NODE=${rDNS%%.}
-                                        NODEIP=${rDNS%%.}
                                    else
                                         fatal "No DNS supplied and no PTR record available which I can try for XMPP" $ERR_DNSLOOKUP
                                    fi
+                              fi
+                              if "$HAS_XMPP"; then
+                                   # small hack -- instead of changing calls all over the place
+                                   STARTTLS="$STARTTLS -xmpphost $NODE"
+                              else
+                                   # If the XMPP name cannot be provided using -xmpphost,
+                                   # then it needs to be provided to the -connect option
+                                   NODEIP="$NODE" 
                               fi
                          fi
                          if [[ "$protocol" == xmpp-server ]] && ! "$HAS_XMPP_SERVER"; then


### PR DESCRIPTION
This PR fixes #1961 in the 3.1dev branch by leaving $NODEIP set to the server's IP address rather than changing it to the DNS name in the case of STARTTLS XMPP.

Currently, `determine_service()` sets `$NODEIP` to `$NODE` in the case of STARTTLS XMPP based on the following note:
```
# for XMPP, openssl has a problem using -connect $NODEIP:$PORT. thus we use -connect $NODE:$PORT instead!
```
Based on some limited testing, it seems that the issue is that the XMPP host name needs to be set. According the manual page for s_cilent:
> [The -xmpphost hostname] option, when used with "-starttls xmpp" or "-starttls xmpp-server", specifies the host for the "to" attribute of the stream element.  If this option is not specified, then the host specified with "-connect" will be used.

So, my guess is that if the `-xmpphost` isn't provided to $OPENSSL, then `-connect` needs to be provided a DNS name so that the "to" attribute can be set.

Currently, the `-xmpphost` option is only provided to $OPENSSL if testssl.sh's `--xmpphost` option is used. This PR changes `determine_service()` so that the `-xmpphost` option is always provided to $OPENSSL when STARTTLS XMPP is used, as long as $OPENSSL supports that option.

Note that my ability to test this PR was very limited, so please test it carefully before committing.

If the PR is considered acceptable, then I can also create a PR for the 3.0 branch.