### PR TITLE
Addressing lame DNS responses on WSL (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -220,6 +220,7 @@ FNAME=${FNAME:-""}                      # file name to read commands from
 FNAME_PREFIX=${FNAME_PREFIX:-""}        # output filename prefix, see --outprefix
 APPEND=${APPEND:-false}                 # append to csv/json file instead of overwriting it
 [[ -z "$NODNS" ]] && declare NODNS      # If unset it does all DNS lookups per default. "min" only for hosts or "none" at all
+NXCONNECT=${NXCONNECT:-invalid.}        # For WSL this helps avoiding DNS requests to "invalid." which windows seem to handle delayed
 HAS_IPv6=${HAS_IPv6:-false}             # if you have OpenSSL with IPv6 support AND IPv6 networking set it to yes
 ALL_CLIENTS=${ALL_CLIENTS:-false}       # do you want to run all client simulation form all clients supplied by SSLlabs?
 OFFENSIVE=${OFFENSIVE:-true}            # do you want to include offensive vulnerability tests which may cause blocking by an IDS?
@@ -4790,11 +4791,13 @@ run_client_simulation() {
      return $ret
 }
 
-# generic function whether $1 is supported by s_client ($2: string to display, currently nowhere being used)
+# generic function whether $1 is supported by s_client ($2: string to display)
+# Currently only used for protocols that's why we saved -connect $NXCONNECT.
+#TODO: we need to consider to remove the two instances from where this is called.
 #
 locally_supported() {
      [[ -n "$2" ]] && out "$2 "
-     if $OPENSSL s_client "$1" -connect invalid. 2>&1 | grep -aiq "unknown option"; then
+     if $OPENSSL s_client "$1" 2>&1 | grep -aiq "unknown option"; then
           prln_local_problem "$OPENSSL doesn't support \"s_client $1\""
           return 7
      fi
@@ -4814,9 +4817,9 @@ locally_supported() {
 run_prototest_openssl() {
      local -i ret=0
      local protos proto
+     local passed_check=false
 
-     # check whether the protocol being tested is supported by $OPENSSL
-     $OPENSSL s_client "$1" -connect invalid. 2>&1 | grep -aiq "unknown option" && return 7
+     $OPENSSL s_client "$1" 2>&1 | grep -aiq "unknown option" && return 7
      case "$1" in
           -ssl2) protos="-ssl2" ;;
           -ssl3) protos="-ssl3" ;;
@@ -4825,6 +4828,8 @@ run_prototest_openssl() {
           -tls1_2) protos="-no_ssl2"; "$HAS_TLS13" && protos+=" -no_tls1_3" ;;
           -tls1_3) protos="" ;;
      esac
+
+     #FIXME: we have here HAS_SSL(2|3) and more but we don't use that
      $OPENSSL s_client $(s_client_options "-state $protos $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>&1 </dev/null
      sclient_connect_successful $? $TMPFILE
      ret=$?
@@ -16921,6 +16926,8 @@ find_openssl_binary() {
      elif [[ -e "/mnt/c/Windows/System32/bash.exe" ]] && test_openssl_suffix "$(dirname "$(type -p openssl)")"; then
           # 2. otherwise, only if on Bash on Windows, use system binaries only.
           SYSTEM2="WSL"
+          # Workaround for delayed responses of Windows DNS when using "invalid.", see #1738, #1812.
+          [[ $NXCONNECT == invalid. ]] && NXCONNECT=127.0.0.1:0
      elif test_openssl_suffix "$TESTSSL_INSTALL_DIR"; then
           :    # 3. otherwise try openssl in path of testssl.sh
      elif test_openssl_suffix "$TESTSSL_INSTALL_DIR/bin"; then
@@ -17015,92 +17022,54 @@ find_openssl_binary() {
 
      # This and all other occurrences we do a little trick using "invalid." to avoid plain and
      # link level DNS lookups. See issue #1418 and https://tools.ietf.org/html/rfc6761#section-6.4
-     $OPENSSL s_client -ssl2 -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_SSL2=true
 
-     $OPENSSL s_client -ssl3 -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_SSL3=true
+     $OPENSSL s_client -ssl2  2>&1 | grep -aiq "unknown option" || HAS_SSL2=true
+     $OPENSSL s_client -ssl3  2>&1 | grep -aiq "unknown option" || HAS_SSL3=true
+     $OPENSSL s_client -tls1_3 2>&1 | grep -aiq "unknown option" || HAS_TLS13=true
+     $OPENSSL s_client -no_ssl2 2>&1 | grep -aiq "unknown option" || HAS_NO_SSL2=true
 
-     $OPENSSL s_client -tls1_3 -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_TLS13=true
+     $OPENSSL genpkey -algorithm X448 2>&1 | grep -aq "not found" || HAS_X448=true
+     $OPENSSL genpkey -algorithm X25519 2>&1 | grep -aq "not found" || HAS_X25519=true
 
-     $OPENSSL genpkey -algorithm X448 2>&1 | grep -aq "not found" || \
-          HAS_X448=true
+     $OPENSSL pkey -help 2>&1 | grep -q Error || HAS_PKEY=true
+     $OPENSSL pkeyutl 2>&1 | grep -q Error || HAS_PKUTIL=true
 
-     $OPENSSL genpkey -algorithm X25519 2>&1 | grep -aq "not found" || \
-          HAS_X25519=true
+     $OPENSSL s_client -noservername 2>&1 | grep -aiq "unknown option" || HAS_NOSERVERNAME=true
+     $OPENSSL s_client -ciphersuites 2>&1 | grep -aiq "unknown option" || HAS_CIPHERSUITES=true
 
-     $OPENSSL s_client -no_ssl2 -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_NO_SSL2=true
-
-     $OPENSSL s_client -noservername -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_NOSERVERNAME=true
-
-     $OPENSSL s_client -ciphersuites -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_CIPHERSUITES=true
-
-     $OPENSSL s_client -comp -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_COMP=true
-
-     $OPENSSL s_client -no_comp -connect invalid. 2>&1 | grep -aiq "unknown option" || \
-          HAS_NO_COMP=true
+     $OPENSSL s_client -comp 2>&1 | grep -aiq "unknown option" || HAS_COMP=true
+     $OPENSSL s_client -no_comp 2>&1 | grep -aiq "unknown option" || HAS_NO_COMP=true
 
      OPENSSL_NR_CIPHERS=$(count_ciphers "$(actually_supported_osslciphers 'ALL:COMPLEMENTOFALL' 'ALL')")
 
-     if $OPENSSL s_client -curves "${curves_ossl[0]}" -connect invalid. 2>&1 | grep -aiq "unknown option"; then
+     if $OPENSSL s_client -curves "${curves_ossl[0]}" -connect $NXCONNECT 2>&1 | grep -aiq "unknown option"; then
           for curve in "${curves_ossl[@]}"; do
-               $OPENSSL s_client -groups $curve -connect invalid.:8443 2>&1 | grep -Eiaq "Error with command|unknown option|Failed to set groups"
+               $OPENSSL s_client -groups $curve -connect ${NXCONNECT%:*}:8443 2>&1 | grep -Eiaq "Error with command|unknown option|Failed to set groups"
                [[ $? -ne 0 ]] && OSSL_SUPPORTED_CURVES+=" $curve "
           done
      else
           HAS_CURVES=true
           for curve in "${curves_ossl[@]}"; do
-               $OPENSSL s_client -curves $curve -connect invalid. 2>&1 | grep -Eiaq "Error with command|unknown option"
+               $OPENSSL s_client -curves $curve -connect $NXCONNECT 2>&1 | grep -Eiaq "Error with command|unknown option"
                [[ $? -ne 0 ]] && OSSL_SUPPORTED_CURVES+=" $curve "
           done
      fi
 
-     $OPENSSL pkey -help 2>&1 | grep -q Error || \
-          HAS_PKEY=true
-
-     $OPENSSL pkeyutl 2>&1 | grep -q Error || \
-          HAS_PKUTIL=true
-
      # For the following we feel safe enough to query the s_client help functions.
      # That was not good enough for the previous lookups
      $OPENSSL s_client -help 2>$s_client_has
+     grep -qw '\-alpn' $s_client_has && HAS_ALPN=true
+     grep -qw '\-nextprotoneg' $s_client_has &&  HAS_NPN=true
+     grep -qw '\-fallback_scsv' $s_client_has && HAS_FALLBACK_SCSV=true
+     grep -q '\-proxy' $s_client_has && HAS_PROXY=true
+     grep -q '\-xmpp' $s_client_has && HAS_XMPP=true
 
      $OPENSSL s_client -starttls foo 2>$s_client_starttls_has
-
-     grep -qw '\-alpn' $s_client_has && \
-          HAS_ALPN=true
-
-     grep -qw '\-nextprotoneg' $s_client_has && \
-          HAS_NPN=true
-
-     grep -qw '\-fallback_scsv' $s_client_has && \
-          HAS_FALLBACK_SCSV=true
-
-     grep -q '\-proxy' $s_client_has && \
-          HAS_PROXY=true
-
-     grep -q '\-xmpp' $s_client_has && \
-          HAS_XMPP=true
-
-     grep -q 'postgres' $s_client_starttls_has && \
-          HAS_POSTGRES=true
-
-     grep -q 'mysql' $s_client_starttls_has && \
-          HAS_MYSQL=true
-
-     grep -q 'lmtp' $s_client_starttls_has && \
-          HAS_LMTP=true
-
-     grep -q 'nntp' $s_client_starttls_has && \
-          HAS_NNTP=true
-
-     grep -q 'irc' $s_client_starttls_has && \
-          HAS_IRC=true
+     grep -q 'postgres' $s_client_starttls_has && HAS_POSTGRES=true
+     grep -q 'mysql' $s_client_starttls_has && HAS_MYSQL=true
+     grep -q 'lmtp' $s_client_starttls_has &&  HAS_LMTP=true
+     grep -q 'nntp' $s_client_starttls_has && HAS_NNTP=true
+     grep -q 'irc' $s_client_starttls_has && HAS_IRC=true
 
      $OPENSSL enc -chacha20 -K 12345678901234567890123456789012 -iv 01000000123456789012345678901234 > /dev/null 2> /dev/null <<< "test"
      [[ $? -eq 0 ]] && HAS_CHACHA20=true
@@ -18472,7 +18441,7 @@ determine_optimal_proto() {
      elif "$all_failed" && ! "$ALL_FAILED_SOCKETS"; then
           if ! "$HAS_TLS13" && "$TLS13_ONLY"; then
                pr_magenta " $NODE:$PORT appears to support TLS 1.3 ONLY. You better use --openssl=<path_to_openssl_supporting_TLS_1.3>"
-               if ! "$OSSL_SHORTCUT" || [[ ! -x /usr/bin/openssl ]] || /usr/bin/openssl s_client -tls1_3 -connect invalid. 2>&1 | grep -aiq "unknown option"; then
+               if ! "$OSSL_SHORTCUT" || [[ ! -x /usr/bin/openssl ]] || /usr/bin/openssl s_client -tls1_3 2>&1 | grep -aiq "unknown option"; then
                     outln
                     ignore_no_or_lame " Type \"yes\" to proceed and accept all scan problems" "yes"
                     [[ $? -ne 0 ]] && exit $ERR_CLUELESS


### PR DESCRIPTION
This PR provides a global variable to the RFC 6761 use of "invalid."
which WSL clients don't seem to handle very well, see #1738, #1812.
"invalid."  is used as a target to find out in a couple of pre-checks what
is supported by the openssl version.

This PR reduces the number of ``openssl s_client -connect`` by a huge factor.
For the remaining invocations the OS used is being determined and if WSL is
assumed (the check is probably not 100% accurate) it uses ``127.0.0.1:0`` instead.
In (unfortunately only a few) pre-tests the response was immediate.

Also it is possible to use another target if needed by

     NXCONNECT=<mytargethere>:<myport> ./testssl.sh <URL>

This is for 3.0. For 3.1dev see #1988 .