### PR TITLE
Fix s_client_options()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2197,7 +2197,7 @@ s_client_options() {
      if "$HAS_SECLEVEL"; then
           if [[ "$ciphers" == notpresent ]]; then
                [[ ! " $options " =~ \ -tls1_3\  ]] && ciphers="@SECLEVEL=0:ALL:COMPLEMENTOFALL"
-          else
+          elif [[ -n "$ciphers" ]]; then
                ciphers="@SECLEVEL=0:$ciphers"
           fi
      fi


### PR DESCRIPTION
This PR fixes an error in `s_client_options()` when the function is called with an empty "-cipher" list and $OPENSSL supports "@SECLEVEL". This happens, for example, when `ciphers_by_strength()` is called for TLS 1.3 and OpenSSL 1.1.1 is being used.

The call to `openssl s_client` will fail is the cipher option is provided with an empty list or a list that just contains "@SECLEVEL=0". So, "@SECLEVEL=0" should only be added if the "$ciphers" list is non-empty. If "$ciphers" remains empty, then the "-cipher" option will not be added to the command line.