### PR TITLE
Document $keyopts

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2231,6 +2231,7 @@ s_client_options() {
           [[ "$1" =~ secp192r1 ]] && options="${options//secp192r1/prime192v1}"
           [[ "$1" =~ secp256r1 ]] && options="${options//secp256r1/prime256v1}"
      fi
+     # $keyopts may be set as an environment variable to enable client authentication (see PR #1383)
      tm_out "$options $keyopts"
 }
 


### PR DESCRIPTION
Shellcheck complains on line 2234 that keyopts is referenced but not assigned and there is no explanation in the code (or in the documentation) why "$keyopts" is there. This commit adds a comment so that "$keyopts" isn't deleted as part of a code cleanup.