### PR TITLE
In determine_trust(), use the OpenSSL '-trusted_first' flag to ignore the now-expired DST Root CA X3 root certificate

### DIFF
--- a/t/51_badssl.com.t
+++ b/t/51_badssl.com.t
@@ -22,6 +22,7 @@ cmp_ok(@$okjson,'>',10,"We have more then 10 findings"); $tests++;
 # Expiration
 pass("Running testssl against expired.badssl.com"); $tests++;
 $out = `./testssl.sh -S --jsonfile tmp.json --color 0 expired.badssl.com`;
+like($out, qr/Chain of trust\s+NOT ok \(expired\)/,"The chain of trust should be expired"); $tests++;
 like($out, qr/Certificate Validity \(UTC\)\s+expired/,"The certificate should be expired"); $tests++;
 $json = json('tmp.json');
 unlink 'tmp.json';

--- a/testssl.sh
+++ b/testssl.sh
@@ -7264,9 +7264,9 @@ determine_trust() {
           # in a subshell because that should be valid here only
           (export SSL_CERT_DIR="/dev/null"; export SSL_CERT_FILE="/dev/null"
           if [[ $certificates_provided -ge 2 ]]; then
-               $OPENSSL verify -purpose sslserver -CAfile <(cat $ADDTL_CA_FILES "$bundle_fname") -untrusted $TEMPDIR/intermediatecerts.pem $HOSTCERT >$TEMPDIR/${certificate_file[i]}.1 2>$TEMPDIR/${certificate_file[i]}.2
+               $OPENSSL verify $TRUSTED1ST -purpose sslserver -CAfile <(cat $ADDTL_CA_FILES "$bundle_fname") -untrusted $TEMPDIR/intermediatecerts.pem $HOSTCERT >$TEMPDIR/${certificate_file[i]}.1 2>$TEMPDIR/${certificate_file[i]}.2
           else
-               $OPENSSL verify -purpose sslserver -CAfile <(cat $ADDTL_CA_FILES "$bundle_fname") $HOSTCERT >$TEMPDIR/${certificate_file[i]}.1 2>$TEMPDIR/${certificate_file[i]}.2
+               $OPENSSL verify $TRUSTED1ST -purpose sslserver -CAfile <(cat $ADDTL_CA_FILES "$bundle_fname") $HOSTCERT >$TEMPDIR/${certificate_file[i]}.1 2>$TEMPDIR/${certificate_file[i]}.2
           fi)
           verify_retcode[i]=$(awk '/error [1-9][0-9]? at [0-9]+ depth lookup:/ { if (!found) {print $2; found=1} }' $TEMPDIR/${certificate_file[i]}.1 $TEMPDIR/${certificate_file[i]}.2)
           [[ -z "${verify_retcode[i]}" ]] && verify_retcode[i]=0
@@ -19325,6 +19325,8 @@ find_openssl_binary() {
      [[ $? -eq 0 ]] && HAS_AES256_GCM=true
 
      [[ "$(echo -e "\x78\x9C\xAB\xCA\xC9\x4C\xE2\x02\x00\x06\x20\x01\xBC" | $OPENSSL zlib -d 2>/dev/null)" == zlib ]] && HAS_ZLIB=true
+
+     $OPENSSL verify -trusted_first </dev/null 2>&1 | grep -q '^usage' || TRUSTED1ST="-trusted_first"
 
      if [[ -n "$CONNECT_TIMEOUT" ]] || [[ -n "$OPENSSL_TIMEOUT" ]]; then
           # We don't set a general timeout as we might not have "timeout" installed and we only

--- a/testssl.sh
+++ b/testssl.sh
@@ -410,6 +410,7 @@ KEY_EXCH_SCORE=100                      # Keeps track of the score for category 
 CIPH_STR_BEST=0                         # Keeps track of the best bit size for category 3 "Cipher Strength"
 CIPH_STR_WORST=100000                   # Keeps track of the worst bit size for category 3 "Cipher Strength"
                                         # Intentionally set very high, so it can be set to 0, if necessary
+TRUSTED1ST=""                           # Contains the `-trusted_first` flag, if this version of openssl supports it
 
 ########### Global variables for parallel mass testing
 #
@@ -19238,6 +19239,7 @@ find_openssl_binary() {
      HAS_ZLIB=false
      HAS_UDS=false
      HAS_UDS2=false
+	 TRUSTED1ST=""
 
      $OPENSSL ciphers -s 2>&1 | grep -aiq "unknown option" || OSSL_CIPHERS_S="-s"
 


### PR DESCRIPTION
Fixes #1995.

Tested:

- bundled OpenSSL 1.0.2-chacha on CentOS Stream 8 Linux 4.18.0-338.el8.x86_64
- system OpenSSL 1.1.1k on CentOS Stream 8 Linux 4.18.0-338.el8.x86_64
- bundled OpenSSL 1.0.2-chacha on macOS 11.6
- system LibreSSL 2.8.3 on macOS 11.6

(Resubmitting due to accidental merge-then-revert of #1998.)