### PR TITLE
Fix #2049

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1331,6 +1331,7 @@ fileout() {
 
      if ( "$do_pretty_json" && [[ "$1" == service ]] ) || show_finding "$severity"; then
           local finding=$(strip_lf "$(newline_to_spaces "$(strip_quote "$3")")")           # additional quotes will mess up screen output
+          finding="${finding//\\n/ }"
           [[ -e "$JSONFILE" ]] && [[ ! -d "$JSONFILE" ]] && fileout_json_finding "$1" "$severity" "$finding" "$cve" "$cwe" "$hint"
           "$do_csv" && [[ -n "$CSVFILE" ]] && [[ ! -d "$CSVFILE" ]] && \
                fileout_csv_finding "$1" "$NODE/$NODEIP" "$PORT" "$severity" "$finding" "$cve" "$cwe" "$hint"


### PR DESCRIPTION
This PR fixes #2049 by converting newline characters to spaces in JSON and CSV findings.

`fileout()` calls `newline_to_spaces()` on any `$finding` that is to be written to a JSON or CSV file. However, this only affects actual newline characters in the string, not escaped newline characters (i.e., "\n"). Escaped newline characters pass through this function unchanged, but then get converted to newline characters when they are written to the JSON and/or CSV files. This PR fixes the problem by also converting escaped newline characters ("\n") to spaces.

If this PR is accepted, then I can create another one for the 3.0 branch.