### PR TITLE
Simplify check for git working tree

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -127,7 +127,7 @@ declare -r SWCONTACT="dirk aet testssl dot sh"
 [[ "$VERSION" =~ dev|rc|beta ]] && \
      SWURL="https://testssl.sh/dev/" ||
      SWURL="https://testssl.sh/"
-if git log &>/dev/null; then
+if git rev-parse --is-inside-work-tree &>/dev/null; then
      declare -r GIT_REL="$(git log --format='%h %ci' -1 2>/dev/null | awk '{ print $1" "$2" "$3 }')"
      declare -r GIT_REL_SHORT="$(git log --format='%h %ci' -1 2>/dev/null | awk '{ print $1 }')"
      declare -r REL_DATE="$(git log --format='%h %ci' -1 2>/dev/null | awk '{ print $2 }')"


### PR DESCRIPTION
Sending the entire log to /dev/null is a rather expensive way of checking whether
we are inside a git working tree. Use `git rev-parse --is-inside-work-tree` instead.