### PR TITLE
Fix #2053

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1175,7 +1175,7 @@ fileout_section_header() {
 
 # arg1: whether to end object too
 fileout_section_footer() {
-     "$do_pretty_json" && printf "\n                    ]" >> "$JSONFILE"
+     "$do_pretty_json" && FIRST_FINDING=false && printf "\n                    ]" >> "$JSONFILE"
      "$do_pretty_json" && "$1" && echo -e "\n          }" >> "$JSONFILE"
      SECTION_FOOTER_NEEDED=false
 }


### PR DESCRIPTION
This PR fixes #2053 by resetting `$FIRST_FINDING` after the test for each IP address completes. It also changes the return value for `run_mx_all_ips()` to be the sum of the return values for all calls to `lets_roll()` to match what is done at the end of testssl.sh for multiple IP addresses.