### PR TITLE
Speedup cipher_pref_check()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6957,7 +6957,8 @@ cipher_pref_check() {
      fi
 
      if ( [[ $proto != tls1_3 ]] || "$HAS_TLS13" ) && ( [[ $proto != ssl3 ]] || "$HAS_SSL3" ); then
-          if [[ $proto == tls1_2 ]] && "$SERVER_SIZE_LIMIT_BUG"; then
+          if [[ $proto == tls1_2 ]] && "$SERVER_SIZE_LIMIT_BUG" && \
+             [[ "$(count_ciphers "$(actually_supported_osslciphers "ALL:COMPLEMENTOFALL" "" "")")" -gt 127 ]]; then
                order="$(check_tls12_pref "$wide")"
                [[ "${order:0:1}" == \  ]] && order="${order:1}"
                ciphers_found="$order"


### PR DESCRIPTION
While OpenSSL 1.0.2-chacha supports more than 128 cipher suites, other versions of OpenSSL tend to support far fewer than that.

Calling `check_tls12_pref()` adds to the run time of `cipher_pref_check()`, but is only needed if OpenSSL would otherwise send a ClientHello with more than 128 cipher suites. So, this PR adds another check and only calls `check_tls12_pref()` if the server has the size limit bug and OpenSSL supports more than 127 ciphers.