### PR TITLE
Update reset_hostdepended_vars()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22965,12 +22965,37 @@ nodeip_to_proper_ip6() {
 
 
 reset_hostdepended_vars() {
+     NR_SOCKET_FAIL=0
+     NR_OSSL_FAIL=0
+     NR_STARTTLS_FAIL=0
+     NR_HEADER_FAIL=0
      TLS_EXTENSIONS=""
      PROTOS_OFFERED=""
+     TLS12_CIPHER_OFFERED=""
      CURVES_OFFERED=""
+     KNOWN_OSSL_PROB=false
+     TLS13_ONLY=false
+     CLIENT_AUTH="none"
+     NO_SSL_SESSIONID=false
+     DH_GROUP_OFFERED=""
+     DH_GROUP_LEN_P=0
+     KEY_SHARE_EXTN_NR="33"
+     BAD_SERVER_HELLO_CIPHER=false
+     GOST_STATUS_PROBLEM=false
      OPTIMAL_PROTO=""
+     STARTTLS_OPTIMAL_PROTO=""
      ALL_FAILED_SOCKETS=true
      SERVER_SIZE_LIMIT_BUG=false
+     SERVICE=""
+     CERT_FINGERPRINT_SHA2=""
+     RSA_CERT_FINGERPRINT_SHA2=""
+     TLS_TIME=""
+     GRADE_CAP=""
+     GRADE_CAP_REASONS=()
+     GRADE_WARNINGS=()
+     KEY_EXCH_SCORE=100
+     CIPH_STR_BEST=0
+     CIPH_STR_WORST=100000
 }
 
 # Rough estimate, in the future we maybe want to make use of nano secs (%N). Note this
@@ -23130,10 +23155,6 @@ lets_roll() {
      outln
      calc_scantime
      datebanner " Done"
-
-     # reset the failed connect counter as we are finished
-     NR_SOCKET_FAIL=0
-     NR_OSSL_FAIL=0
 
      "$MEASURE_TIME" && printf "$1: %${COLUMNS}s\n" "$SCAN_TIME"
      [[ -e "$MEASURE_TIME_FILE" ]] && echo "Total : $SCAN_TIME " >> "$MEASURE_TIME_FILE"


### PR DESCRIPTION
I noticed in the JSON output shown in https://github.com/drwetter/testssl.sh/issues/2053#issue-1068946357 that two different "scanProblem" error messages appear. While this may not be the reason for it, I discovered that `lets_roll()` was resetting `$NR_SOCKET_FAIL` and `$NR_OSSL_FAIL` after each host was tested, but it was not resetting `$NR_STARTTLS_FAIL`. This led me to compare the variables initialized at the start of testssl.sh to those reset in `reset_hostdepended_vars()` and I discovered a lot a variables were not being reset for each host, but should be.

This PR attempts to fix the problem by adding several variables to `reset_hostdepended_vars()`. For consistency purposes, I moved the resetting of `$NR_SOCKET_FAIL` and `$NR_OSSL_FAIL` from `lets_roll()` to `reset_hostdepended_vars()`. While I tried to find every variable that should be reset for each host, there is a chance that I missed something. In most cases, this PR won't have any effect, since servers with the same DNS name and port number tend to be configured very similarly.