### PR TITLE
Add GH Action to build Docker images (3.0 branch)

### DIFF
--- a/.github/workflows/docker-3.0.yml
+++ b/.github/workflows/docker-3.0.yml
@@ -1,0 +1,63 @@
+name: docker-3.0
+
+on:
+  push:
+    branches: 
+      - 3.0
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1"
+
+env:
+  BUILD_VERSION: "3.0"
+  DOCKER_CLI_EXPERIMENTAL: enabled
+  REPOSITORY: ${{ github.actor }}/testssl.sh
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Source checkout
+        uses: actions/checkout@v2.3.4 
+ 
+      - name: Setup QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1.2.0
+      
+      - name: Setup Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set Docker metadata
+        id: docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REPOSITORY }}
+          labels: |
+            org.opencontainers.image.version=${{ env.BUILD_VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=${{ env.REPOSITORY }}
+            
+      - name: GitHub login
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.6.1
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          context: .
+          file: Dockerfile.git
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le
+          build-args: BUILD_VERSION
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: |
+            ghcr.io/${{ env.REPOSITORY }}:${{ env.BUILD_VERSION }}

--- a/.github/workflows/docker-3.0.yml
+++ b/.github/workflows/docker-3.0.yml
@@ -11,7 +11,6 @@ on:
 env:
   BUILD_VERSION: "3.0"
   DOCKER_CLI_EXPERIMENTAL: enabled
-  REPOSITORY: ${{ github.actor }}/testssl.sh
 
 jobs:
 

--- a/.github/workflows/docker-3.0.yml
+++ b/.github/workflows/docker-3.0.yml
@@ -34,11 +34,11 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REPOSITORY }}
+          images: ${{ github.repository }}
           labels: |
             org.opencontainers.image.version=${{ env.BUILD_VERSION }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.title=${{ env.REPOSITORY }}
+            org.opencontainers.image.title=${{ github.repository }}
             
       - name: GitHub login
         if: ${{ github.event_name != 'pull_request' }}
@@ -60,4 +60,4 @@ jobs:
           cache-to: type=gha, scope=${{ github.workflow }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           tags: |
-            ghcr.io/${{ env.REPOSITORY }}:${{ env.BUILD_VERSION }}
+            ghcr.io/${{ github.repository }}:${{ env.BUILD_VERSION }}

--- a/Dockerfile.git
+++ b/Dockerfile.git
@@ -1,0 +1,24 @@
+# Build using git repo
+
+FROM alpine:3.14
+
+WORKDIR /home/testssl
+
+ARG BUILD_VERSION
+ARG ARCHIVE_URL=https://github.com/drwetter/testssl.sh/archive/
+ARG URL=https://github.com/drwetter/testssl.sh.git
+
+RUN test -n "${BUILD_VERSION}" \
+    && apk update \
+    && apk add --no-cache bash procps drill git coreutils libidn curl socat openssl xxd \
+	&& git clone --depth 1 --branch ${BUILD_VERSION} $URL /home/testssl \
+    && addgroup testssl \
+    && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl \
+    && ln -s /home/testssl/testssl.sh /usr/local/bin/ \
+    && mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
+
+USER testssl
+
+ENTRYPOINT ["testssl.sh"]
+
+CMD ["--help"]


### PR DESCRIPTION
This only builds and pushes to GHCR at this time. As mentioned, you will need to create and add a Docker Hub PAT to your repo before I can update the action to push to Docker Hub too. 

