### PR TITLE
Fix minor inconsistency in description of cipher categories

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -196,7 +196,7 @@ Any single check switch supplied as an argument prevents testssl\.sh from doing 
 \fB\-E, \-\-cipher\-per\-proto\fR is similar to \fB\-e, \-\-each\-cipher\fR\. It checks each of the possible ciphers, here: per protocol\. If you want to display each cipher tested you need to add \fB\-\-show\-each\fR\. The output is sorted by security strength, it lists the encryption bits though\.
 .
 .P
-\fB\-s, \-\-std, \-\-standard\fR tests certain lists of cipher suites / cipher categories by strength\. Those lists are (\fBopenssl ciphers $LIST\fR, $LIST from below:)
+\fB\-s, \-\-std, \-\-categories\fR tests certain lists of cipher suites / cipher categories by strength\. (\fB\-\-standard\fR is deprecated\.) Those lists are (\fBopenssl ciphers $LIST\fR, $LIST from below:)
 .
 .IP "\(bu" 4
 \fBNULL encryption ciphers\fR: \'NULL:eNULL\'

--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -196,7 +196,7 @@ Any single check switch supplied as an argument prevents testssl\.sh from doing 
 \fB\-E, \-\-cipher\-per\-proto\fR is similar to \fB\-e, \-\-each\-cipher\fR\. It checks each of the possible ciphers, here: per protocol\. If you want to display each cipher tested you need to add \fB\-\-show\-each\fR\. The output is sorted by security strength, it lists the encryption bits though\.
 .
 .P
-\fB\-s, \-\-std, \-\-standard\fR tests certain lists of cipher suites by strength\. Those lists are (\fBopenssl ciphers $LIST\fR, $LIST from below:)
+\fB\-s, \-\-std, \-\-standard\fR tests certain lists of cipher suites / cipher categories by strength\. Those lists are (\fBopenssl ciphers $LIST\fR, $LIST from below:)
 .
 .IP "\(bu" 4
 \fBNULL encryption ciphers\fR: \'NULL:eNULL\'

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -236,7 +236,7 @@ containing files with a .pem extension, a single file or multiple files as a com
 
 <p><code>-E, --cipher-per-proto</code>  is similar to <code>-e, --each-cipher</code>. It checks each of the possible ciphers, here: per protocol. If you want to display each cipher tested you need to add <code>--show-each</code>. The output is sorted by security strength, it lists the encryption bits though.</p>
 
-<p><code>-s, --std, --standard</code>   tests certain lists of cipher suites by strength. Those lists are (<code>openssl ciphers $LIST</code>, $LIST from below:)</p>
+<p><code>-s, --std, --standard</code>   tests certain lists of cipher suites / cipher catagories by strength. Those lists are (<code>openssl ciphers $LIST</code>, $LIST from below:)</p>
 
 <ul>
 <li><code>NULL encryption ciphers</code>: 'NULL:eNULL'</li>

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -236,7 +236,7 @@ containing files with a .pem extension, a single file or multiple files as a com
 
 <p><code>-E, --cipher-per-proto</code>  is similar to <code>-e, --each-cipher</code>. It checks each of the possible ciphers, here: per protocol. If you want to display each cipher tested you need to add <code>--show-each</code>. The output is sorted by security strength, it lists the encryption bits though.</p>
 
-<p><code>-s, --std, --standard</code>   tests certain lists of cipher suites / cipher catagories by strength. Those lists are (<code>openssl ciphers $LIST</code>, $LIST from below:)</p>
+<p><code>-s, --std, --categories</code>   tests certain lists of cipher suites / cipher catagories by strength. (<code>--standard</code> is deprecated.) Those lists are (<code>openssl ciphers $LIST</code>, $LIST from below:)</p>
 
 <ul>
 <li><code>NULL encryption ciphers</code>: 'NULL:eNULL'</li>

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -161,7 +161,7 @@ Any single check switch supplied as an argument prevents testssl.sh from doing a
 
 `-E, --cipher-per-proto`  is similar to `-e, --each-cipher`. It checks each of the possible ciphers, here: per protocol. If you want to display each cipher tested you need to add `--show-each`. The output is sorted by security strength, it lists the encryption bits though.
 
-`-s, --std, --standard`   tests certain lists of cipher suites by strength. Those lists are (`openssl ciphers $LIST`, $LIST from below:)
+`-s, --std, --standard`   tests certain lists of cipher suites / cipher catagories by strength. Those lists are (`openssl ciphers $LIST`, $LIST from below:)
 
 * `NULL encryption ciphers`: 'NULL:eNULL'
 * `Anonymous NULL ciphers`: 'aNULL:ADH'

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -161,7 +161,7 @@ Any single check switch supplied as an argument prevents testssl.sh from doing a
 
 `-E, --cipher-per-proto`  is similar to `-e, --each-cipher`. It checks each of the possible ciphers, here: per protocol. If you want to display each cipher tested you need to add `--show-each`. The output is sorted by security strength, it lists the encryption bits though.
 
-`-s, --std, --standard`   tests certain lists of cipher suites / cipher catagories by strength. Those lists are (`openssl ciphers $LIST`, $LIST from below:)
+`-s, --std, --categories`   tests certain lists of cipher suites / cipher catagories by strength. (`--standard` is deprecated.)  Those lists are (`openssl ciphers $LIST`, $LIST from below:)
 
 * `NULL encryption ciphers`: 'NULL:eNULL'
 * `Anonymous NULL ciphers`: 'aNULL:ADH'

--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -143,7 +143,7 @@ unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
 
 
-$uri="news.newsguy.com:119";
+$uri="140.238.219.117:119";
 
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS NNTP unit tests via sockets --> $uri ...";

--- a/testssl.sh
+++ b/testssl.sh
@@ -19467,7 +19467,7 @@ help() {
 single check as <options>  ("$PROG_NAME URI" does everything except -E and -g):
      -e, --each-cipher             checks each local cipher remotely
      -E, --cipher-per-proto        checks those per protocol
-     -s, --std, --standard         tests standard cipher categories by strength
+     -s, --std, --categories       tests standard cipher categories by strength
      -f, --fs, --nsa               checks forward secrecy settings
      -p, --protocols               checks TLS/SSL protocols (including SPDY/HTTP2)
      -g, --grease                  tests several server implementation bugs like GREASE and size limitations
@@ -22243,7 +22243,8 @@ parse_cmd_line() {
                -p|--protocols)
                     do_protocols=true
                     ;;
-               -s|--std|--standard)
+               -s|--std|--standard|--categories)
+                    # --standard is deprecated
                     do_cipherlists=true
                     ;;
                -S|--server[-_]defaults)

--- a/testssl.sh
+++ b/testssl.sh
@@ -19467,7 +19467,7 @@ help() {
 single check as <options>  ("$PROG_NAME URI" does everything except -E and -g):
      -e, --each-cipher             checks each local cipher remotely
      -E, --cipher-per-proto        checks those per protocol
-     -s, --std, --standard         tests certain lists of cipher suites by strength
+     -s, --std, --standard         tests standard cipher categories by strength
      -f, --fs, --nsa               checks forward secrecy settings
      -p, --protocols               checks TLS/SSL protocols (including SPDY/HTTP2)
      -g, --grease                  tests several server implementation bugs like GREASE and size limitations


### PR DESCRIPTION
A longer while back the section ~ "Testing standard ciphers" was
renamed to "Testing cipher categories". However the internal help
didn't reflect that.

This fixes that, including an addition to the documentation.

``--standard`` was replaced by ``--categories`` but ``--standard`` still works but will be removed soon

This fixes #1978 