### PR TITLE
Check file permissions on ./testssl.sh

### DIFF
--- a/t/00_testssl_help.t
+++ b/t/00_testssl_help.t
@@ -4,6 +4,7 @@
 
 use strict;
 use Test::More;
+use File::stat;
 
 my $tests = 0;
 my $fileout="";
@@ -20,6 +21,15 @@ my $error_regexp4='command not found';
 my $error_regexp5='(syntax error|unexpected token)';
 
 printf "\n%s\n", "Testing whether just calling \"./testssl.sh\" produces no error ...";
+my $info    = stat($prg);
+my $retMode = $info->mode;
+
+is($retMode & 0400, 0400, "Checking \"./testssl.sh\" for read permission"); 
+$tests++;
+
+is($retMode & 0100, 0100, "Checking \"./testssl.sh\" for execute permission"); 
+$tests++;
+
 $fileout = `timeout 10 bash $prg 2>&1`;
 my $retval=$?;
 


### PR DESCRIPTION
This PR adds a check that ./testssl.sh has both read and execute permission. If ./testssl.sh is lacking execute permission, it will pass the tests in 00_testssl_help.t and 01_testssl_banner.t, which run the program as `bash ./testssl.sh`, but will fail the subsequent tests, which run the program as `./testssl.sh`, but the reason for the failure will not be clear.

I accidentally created a branch in which ./testssl.sh did not have execute permission. That caused the Travis/CI tests to fail, but it took me a long time to discover the reason for the failure.