### PR TITLE
Fix sub_cipherlists()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5889,7 +5889,7 @@ sub_cipherlists() {
                elif [[ -n "$7" ]]; then
                     sslv2_sockets "$7" "true"
                     if [[ $? -eq 3 ]] && [[ "$V2_HELLO_CIPHERSPEC_LENGTH" -ne 0 ]]; then
-                         sslv2_cipherlist="$(strip_spaces "${6//,/}")"
+                         sslv2_cipherlist="$(strip_spaces "${7//,/}")"
                          len=${#sslv2_cipherlist}
                          detected_ssl2_ciphers="$(grep "Supported cipher: " "$TEMPDIR/$NODEIP.parse_sslv2_serverhello.txt")"
                          for (( i=0; i<len; i+=6 )); do


### PR DESCRIPTION
This PR fixes a bug in `sub_cipherlists()` when using sockets to test whether a server supports a set of ciphers with SSLv2. Code that is supposed to extract the list of SSLv2 ciphers to test for is incorrectly reading from the list of non-SSLv2 ciphers.