### PR TITLE
Improve check for client authentication

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -353,6 +353,7 @@ HAS_AES256_GCM=false
 HAS_ZLIB=false
 HAS_UDS=false
 HAS_UDS2=false
+HAS_ENABLE_PHA=false
 HAS_DIG=false
 HAS_DIG_R=true
 DIG_R="-r"
@@ -2174,6 +2175,10 @@ s_client_options() {
      # OpenSSL that don't support -no_ssl2 also don't support SSLv2, the option
      # isn't needed for these versions of OpenSSL.)
      ! "$HAS_NO_SSL2" && options="${options//-no_ssl2/}"
+
+     # The -enable_pha option causes the Post-Handshake Authentication extension to be sent.
+     # It is only supported by OpenSSL 1.1.1 and newer.
+     ! "$HAS_ENABLE_PHA" && options="${options//-enable_pha/}"
 
      # At least one server will fail under some circumstances if compression methods are offered.
      # So, only offer compression methods if necessary for the test. In OpenSSL 1.1.0 and
@@ -19450,6 +19455,7 @@ find_openssl_binary() {
      HAS_UDS=false
      HAS_UDS2=false
 	 TRUSTED1ST=""
+     HAS_ENABLE_PHA=false
 
      $OPENSSL ciphers -s 2>&1 | grep -aiq "unknown option" || OSSL_CIPHERS_S="-s"
 
@@ -19520,6 +19526,8 @@ find_openssl_binary() {
      grep -q 'irc' $s_client_starttls_has && HAS_IRC=true
 
      grep -q 'Unix-domain socket' $s_client_has && HAS_UDS=true
+
+     grep -q '\-enable_pha' $s_client_has && HAS_ENABLE_PHA=true
 
      # Now check whether the standard $OPENSSL has Unix-domain socket and xmpp-server support. If
      # not check /usr/bin/openssl -- if available. This is more a kludge which we shouldn't use for
@@ -19872,6 +19880,7 @@ HAS_NNTP: $HAS_NNTP
 HAS_IRC: $HAS_IRC
 HAS_UDS: $HAS_UDS
 HAS_UDS2: $HAS_UDS2
+HAS_ENABLE_PHA: $HAS_ENABLE_PHA
 
 HAS_DIG: $HAS_DIG
 HAS_HOST: $HAS_HOST
@@ -21070,7 +21079,16 @@ determine_optimal_proto() {
                     -ssl2)   "$HAS_SSL2" || continue ;;
                     *) ;;
                esac
-               $OPENSSL s_client $(s_client_options "$proto $BUGS -connect "$NODEIP:$PORT" -msg $PROXY $SNI") </dev/null >$TMPFILE 2>>$ERRFILE
+               # Only send $GET_REQ11 in case of a non-empty $URL_PATH, as it
+               # is not needed otherwise. Also, sending $GET_REQ11 may cause
+               # problems if the server being tested is not an HTTPS server,
+               # and $GET_REQ11 should be empty for non-HTTPS servers.
+               if [[ -z "$URL_PATH" ]] || [[ "$URL_PATH" == "/" ]]; then
+                    $OPENSSL s_client $(s_client_options "$proto $BUGS -connect "$NODEIP:$PORT" -msg $PROXY $SNI") </dev/null >$TMPFILE 2>>$ERRFILE
+               else
+                    safe_echo "$GET_REQ11" | $OPENSSL s_client $(s_client_options "$proto $BUGS -connect "$NODEIP:$PORT" -msg $PROXY $SNI -prexit -enable_pha") </dev/null >$TMPFILE 2>>$ERRFILE
+               fi
+               
                if sclient_auth $? $TMPFILE; then
                     # we use the successful handshake at least to get one valid protocol supported -- it saves us time later
                     if [[ -z "$proto" ]]; then
@@ -21188,7 +21206,6 @@ determine_service() {
      if [[ -z "$1" ]]; then
           # no STARTTLS.
           determine_optimal_sockets_params
-          determine_optimal_proto
           $SNEAKY && \
                ua="$UA_SNEAKY" || \
                ua="$UA_STD"
@@ -21199,6 +21216,7 @@ determine_service() {
                reqheader="$(join_by "\r\n" "${REQHEADERS[@]}")\r\n" #Add all required custom http headers to one string with newlines
           fi
           GET_REQ11="GET $URL_PATH HTTP/1.1\r\nHost: $NODE\r\nUser-Agent: $ua\r\n${basicauth_header}${reqheader}Accept-Encoding: identity\r\nAccept: text/*\r\nConnection: Close\r\n\r\n"
+          determine_optimal_proto
           # returns always 0:
           service_detection $OPTIMAL_PROTO
      else # STARTTLS

--- a/testssl.sh
+++ b/testssl.sh
@@ -21086,7 +21086,7 @@ determine_optimal_proto() {
                if [[ -z "$URL_PATH" ]] || [[ "$URL_PATH" == "/" ]]; then
                     $OPENSSL s_client $(s_client_options "$proto $BUGS -connect "$NODEIP:$PORT" -msg $PROXY $SNI") </dev/null >$TMPFILE 2>>$ERRFILE
                else
-                    safe_echo "$GET_REQ11" | $OPENSSL s_client $(s_client_options "$proto $BUGS -connect "$NODEIP:$PORT" -msg $PROXY $SNI -prexit -enable_pha") </dev/null >$TMPFILE 2>>$ERRFILE
+                    safe_echo "$GET_REQ11" | $OPENSSL s_client $(s_client_options "$proto $BUGS -connect "$NODEIP:$PORT" -msg $PROXY $SNI -ign_eof -enable_pha") >$TMPFILE 2>>$ERRFILE
                fi
                
                if sclient_auth $? $TMPFILE; then


### PR DESCRIPTION
As noted in #1709, some servers will only request client authentication if a specific URL is requested. This PR modifies the check for client authentication, in the case that a $URL_PATH is provided, by having testssl.sh perform a GET request on the URL provided on the command line.

I have not been able to find or set up a server that only requests client authentication if a specific URL is requested, so I have not been able to test this PR.

@lesterw1: Do you have a server that you can test this on or that you can point me to so that I can test it?