### PR TITLE
Fix double ports statement

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19304,7 +19304,7 @@ find_openssl_binary() {
 
      if $OPENSSL s_client -curves "${curves_ossl[0]}" -connect $NXCONNECT 2>&1 | grep -aiq "unknown option"; then
           for curve in "${curves_ossl[@]}"; do
-               $OPENSSL s_client -groups $curve -connect $NXCONNECT:8443 2>&1 | grep -Eiaq "Error with command|unknown option|Failed to set groups"
+               $OPENSSL s_client -groups $curve -connect ${NXCONNECT%:*}:8443 2>&1 | grep -Eiaq "Error with command|unknown option|Failed to set groups"
                [[ $? -ne 0 ]] && OSSL_SUPPORTED_CURVES+=" $curve "
           done
      else


### PR DESCRIPTION
In order to be in line with 3.0 this adds a statement to avoid double port
statements for WSL users in a precheck condition

   $OPENSSL s_client -groups $curve -connect 127.0.0.1:0:8443

This commit changes that to $OPENSSL s_client -groups $curve -connect 127.0.0.1:8443
which could cause a delay for WSL users and needs further investigation.

Not clear why port 8443 was chosen.

See also #2012