### PR TITLE
Fix invalid JSON when certificate issuer contains non-ASCII chars (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -802,7 +802,7 @@ fileout_json_print_parameter() {
           spaces="              " || \
           spaces="                                "
      if [[ -n "$value" ]] || [[ "$parameter" == finding ]]; then
-          printf "%s%s%s%s" "$spaces" "\"$parameter\"" "$filler" ": \"$value\"" >> "$JSONFILE"
+          printf -- "%b%b%b%b" "$spaces" "\"$parameter\"" "$filler" ": \"$value\"" >> "$JSONFILE"
           "$not_last" && printf ",\n" >> "$JSONFILE"
      fi
 }


### PR DESCRIPTION
Changed printf %s to printf %b which cause now to output UTF-8 correctly.

See #1992.