### PR TITLE
Simplify extracting Git information

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -129,8 +129,9 @@ declare -r SWCONTACT="dirk aet testssl dot sh"
      SWURL="https://testssl.sh/"
 if git rev-parse --is-inside-work-tree &>/dev/null; then
      declare -r GIT_REL="$(git log --format='%h %ci' -1 2>/dev/null | awk '{ print $1" "$2" "$3 }')"
-     declare -r GIT_REL_SHORT="$(git log --format='%h %ci' -1 2>/dev/null | awk '{ print $1 }')"
-     declare -r REL_DATE="$(git log --format='%h %ci' -1 2>/dev/null | awk '{ print $2 }')"
+     declare -r GIT_REL_SHORT="${GIT_REL%% *}"
+     declare -r REL_DATE_TIME="${GIT_REL#* }"
+     declare -r REL_DATE="${REL_DATE_TIME% *}"
 fi
 declare -r PROG_NAME="$(basename "$0")"
 declare -r RUN_DIR="$(dirname "$0")"


### PR DESCRIPTION
testssl.sh currently calls `git log --format='%h %ci' -1 2>/dev/null` three times. This PR changes testssl.sh to make this call just once and then use Bash string manipulation to extract the necessary information from the result.