### PR TITLE
Add sieve protocol support when using STARTTLS

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -1,939 +1,600 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "TESTSSL" "1" "May 2020" "" ""
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "TESTSSL" "1" "December 2021" ""
 .SH "NAME"
 \fBtestssl\fR
-.
 .SH "NAME"
 testssl\.sh \-\- check encryption of SSL/TLS servers
-.
 .SH "SYNOPSIS"
 \fBtestssl\.sh [OPTIONS] <URI>\fR, \fBtestssl\.sh [OPTIONS] \-\-file <FILE>\fR
-.
 .P
 or
-.
 .P
 \fBtestssl\.sh [BANNER OPTIONS]\fR
-.
 .SH "DESCRIPTION"
-testssl\.sh is a free command line tool which checks a server\'s service on any port for the support of TLS/SSL ciphers, protocols as well as cryptographic flaws and much more\.
-.
+testssl\.sh is a free command line tool which checks a server's service on any port for the support of TLS/SSL ciphers, protocols as well as cryptographic flaws and much more\.
 .P
 The output rates findings by color (screen) or severity (file output) so that you are able to tell whether something is good or bad\. The (screen) output has several sections in which classes of checks are being performed\. To ease readability on the screen it aligns and indents the output properly\.
-.
 .P
-Only you see the result\. You also can use it internally on your LAN\. Except DNS lookups or unless you instruct testssl\.sh to check for revocation of certificates it doesn\'t use any other hosts or even third parties for any test\.
-.
+Only you see the result\. You also can use it internally on your LAN\. Except DNS lookups or unless you instruct testssl\.sh to check for revocation of certificates it doesn't use any other hosts or even third parties for any test\.
 .SH "REQUIREMENTS"
 Testssl\.sh is out of the box portable: it runs under any Unix\-like stack: Linux, *BSD, MacOS X, WSL=Windows Subsystem for Linux, Cygwin and MSYS2\. \fBbash\fR is a prerequisite, also version 3 is still supported\. Standard utilities like awk, sed, tr and head are also needed\. This can be of a BSD, System 5 or GNU flavor whereas grep from System V is not yet supported\.
-.
 .P
 Any OpenSSL or LibreSSL version is needed as a helper\. Unlike previous versions of testssl\.sh almost every check is done via (TCP) sockets\. In addition statically linked OpenSSL binaries for major operating systems are supplied in \fB\./bin/\fR\.
-.
 .SH "GENERAL"
 \fBtestssl\.sh URI\fR as the default invocation does the so\-called default run which does a number of checks and puts out the results colorized (ANSI and termcap) on the screen\. It does every check listed below except \fB\-E\fR which are (order of appearance):
-.
 .P
 0) displays a banner (see below), does a DNS lookup also for further IP addresses and does for the returned IP address a reverse lookup\. Last but not least a service check is being done\.
-.
 .P
 1) SSL/TLS protocol check
-.
 .P
 2) standard cipher categories
-.
 .P
-3) server\'s cipher preferences (server order?)
-.
+3) server's cipher preferences (server order?)
 .P
 4) forward secrecy: ciphers and elliptical curves
-.
 .P
 5) server defaults (certificate info, TLS extensions, session information)
-.
 .P
 6) HTTP header (if HTTP detected or being forced via \fB\-\-assume\-http\fR)
-.
 .P
 7) vulnerabilities
-.
 .P
 8) testing each of 370 preconfigured ciphers
-.
 .P
 8) client simulation
-.
 .P
 9) rating
-.
 .SH "OPTIONS AND PARAMETERS"
 Options are either short or long options\. Any long or short option requiring a value can be called with or without an equal sign\. E\.g\. \fBtestssl\.sh \-t=smtp \-\-wide \-\-openssl=/usr/bin/openssl <URI>\fR (short options with equal sign) is equivalent to \fBtestssl\.sh \-\-starttls smtp \-\-wide \-\-openssl /usr/bin/openssl <URI>\fR (long option without equal sign)\. Some command line options can also be preset via ENV variables\. \fBWIDE=true OPENSSL=/usr/bin/openssl testssl\.sh \-\-starttls=smtp <URI>\fR would be the equivalent to the aforementioned examples\. Preference has the command line over any environment variables\.
-.
 .P
 \fB<URI>\fR or \fB\-\-file <FILE>\fR always needs to be the last parameter\.
-.
 .SS "BANNER OPTIONS (standalone)"
 \fB\-\-help\fR (or no arg) displays command line help
-.
 .P
 \fB\-b, \-\-banner\fR displays testssl\.sh banner, including license, usage conditions, version of testssl\.sh, detected openssl version, its path to it, # of ciphers of openssl, its build date and the architecture\.
-.
 .P
 \fB\-v, \-\-version\fR same as before
-.
 .P
-\fB\-V [pattern], \-\-local [pattern]\fR pretty print all local ciphers supported by openssl version\. If a pattern is supplied it performs a match (ignore case) on any of the strings supplied in the wide output, see below\. The pattern will be searched in the any of the columns: hexcode, cipher suite name (OpenSSL or IANA), key exchange, encryption, bits\. It does a word pattern match for non\-numbers, for number just a normal match applies\. Numbers here are defined as [0\-9,A\-F]\. This means (attention: catch) that the pattern CBC is matched as non\-word, but AES as word\. This option also accepts -\fB-openssl=<path_to_openssl>\fR\.
-.
+\fB\-V [pattern], \-\-local [pattern]\fR pretty print all local ciphers supported by openssl version\. If a pattern is supplied it performs a match (ignore case) on any of the strings supplied in the wide output, see below\. The pattern will be searched in the any of the columns: hexcode, cipher suite name (OpenSSL or IANA), key exchange, encryption, bits\. It does a word pattern match for non\-numbers, for number just a normal match applies\. Numbers here are defined as [0\-9,A\-F]\. This means (attention: catch) that the pattern CBC is matched as non\-word, but AES as word\. This option also accepts \fB\-\-openssl=<path_to_openssl>\fR\.
 .SS "INPUT PARAMETERS"
 \fBURI\fR can be a hostname, an IPv4 or IPv6 address (restriction see below) or an URL\. IPv6 addresses need to be in square brackets\. For any given parameter port 443 is assumed unless specified by appending a colon and a port number\. The only preceding protocol specifier allowed is \fBhttps\fR\. You need to be aware that checks for an IP address might not hit the vhost you want\. DNS resolution (A/AAAA record) is being performed unless you have an \fB/etc/hosts\fR entry for the hostname\.
-.
 .P
-\fB\-\-file <fname>\fR or the equivalent \fB\-iL <fname>\fR are mass testing options\. Per default it implicitly turns on \fB\-\-warnings batch\fR\. In its first incarnation the mass testing option reads command lines from \fBfname\fR\. \fBfname\fR consists of command lines of testssl, one line per instance\. Comments after \fB#\fR are ignored, \fBEOF\fR signals the end of fname any subsequent lines will be ignored too\. You can also supply additional options which will be inherited to each child, e\.g\. When invoking \fBtestssl\.sh \-\-wide \-\-log \-\-file <fname>\fR \. Each single line in \fBfname\fR is parsed upon execution\. If there\'s a conflicting option and serial mass testing option is being performed the check will be aborted at the time it occurs and depending on the output option potentially leaving you with an output file without footer\. In parallel mode the mileage varies, likely a line won\'t be scanned\.
-.
+\fB\-\-file <fname>\fR or the equivalent \fB\-iL <fname>\fR are mass testing options\. Per default it implicitly turns on \fB\-\-warnings batch\fR\. In its first incarnation the mass testing option reads command lines from \fBfname\fR\. \fBfname\fR consists of command lines of testssl, one line per instance\. Comments after \fB#\fR are ignored, \fBEOF\fR signals the end of fname any subsequent lines will be ignored too\. You can also supply additional options which will be inherited to each child, e\.g\. When invoking \fBtestssl\.sh \-\-wide \-\-log \-\-file <fname>\fR \. Each single line in \fBfname\fR is parsed upon execution\. If there's a conflicting option and serial mass testing option is being performed the check will be aborted at the time it occurs and depending on the output option potentially leaving you with an output file without footer\. In parallel mode the mileage varies, likely a line won't be scanned\.
 .P
-Alternatively \fBfname\fR can be in \fBnmap\fR\'s grep(p)able output format (\fB\-oG\fR)\. Only open ports will be considered\. Multiple ports per line are allowed\. The ports can be different and will be tested by testssl\.sh according to common practice in the internet, i\.e\. if nmap shows in its output an open port 25, automatically \fB\-t smtp\fR will be added before the URI whereas port 465 will be treated as a plain TLS/SSL port, not requiring an STARTTLS SMTP handshake upfront\. This is done by an internal table which correlates nmap\'s open port detected to the STARTTLS/plain text decision from testssl\.sh\.
-.
+Alternatively \fBfname\fR can be in \fBnmap\fR's grep(p)able output format (\fB\-oG\fR)\. Only open ports will be considered\. Multiple ports per line are allowed\. The ports can be different and will be tested by testssl\.sh according to common practice in the internet, i\.e\. if nmap shows in its output an open port 25, automatically \fB\-t smtp\fR will be added before the URI whereas port 465 will be treated as a plain TLS/SSL port, not requiring an STARTTLS SMTP handshake upfront\. This is done by an internal table which correlates nmap's open port detected to the STARTTLS/plain text decision from testssl\.sh\.
 .P
-Nmap\'s output always returns IP addresses and only if there\'s a PTR DNS record available a hostname\. As it is not checked by nmap whether the hostname matches the IP (A or AAAA record), testssl\.sh does this automatically for you\. If the A record of the hostname matches the IP address, the hostname is used and not the IP address\. Please keep in mind that checks against an IP address might not hit the vhost you maybe were aiming at and thus it may lead to different results\.
-.
+Nmap's output always returns IP addresses and only if there's a PTR DNS record available a hostname\. As it is not checked by nmap whether the hostname matches the IP (A or AAAA record), testssl\.sh does this automatically for you\. If the A record of the hostname matches the IP address, the hostname is used and not the IP address\. Please keep in mind that checks against an IP address might not hit the vhost you maybe were aiming at and thus it may lead to different results\.
 .P
-A typical internal conversion to testssl\.sh file format from nmap\'s grep(p)able format could look like:
-.
-.IP "" 4
-.
-.nf
-
-10\.10\.12\.16:443
-10\.10\.12\.16:1443
-\-t smtp host\.example\.com:25
-host\.example\.com:443
-host\.example\.com:631
-\-t ftp 10\.10\.12\.11:21
-10\.10\.12\.11:8443
-.
-.fi
-.
-.IP "" 0
-.
+A typical internal conversion to testssl\.sh file format from nmap's grep(p)able format could look like:
 .P
-Please note that \fBfname\fR has to be in Unix format\. DOS carriage returns won\'t be accepted\. Instead of the command line switch the environment variable FNAME will be honored too\.
-.
+\fB10\.10\.12\.16:443 10\.10\.12\.16:1443 \-t smtp host\.example\.com:25 host\.example\.com:443 host\.example\.com:631 \-t ftp 10\.10\.12\.11:21 10\.10\.12\.11:8443\fR Please note that \fBfname\fR has to be in Unix format\. DOS carriage returns won't be accepted\. Instead of the command line switch the environment variable FNAME will be honored too\.
 .P
 \fB\-\-mode <serial|parallel>\fR\. Mass testing to be done serial (default) or parallel (\fB\-\-parallel\fR is shortcut for the latter, \fB\-\-serial\fR is the opposite option)\. Per default mass testing is being run in serial mode, i\.e\. one line after the other is processed and invoked\. The variable \fBMASS_TESTING_MODE\fR can be defined to be either equal \fBserial\fR or \fBparallel\fR\.
-.
 .P
-\fB\-\-warnings <batch|off>\fR\. The warnings parameter determines how testssl\.sh will deal with situations where user input normally will be necessary\. There are two options\. \fBbatch\fR doesn\'t wait for a confirming keypress when a client\- or server\-side problem is encountered\. As of 3\.0 it just then terminates the particular scan\. This is automatically chosen for mass testing (\fB\-\-file\fR)\. \fBoff\fR just skips the warning, the confirmation but continues the scan, independent whether it makes sense or not\. Please note that there are conflicts where testssl\.sh will still ask for confirmation which are the ones which otherwise would have a drastic impact on the results\. Almost any other decision will be made in the future as a best guess by testssl\.sh\. The same can be achieved by setting the environment variable \fBWARNINGS\fR\.
-.
+\fB\-\-warnings <batch|off>\fR\. The warnings parameter determines how testssl\.sh will deal with situations where user input normally will be necessary\. There are two options\. \fBbatch\fR doesn't wait for a confirming keypress when a client\- or server\-side problem is encountered\. As of 3\.0 it just then terminates the particular scan\. This is automatically chosen for mass testing (\fB\-\-file\fR)\. \fBoff\fR just skips the warning, the confirmation but continues the scan, independent whether it makes sense or not\. Please note that there are conflicts where testssl\.sh will still ask for confirmation which are the ones which otherwise would have a drastic impact on the results\. Almost any other decision will be made in the future as a best guess by testssl\.sh\. The same can be achieved by setting the environment variable \fBWARNINGS\fR\.
 .P
-\fB\-\-connect\-timeout <seconds>\fR This is useful for socket TCP connections to a node\. If the node does not complete a TCP handshake (e\.g\. because it is down or behind a firewall or there\'s an IDS or a tarpit) testssl\.sh may usually hang for around 2 minutes or even much more\. This parameter instructs testssl\.sh to wait at most \fBseconds\fR for the handshake to complete before giving up\. This option only works if your OS has a timeout binary installed\. CONNECT_TIMEOUT is the corresponding environment variable\.
-.
+\fB\-\-connect\-timeout <seconds>\fR This is useful for socket TCP connections to a node\. If the node does not complete a TCP handshake (e\.g\. because it is down or behind a firewall or there's an IDS or a tarpit) testssl\.sh may usually hang for around 2 minutes or even much more\. This parameter instructs testssl\.sh to wait at most \fBseconds\fR for the handshake to complete before giving up\. This option only works if your OS has a timeout binary installed\. CONNECT_TIMEOUT is the corresponding environment variable\.
 .P
 \fB\-\-openssl\-timeout <seconds>\fR This is especially useful for all connects using openssl and practically useful for mass testing\. It avoids the openssl connect to hang for ~2 minutes\. The expected parameter \fBseconds\fR instructs testssl\.sh to wait before the openssl connect will be terminated\. The option is only available if your OS has a timeout binary installed\. As there are different implementations of \fBtimeout\fR: It automatically calls the binary with the right parameters\. OPENSSL_TIMEOUT is the equivalent environment variable\.
-.
 .P
 \fB\-\-basicauth <user:pass>\fR This can be set to provide HTTP basic auth credentials which are used during checks for security headers\. BASICAUTH is the ENV variable you can use instead\.
-.
 .P
-\fB\-\-reqheader <header>\fR This can be used to add additional HTTP request headers in the correct format \fBHeadername: headercontent\fR\. This parameter can be called multiple times if required\. For example: \fB\-\-reqheader \'Proxy\-Authorization: Basic dGVzdHNzbDpydWxlcw==\' \-\-reqheader \'ClientID: 0xDEADBEAF\'\fR\. REQHEADER is the corresponding environment variable\.
-.
+\fB\-\-reqheader <header>\fR This can be used to add additional HTTP request headers in the correct format \fBHeadername: headercontent\fR\. This parameter can be called multiple times if required\. For example: \fB\-\-reqheader 'Proxy\-Authorization: Basic dGVzdHNzbDpydWxlcw==' \-\-reqheader 'ClientID: 0xDEADBEAF'\fR\. REQHEADER is the corresponding environment variable\.
 .SS "SPECIAL INVOCATIONS"
-\fB\-t <protocol>, \-\-starttls <protocol>\fR does a default run against a STARTTLS enabled \fBprotocol\fR\. \fBprotocol\fR must be one of \fBftp\fR, \fBsmtp\fR, \fBpop3\fR, \fBimap\fR, \fBxmpp\fR, \fBxmpp-server\fR, \fBtelnet\fR, \fBldap\fR, \fBirc\fR, \fBlmtp\fR, \fBnntp\fR, \fBpostgres\fR, \fBmysql\fR\. For the latter four you need e\.g\. the supplied OpenSSL or OpenSSL version 1\.1\.1\. Please note: MongoDB doesn\'t offer a STARTTLS connection, LDAP currently only works with \fB\-\-ssl\-native\fR\. \fBtelnet\fR and \fBirc\fR is WIP\.
-.
+\fB\-t <protocol>, \-\-starttls <protocol>\fR does a default run against a STARTTLS enabled \fBprotocol\fR\. \fBprotocol\fR must be one of \fBftp\fR, \fBsmtp\fR, \fBpop3\fR, \fBimap\fR, \fBxmpp\fR, \fBsieve\fR, \fBxmpp\-server\fR, \fBtelnet\fR, \fBldap\fR, \fBirc\fR, \fBlmtp\fR, \fBnntp\fR, \fBpostgres\fR, \fBmysql\fR\. For the latter four you need e\.g\. the supplied OpenSSL or OpenSSL version 1\.1\.1\. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with \fB\-\-ssl\-native\fR\. \fBtelnet\fR and \fBirc\fR is WIP\.
 .P
 \fB\-\-xmpphost <jabber_domain>\fR is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter\. This is only needed if the domain is different from the URI supplied\.
-.
 .P
 \fB\-\-mx <domain|host>\fR tests all MX records (STARTTLS on port 25) from high to low priority, one after the other\.
-.
 .P
 \fB\-\-ip <ip>\fR tests either the supplied IPv4 or IPv6 address instead of resolving host(s) in \fB<URI>\fR\. IPv6 addresses need to be supplied in square brackets\. \fB\-\-ip=one\fR means: just test the first A record DNS returns (useful for multiple IPs)\. If \fB\-6\fR and \fB\-\-ip=one\fR was supplied an AAAA record will be picked if available\. The \fB\-\-ip\fR option might be also useful if you want to resolve the supplied hostname to a different IP, similar as if you would edit \fB/etc/hosts\fR or \fB/c/Windows/System32/drivers/etc/hosts\fR\. \fB\-\-ip=proxy\fR tries a DNS resolution via proxy\.
-.
 .P
-\fB\-\-proxy <host>:<port>\fR does ANY check via the specified proxy\. \fB\-\-proxy=auto\fR inherits the proxy setting from the environment\. The hostname supplied will be resolved to the first A record\. In addition if you want lookups via proxy you can specify \fBDNS_VIA_PROXY=true\fR\. OCSP revocation checking (\fB\-S \-\-phone\-out\fR) is not supported by OpenSSL via proxy\. As supplying a proxy is an indicator for port 80 and 443 outgoing being blocked in your network an OCSP revocation check won\'t be performed\. However if \fBIGN_OCSP_PROXY=true\fR has been supplied it will be tried directly\. Authentication to the proxy is not supported\. Proxying via IPv6 addresses is not possible, no HTTPS or SOCKS proxy is supported\.
-.
+\fB\-\-proxy <host>:<port>\fR does ANY check via the specified proxy\. \fB\-\-proxy=auto\fR inherits the proxy setting from the environment\. The hostname supplied will be resolved to the first A record\. In addition if you want lookups via proxy you can specify \fBDNS_VIA_PROXY=true\fR\. OCSP revocation checking (\fB\-S \-\-phone\-out\fR) is not supported by OpenSSL via proxy\. As supplying a proxy is an indicator for port 80 and 443 outgoing being blocked in your network an OCSP revocation check won't be performed\. However if \fBIGN_OCSP_PROXY=true\fR has been supplied it will be tried directly\. Authentication to the proxy is not supported\. Proxying via IPv6 addresses is not possible, no HTTPS or SOCKS proxy is supported\.
 .P
-\fB\-6\fR does (also) IPv6 checks\. Please note that testssl\.sh doesn\'t perform checks on an IPv6 address automatically, because of two reasons: testssl\.sh does no connectivity checks for IPv6 and it cannot determine reliably whether the OpenSSL binary you\'re using has IPv6 s_client support\. \fB\-6\fR assumes both is the case\. If both conditions are met and you in general prefer to test for IPv6 branches as well you can add \fBHAS_IPv6\fR to your shell environment\. Besides the OpenSSL binary supplied IPv6 is known to work with vanilla OpenSSL >= 1\.1\.0 and older versions >=1\.0\.2 in RHEL/CentOS/FC and Gentoo\.
-.
+\fB\-6\fR does (also) IPv6 checks\. Please note that testssl\.sh doesn't perform checks on an IPv6 address automatically, because of two reasons: testssl\.sh does no connectivity checks for IPv6 and it cannot determine reliably whether the OpenSSL binary you're using has IPv6 s_client support\. \fB\-6\fR assumes both is the case\. If both conditions are met and you in general prefer to test for IPv6 branches as well you can add \fBHAS_IPv6\fR to your shell environment\. Besides the OpenSSL binary supplied IPv6 is known to work with vanilla OpenSSL >= 1\.1\.0 and older versions >=1\.0\.2 in RHEL/CentOS/FC and Gentoo\.
 .P
 \fB\-\-ssl\-native\fR Instead of using a mixture of bash sockets and a few openssl s_client connects, testssl\.sh uses the latter (almost) only\. This is faster at the moment but provides less accurate results, especially for the client simulation and for cipher support\. For all checks you will see a warning if testssl\.sh cannot tell if a particular check cannot be performed\. For some checks however you might end up getting false negatives without a warning\. This option is only recommended if you prefer speed over accuracy or you know that your target has sufficient overlap with the protocols and cipher provided by your openssl binary\.
-.
 .P
-\fB\-\-openssl <path_to_openssl>\fR testssl\.sh tries very hard to find automagically the binary supplied (where the tree of testssl\.sh resides, from the directory where testssl\.sh has been started from, etc\.)\. If all that doesn\'t work it falls back to openssl supplied from the OS (\fB$PATH\fR)\. With this option you can point testssl\.sh to your binary of choice and override any internal magic to find the openssl binary\. (Environment preset via \fBOPENSSL=<path_to_openssl>\fR)\.
-.
+\fB\-\-openssl <path_to_openssl>\fR testssl\.sh tries very hard to find automagically the binary supplied (where the tree of testssl\.sh resides, from the directory where testssl\.sh has been started from, etc\.)\. If all that doesn't work it falls back to openssl supplied from the OS (\fB$PATH\fR)\. With this option you can point testssl\.sh to your binary of choice and override any internal magic to find the openssl binary\. (Environment preset via \fBOPENSSL=<path_to_openssl>\fR)\.
 .SS "TUNING OPTIONS"
 \fB\-\-bugs\fR does some workarounds for buggy servers like padding for old F5 devices\. The option is passed as \fB\-bug\fR to openssl when needed, see \fBs_client(1)\fR, environment preset via \fBBUGS="\-bugs"\fR (1x dash)\. For the socket part testssl\.sh has always workarounds in place to cope with broken server implementations\.
-.
 .P
 \fB\-\-assuming\-http\fR testssl\.sh normally does upfront an application protocol detection\. In cases where HTTP cannot be automatically detected you may want to use this option\. It enforces testssl\.sh not to skip HTTP specific tests (HTTP header) and to run a browser based client simulation\. Please note that sometimes also the severity depends on the application protocol, e\.g\. SHA1 signed certificates, the lack of any SAN matches and some vulnerabilities will be punished harder when checking a web server as opposed to a mail server\.
-.
 .P
-\fB\-n, \-\-nodns <min|none>\fR tells testssl\.sh which DNS lookups should be performed\. \fBmin\fR uses only forward DNS resolution (A and AAAA record or MX record) and skips CAA lookups and PTR records from the IP address back to a DNS name\. \fBnone\fR performs no DNS lookups at all\. For the latter you either have to supply the IP address as a target, to use \fB\-\-ip\fR or have the IP address in \fB/etc/hosts\fR\. The use of the switch is only useful if you either can\'t or are not willing to perform DNS lookups\. The latter can apply e\.g\. to some pentests\. In general this option could e\.g\. help you to avoid timeouts by DNS lookups\. \fBNODNS\fR is the environment variable for this\.
-.
+\fB\-n, \-\-nodns <min|none>\fR tells testssl\.sh which DNS lookups should be performed\. \fBmin\fR uses only forward DNS resolution (A and AAAA record or MX record) and skips CAA lookups and PTR records from the IP address back to a DNS name\. \fBnone\fR performs no DNS lookups at all\. For the latter you either have to supply the IP address as a target, to use \fB\-\-ip\fR or have the IP address in \fB/etc/hosts\fR\. The use of the switch is only useful if you either can't or are not willing to perform DNS lookups\. The latter can apply e\.g\. to some pentests\. In general this option could e\.g\. help you to avoid timeouts by DNS lookups\. \fBNODNS\fR is the environment variable for this\.
 .P
-\fB\-\-sneaky\fR For HTTP header checks testssl\.sh uses normally the server friendly HTTP user agent \fBTLS tester from ${URL}\fR\. With this option your traces are less verbose and a Firefox user agent is being used\. Be aware that it doesn\'t hide your activities\. That is just not possible (environment preset via \fBSNEAKY=true\fR)\.
+\fB\-\-sneaky\fR For HTTP header checks testssl\.sh uses normally the server friendly HTTP user agent \fBTLS tester from ${URL}\fR\. With this option your traces are less verbose and a Firefox user agent is being used\. Be aware that it doesn't hide your activities\. That is just not possible (environment preset via \fBSNEAKY=true\fR)\.
 .P
-\fB\-\-user\-agent\fR tells testssl.sh to use the supplied HTTP user agent instead of the standard user agent \fBTLS tester from ${URL}\fR\.
-.
+\fB\-\-user\-agent <user agent>\fR tells testssl\.sh to use the supplied HTTP user agent instead of the standard user agent \fBTLS tester from ${URL}\fR\.
 .P
 \fB\-\-ids\-friendly\fR is a switch which may help to get a scan finished which otherwise would be blocked by a server side IDS\. This switch skips tests for the following vulnerabilities: Heartbleed, CCS Injection, Ticketbleed and ROBOT\. The environment variable OFFENSIVE set to false will achieve the same result\. Please be advised that as an alternative or as a general approach you can try to apply evasion techniques by changing the variables USLEEP_SND and / or USLEEP_REC and maybe MAX_WAITSOCK\.
-.
 .P
-\fB\-\-phone\-out\fR Checking for revoked certificates via CRL and OCSP is not done per default\. This switch instructs testssl\.sh to query external \-\- in a sense of the current run \-\- URIs\. By using this switch you acknowledge that the check might have privacy issues, a download of several megabytes (CRL file) may happen and there may be network connectivity problems while contacting the endpoint which testssl\.sh doesn\'t handle\. PHONE_OUT is the environment variable for this which needs to be set to true if you want this\.
-.
+\fB\-\-phone\-out\fR Checking for revoked certificates via CRL and OCSP is not done per default\. This switch instructs testssl\.sh to query external \-\- in a sense of the current run \-\- URIs\. By using this switch you acknowledge that the check might have privacy issues, a download of several megabytes (CRL file) may happen and there may be network connectivity problems while contacting the endpoint which testssl\.sh doesn't handle\. PHONE_OUT is the environment variable for this which needs to be set to true if you want this\.
 .P
 \fB\-\-add\-ca <CAfile>\fR enables you to add your own CA(s) in PEM format for trust chain checks\. \fBCAfile\fR can be a directory containing files with a \.pem extension, a single file or multiple files as a comma separated list of root CAs\. Internally they will be added during runtime to all CA stores\. This is (only) useful for internal hosts whose certificates are issued by internal CAs\. Alternatively ADDTL_CA_FILES is the environment variable for this\.
-.
 .SS "SINGLE CHECK OPTIONS"
 Any single check switch supplied as an argument prevents testssl\.sh from doing a default run\. It just takes this and if supplied other options and runs them \- in the order they would also appear in the default run\.
-.
 .P
-\fB\-e, \-\-each\-cipher\fR checks each of the (currently configured) 370 ciphers via openssl + sockets remotely on the server and reports back the result in wide mode\. If you want to display each cipher tested you need to add \fB\-\-show\-each\fR\. Per default it lists the following parameters: \fBhexcode\fR, \fBOpenSSL cipher suite name\fR, \fBkey exchange\fR, \fBencryption bits\fR, \fBIANA/RFC cipher suite name\fR\. Please note the \fB\-\-mapping\fR parameter changes what cipher suite names you will see here and at which position\. Also please note that the \fBbit\fR length for the encryption is shown and not the \fBsecurity\fR length, albeit it\'ll be sorted by the latter\. For 3DES due to the Meet\-in\-the\-Middle problem the bit size of 168 bits is equivalent to the security size of 112 bits\.
-.
+\fB\-e, \-\-each\-cipher\fR checks each of the (currently configured) 370 ciphers via openssl + sockets remotely on the server and reports back the result in wide mode\. If you want to display each cipher tested you need to add \fB\-\-show\-each\fR\. Per default it lists the following parameters: \fBhexcode\fR, \fBOpenSSL cipher suite name\fR, \fBkey exchange\fR, \fBencryption bits\fR, \fBIANA/RFC cipher suite name\fR\. Please note the \fB\-\-mapping\fR parameter changes what cipher suite names you will see here and at which position\. Also please note that the \fBbit\fR length for the encryption is shown and not the \fBsecurity\fR length, albeit it'll be sorted by the latter\. For 3DES due to the Meet\-in\-the\-Middle problem the bit size of 168 bits is equivalent to the security size of 112 bits\.
 .P
 \fB\-E, \-\-cipher\-per\-proto\fR is similar to \fB\-e, \-\-each\-cipher\fR\. It checks each of the possible ciphers, here: per protocol\. If you want to display each cipher tested you need to add \fB\-\-show\-each\fR\. The output is sorted by security strength, it lists the encryption bits though\.
-.
 .P
 \fB\-s, \-\-std, \-\-categories\fR tests certain lists of cipher suites / cipher categories by strength\. (\fB\-\-standard\fR is deprecated\.) Those lists are (\fBopenssl ciphers $LIST\fR, $LIST from below:)
-.
-.IP "\(bu" 4
-\fBNULL encryption ciphers\fR: \'NULL:eNULL\'
-.
-.IP "\(bu" 4
-\fBAnonymous NULL ciphers\fR: \'aNULL:ADH\'
-.
-.IP "\(bu" 4
-\fBExport ciphers\fR (w/o the preceding ones): \'EXPORT:!ADH:!NULL\'
-.
-.IP "\(bu" 4
-\fBLOW\fR (64 Bit + DES ciphers, without EXPORT ciphers): \'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL\'
-.
-.IP "\(bu" 4
-\fB3DES + IDEA Ciphers\fR: \'3DES:IDEA:!aNULL:!ADH\'
-.
-.IP "\(bu" 4
-\fBAverage grade Ciphers\fR: \'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL\'
-.
-.IP "\(bu" 4
-\fBStrong grade Ciphers\fR (AEAD): \'AESGCM:CHACHA20:CamelliaGCM:AESCCM\'
-.
+.IP "\[ci]" 4
+\fBNULL encryption ciphers\fR: 'NULL:eNULL'
+.IP "\[ci]" 4
+\fBAnonymous NULL ciphers\fR: 'aNULL:ADH'
+.IP "\[ci]" 4
+\fBExport ciphers\fR (w/o the preceding ones): 'EXPORT:!ADH:!NULL'
+.IP "\[ci]" 4
+\fBLOW\fR (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'
+.IP "\[ci]" 4
+\fB3DES + IDEA Ciphers\fR: '3DES:IDEA:!aNULL:!ADH'
+.IP "\[ci]" 4
+\fBAverage grade Ciphers\fR: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'
+.IP "\[ci]" 4
+\fBStrong grade Ciphers\fR (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM8:AESCCM'
 .IP "" 0
-.
 .P
-\fB\-f, \-\-fs, \-\-nsa, \-\-forward\-secrecy\fR Checks robust forward secrecy key exchange\. "Robust" means that ciphers having intrinsic severe weaknesses like Null Authentication or Encryption, 3DES and RC4 won\'t be considered here\. There shouldn\'t be the wrong impression that a secure key exchange has been taking place and everything is fine when in reality the encryption sucks\. Also this section lists the available elliptical curves and Diffie Hellman groups, as well as FFDHE groups (TLS 1\.2 and TLS 1\.3)\.
-.
+\fB\-f, \-\-fs, \-\-nsa, \-\-forward\-secrecy\fR Checks robust forward secrecy key exchange\. "Robust" means that ciphers having intrinsic severe weaknesses like Null Authentication or Encryption, 3DES and RC4 won't be considered here\. There shouldn't be the wrong impression that a secure key exchange has been taking place and everything is fine when in reality the encryption sucks\. Also this section lists the available elliptical curves and Diffie Hellman groups, as well as FFDHE groups (TLS 1\.2 and TLS 1\.3)\.
 .P
 \fB\-p, \-\-protocols\fR checks TLS/SSL protocols SSLv2, SSLv3, TLS 1\.0 through TLS 1\.3 and for HTTP: SPDY (NPN) and ALPN, a\.k\.a\. HTTP/2\. For TLS 1\.3 several drafts (from 18 on) and final are supported and being tested for\.
-.
 .P
-\fB\-P, \-\-preference\fR displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher\. If there\'s a cipher order enforced by the server it displays it for each protocol (openssl+sockets)\. If there\'s not, it displays instead which ciphers from the server were picked with each protocol\.
-.
+\fB\-P, \-\-preference\fR displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher\. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets)\. If there's not, it displays instead which ciphers from the server were picked with each protocol\.
 .P
 \fB\-S, \-\-server_defaults\fR displays information from the server hello(s):
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Available TLS extensions,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 TLS ticket + session ID information/capabilities,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 session resumption capabilities,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Time skew relative to localhost (most server implementations return random values)\.
-.
-.IP "\(bu" 4
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+Several certificate information
+.IP "\[ci]" 4
 signature algorithm,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 key size,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 key usage and extended key usage,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 fingerprints and serial
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Common Name (CN), Subject Alternative Name (SAN), Issuer,
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Trust via hostname + chain of trust against supplied certificates
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 EV certificate detection
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 experimental "eTLS" detection
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 validity: start + end time, how many days to go (warning for certificate lifetime >=5 years)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 revocation info (CRL, OCSP, OCSP stapling + must staple)\. When \fB\-\-phone\-out\fR supplied it checks against the certificate issuer whether the host certificate has been revoked (plain OCSP, CRL)\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 displaying DNS Certification Authority Authorization resource record
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Certificate Transparency info (if provided by server)\.
-.
 .IP "" 0
 
-.
 .IP "" 0
-.
 .P
 For the trust chain check 5 certificate stores are provided\. If the test against one of the trust stores failed, the one is being identified and the reason for the failure is displayed \- in addition the ones which succeeded are displayed too\. You can configure your own CA via ADDTL_CA_FILES, see section \fBFILES\fR below\. If the server provides no matching record in Subject Alternative Name (SAN) but in Common Name (CN), it will be indicated as this is deprecated\. Also for multiple server certificates are being checked for as well as for the certificate reply to a non\-SNI (Server Name Indication) client hello to the IP address\. Regarding the TLS clock skew: it displays the time difference to the client\. Only a few TLS stacks nowadays still support this and return the local clock \fBgmt_unix_time\fR, e\.g\. IIS, openssl < 1\.0\.1f\. In addition to the HTTP date you could e\.g\. derive that there are different hosts where your TLS and your HTTP request ended \-\- if the time deltas differ significantly\.
-.
 .P
 \fB\-x <pattern>, \-\-single\-cipher <pattern>\fR tests matched \fBpattern\fR of ciphers against a server\. Patterns are similar to \fB\-V pattern , \-\-local pattern\fR, see above about matching\.
-.
 .P
 \fB\-h, \-\-header, \-\-headers\fR if the service is HTTP (either by detection or by enforcing via \fB\-\-assume\-http\fR\. It tests several HTTP headers like
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 HTTP Strict Transport Security (HSTS)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 HTTP Public Key Pinning (HPKP)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Server banner
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 HTTP date+time
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Server banner like Linux or other Unix vendor headers
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Application banner (PHP, RoR, OWA, SharePoint, Wordpress, etc)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Reverse proxy headers
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Web server modules
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 IPv4 address in header
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Cookie (including Secure/HTTPOnly flags)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Decodes BIG IP F5 non\-encrypted cookies
-.
-.IP "\(bu" 4
-Security headers (X\-Frame\-Options, X\-XSS\-Protection, Expect\-CT,\.\.\. , CSP headers)\. Nonsense is not yet detected here\.
-.
+.IP "\[ci]" 4
+Security headers (X\-Frame\-Options, X\-XSS\-Protection, Expect\-CT,\|\.\|\.\|\. , CSP headers)\. Nonsense is not yet detected here\.
 .IP "" 0
-.
 .P
-\fB\-c, \-\-client\-simulation\fR This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site\. For the latter case the protocol, cipher and curve is displayed, also if there\'s Forward Secrecy\. testssl\.sh uses a handselected set of clients which are retrieved by the SSLlabs API\. The output is aligned in columns when combined with the \fB\-\-wide\fR option\. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS\.
-.
+\fB\-c, \-\-client\-simulation\fR This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site\. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy\. testssl\.sh uses a handselected set of clients which are retrieved by the SSLlabs API\. The output is aligned in columns when combined with the \fB\-\-wide\fR option\. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS\.
 .P
-\fB\-g, \-\-grease\fR checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701\. This check doesn\'t run per default\.
-.
+\fB\-g, \-\-grease\fR checks several server implementation bugs like tolerance to size limitations and GREASE, see RFC 8701\. This check doesn't run per default\.
 .SS "VULNERABILITIES"
 \fB\-U, \-\-vulnerable, \-\-vulnerabilities\fR Just tests all (of the following) vulnerabilities\. The environment variable \fBVULN_THRESHLD\fR determines after which value a separate headline for each vulnerability is being displayed\. Default is \fB1\fR which means if you check for two vulnerabilities, only the general headline for vulnerabilities section is displayed \-\- in addition to the vulnerability and the result\. Otherwise each vulnerability or vulnerability section gets its own headline in addition to the output of the name of the vulnerability and test result\. A vulnerability section is comprised of more than one check, e\.g\. the renegotiation vulnerability check has two checks, so has Logjam\.
-.
 .P
-\fB\-H, \-\-heartbleed\fR Checks for Heartbleed, a memory leakage in openssl\. Unless the server side doesn\'t support the heartbeat extension it is likely that this check runs into a timeout\. The seconds to wait for a reply can be adjusted with \fBHEARTBLEED_MAX_WAITSOCK\fR\. 8 is the default\.
-.
+\fB\-H, \-\-heartbleed\fR Checks for Heartbleed, a memory leakage in openssl\. Unless the server side doesn't support the heartbeat extension it is likely that this check runs into a timeout\. The seconds to wait for a reply can be adjusted with \fBHEARTBLEED_MAX_WAITSOCK\fR\. 8 is the default\.
 .P
 \fB\-I, \-\-ccs, \-\-ccs\-injection\fR Checks for CCS Injection which is an openssl vulnerability\. Sometimes also here the check needs to wait for a reply\. The predefined timeout of 5 seconds can be changed with the environment variable \fBCCS_MAX_WAITSOCK\fR\.
-.
 .P
 \fB\-T, \-\-ticketbleed\fR Checks for Ticketbleed memory leakage in BigIP loadbalancers\.
-.
 .P
-\fB\-\-BB, \-\-robot\fR Checks for vulnerability to ROBOT / (\fIReturn Of Bleichenbacher\'s Oracle Threat\fR) attack\.
-.
+\fB\-\-BB, \-\-robot\fR Checks for vulnerability to ROBOT / (\fIReturn Of Bleichenbacher's Oracle Threat\fR) attack\.
 .P
-\fB\-\-SI, \-\-starttls\-injection\fR Checks for STARTTLS injection vulnerabilities (SMTP, IMAP, POP3 only)\. \fIsocat\fR and OpenSSL >=1.1.0 is needed\.
-.
+\fB\-\-SI, \-\-starttls\-injection\fR Checks for STARTTLS injection vulnerabilities (SMTP, IMAP, POP3 only)\. \fBsocat\fR and OpenSSL >=1\.1\.0 is needed\.
 .P
-\fB\-R, \-\-renegotiation\fR Tests renegotiation vulnerabilities\. Currently there\'s a check for \fISecure Renegotiation\fR and for \fISecure Client\-Initiated Renegotiation\fR\. Please be aware that vulnerable servers to the latter can likely be DoSed very easily (HTTP)\. A check for \fIInsecure Client\-Initiated Renegotiation\fR is not yet implemented\.
-.
+\fB\-R, \-\-renegotiation\fR Tests renegotiation vulnerabilities\. Currently there's a check for \fISecure Renegotiation\fR and for \fISecure Client\-Initiated Renegotiation\fR\. Please be aware that vulnerable servers to the latter can likely be DoSed very easily (HTTP)\. A check for \fIInsecure Client\-Initiated Renegotiation\fR is not yet implemented\.
 .P
 \fB\-C, \-\-compression, \-\-crime\fR Checks for CRIME (\fICompression Ratio Info\-leak Made Easy\fR) vulnerability in TLS\. CRIME in SPDY is not yet being checked for\.
-.
 .P
-\fB\-B, \-\-breach\fR Checks for BREACH (\fIBrowser Reconnaissance and Exfiltration via Adaptive Compression of Hypertext\fR) vulnerability\. As for this vulnerability HTTP level compression is a prerequisite it\'ll be not tested if HTTP cannot be detected or the detection is not enforced via \fB`\-\-assume\-http\fR\. Please note that only the URL supplied (normally "/" ) is being tested\.
-.
+\fB\-B, \-\-breach\fR Checks for BREACH (\fIBrowser Reconnaissance and Exfiltration via Adaptive Compression of Hypertext\fR) vulnerability\. As for this vulnerability HTTP level compression is a prerequisite it'll be not tested if HTTP cannot be detected or the detection is not enforced via ``\-\-assume\-http`\. Please note that only the URL supplied (normally "/" ) is being tested\.
 .P
 \fB\-O, \-\-poodle\fR Tests for SSL POODLE (\fIPadding Oracle On Downgraded Legacy Encryption\fR) vulnerability\. It basically checks for the existence of CBC ciphers in SSLv3\.
-.
 .P
 \fB\-Z, \-\-tls\-fallback\fR Checks TLS_FALLBACK_SCSV mitigation\. TLS_FALLBACK_SCSV is basically a ciphersuite appended to the Client Hello trying to prevent protocol downgrade attacks by a Man in the Middle\.
-.
 .P
 \fB\-W, \-\-sweet32\fR Checks for vulnerability to SWEET32 by testing 64 bit block ciphers (3DES, RC2 and IDEA)\.
-.
 .P
 \fB\-F, \-\-freak\fR Checks for FREAK vulnerability (\fIFactoring RSA Export Keys\fR) by testing for EXPORT RSA ciphers
-.
 .P
-\fB\-D, \-\-drown\fR Checks for DROWN vulnerability (\fIDecrypting RSA with Obsolete and Weakened eNcryption\fR) by checking whether the SSL 2 protocol is available at the target\. Please note that if you use the same RSA certificate elsewhere you might be vulnerable too\. testssl\.sh doesn\'t check for this but provides a helpful link @ censys\.io which provides this service\.
-.
+\fB\-D, \-\-drown\fR Checks for DROWN vulnerability (\fIDecrypting RSA with Obsolete and Weakened eNcryption\fR) by checking whether the SSL 2 protocol is available at the target\. Please note that if you use the same RSA certificate elsewhere you might be vulnerable too\. testssl\.sh doesn't check for this but provides a helpful link @ censys\.io which provides this service\.
 .P
 \fB\-J, \-\-logjam\fR Checks for LOGJAM vulnerability by checking for DH EXPORT ciphers\. It also checks for "common primes" which are preconfigured DH keys\. DH keys =< 1024 Bit will be penalized\. Also FFDHE groups (TLS 1\.2) will be displayed here\.
-.
 .P
 \fB\-A, \-\-beast\fR Checks BEAST vulnerabilities in SSL 3 and TLS 1\.0 by testing the usage of CBC ciphers\.
-.
 .P
 \fB\-L, \-\-lucky13\fR Checks for LUCKY13 vulnerability\. It checks for the presence of CBC ciphers in TLS versions 1\.0 \- 1\.2\.
-.
 .P
 \fB\-WS, \-\-winshock\fR Checks for Winshock vulnerability\. It tests for the absence of a lot of ciphers, some TLS extensions and ec curves which were introduced later in Windows\. In the end the server banner is being looked at\.
-.
 .P
 \fB\-4, \-\-rc4, \-\-appelbaum\fR Checks which RC4 stream ciphers are being offered\.
-.
 .SS "OUTPUT OPTIONS"
 \fB\-q, \-\-quiet\fR Normally testssl\.sh displays a banner on stdout with several version information, usage rights and a warning\. This option suppresses it\. Please note that by choosing this option you acknowledge usage terms and the warning normally appearing in the banner\.
-.
 .P
 \fB\-\-wide\fR Except the "each cipher output" all tests displays the single cipher name (scheme see below)\. This option enables testssl\.sh to display also for the following sections the same output as for testing each ciphers: BEAST, FS, RC4\. The client simulation has also a wide mode\. The difference here is restricted to a column aligned output and a proper headline\. The environment variable \fBWIDE\fR can be used instead\.
-.
 .P
 \fB\-\-mapping <openssl|iana|no\-openssl|no\-iana>\fR
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fBopenssl\fR: use the OpenSSL cipher suite name as the primary name cipher suite name form (default),
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 \fBiana\fR: use the IANA cipher suite name as the primary name cipher suite name form\.
-.
-.IP "\(bu" 4
-\fBno\-openssl\fR: don\'t display the OpenSSL cipher suite name, display IANA names only\.
-.
-.IP "\(bu" 4
-\fBno\-iana\fR: don\'t display the IANA cipher suite name, display OpenSSL names only\.
-.
+.IP "\[ci]" 4
+\fBno\-openssl\fR: don't display the OpenSSL cipher suite name, display IANA names only\.
+.IP "\[ci]" 4
+\fBno\-iana\fR: don't display the IANA cipher suite name, display OpenSSL names only\.
 .IP "" 0
-.
 .P
-Please note that in testssl\.sh 3\.0 you can still use \fBrfc\fR instead of \fBiana\fR and \fBno\-rfc\fR instead of \fBno\-iana\fR but it\'ll disappear after 3\.0\.
-.
+Please note that in testssl\.sh 3\.0 you can still use \fBrfc\fR instead of \fBiana\fR and \fBno\-rfc\fR instead of \fBno\-iana\fR but it'll disappear after 3\.0\.
 .P
 \fB\-\-show\-each\fR This is an option for all wide modes only: it displays all ciphers tested \-\- not only succeeded ones\. \fBSHOW_EACH_C\fR is your friend if you prefer to set this via the shell environment\.
-.
 .P
 \fB\-\-color <0|1|2|3>\fR determines the use of colors on the screen and in the log file: \fB2\fR is the default and makes use of ANSI and termcap escape codes on your terminal\. \fB1\fR just uses non\-colored mark\-up like bold, italics, underline, reverse\. \fB0\fR means no mark\-up at all = no escape codes\. This is also what you want when you want a log file without any escape codes\. \fB3\fR will color ciphers and EC according to an internal (not yet perfect) rating\. Setting the environment variable \fBCOLOR\fR to the value achieves the same result\. Please not that OpenBSD and early FreeBSD do not support italics\.
-.
 .P
 \fB\-\-colorblind\fR Swaps green and blue colors in the output, so that this percentage of folks (up to 8% of males, see https://en\.wikipedia\.org/wiki/Color_blindness) can distinguish those findings better\. \fBCOLORBLIND\fR is the according variable if you want to set this in the environment\.
-.
 .P
 \fB\-\-debug <0\-6>\fR This gives you additional output on the screen (2\-6), only useful for debugging\. \fBDEBUG\fR is the according environment variable which you can use\. There are six levels (0 is the default, thus it has no effect):
-.
 .IP "1." 4
 screen output normal but leaves useful debug output in \fB/tmp/testssl\.XXXXXX/\fR \. The info about the exact directory is included in the screen output in the end of the run\.
-.
 .IP "2." 4
-lists more what\'s going on, status (high level) and connection errors, a few general debug output
-.
+lists more what's going on, status (high level) and connection errors, a few general debug output
 .IP "3." 4
 even slightly more info: hexdumps + other info
-.
 .IP "4." 4
 display bytes sent via sockets
-.
 .IP "5." 4
 display bytes received via sockets
-.
 .IP "6." 4
 whole 9 yards
-.
 .IP "" 0
-.
 .P
 \fB\-\-disable\-rating\fR disables rating\. Rating automatically gets disabled, to not give a wrong or misleading grade, when not all required functions are executed (e\.g when checking for a single vulnerabilities)\.
-.
 .SS "FILE OUTPUT OPTIONS"
 \fB\-\-log, \-\-logging\fR Logs stdout also to \fB${NODE}\-p${port}${YYYYMMDD\-HHMM}\.log\fR in current working directory of the shell\. Depending on the color output option (see above) the output file will contain color and other markup escape codes, unless you specify \fB\-\-color 0\fR too\. \fBcat\fR and \-\- if properly configured \fBless\fR \-\- will show the output properly formatted on your terminal\. The output shows a banner with the almost the same information as on the screen\. In addition it shows the command line of the testssl\.sh instance\. Please note that the resulting log file is formatted according to the width of your screen while running testssl\.sh\. You can override the width with the environment variable TERM_WIDTH\.
-.
 .P
 \fB\-\-logfile <logfile>\fR or \fB\-oL <logfile>\fR Instead of the previous option you may want to use this one if you want to log into a directory or if you rather want to specify the log file name yourself\. If \fBlogfile\fR is a directory the output will put into \fBlogfile/${NODE}\-p${port}${YYYYMMDD\-HHMM}\.log\fR\. If \fBlogfile\fR is a file it will use that file name, an absolute path is also permitted here\. LOGFILE is the variable you need to set if you prefer to work environment variables instead\. Please note that the resulting log file is formatted according to the width of your screen while running testssl\.sh\. You can override the width with the environment variable TERM_WIDTH\.
-.
 .P
-\fB\-\-json\fR Logs additionally to JSON file \fB${NODE}\-p${port}${YYYYMMDD\-HHMM}\.json\fR in the current working directory of the shell\. The resulting JSON file is opposed to \fB\-\-json\-pretty\fR flat \-\- which means each section is self contained and has an identifier for each single check, the hostname/IP address, the port, severity and the finding\. For vulnerabilities it may contain a CVE and CWE entry too\. The output doesn\'t contain a banner or a footer\.
-.
+\fB\-\-json\fR Logs additionally to JSON file \fB${NODE}\-p${port}${YYYYMMDD\-HHMM}\.json\fR in the current working directory of the shell\. The resulting JSON file is opposed to \fB\-\-json\-pretty\fR flat \-\- which means each section is self contained and has an identifier for each single check, the hostname/IP address, the port, severity and the finding\. For vulnerabilities it may contain a CVE and CWE entry too\. The output doesn't contain a banner or a footer\.
 .P
 \fB\-\-jsonfile <jsonfile>\fR or \fB\-oj <jsonfile>\fR Instead of the previous option you may want to use this one if you want to log the JSON out put into a directory or if you rather want to specify the log file name yourself\. If \fBjsonfile\fR is a directory the output will put into \fBlogfile/${NODE}\-p${port}${YYYYMMDD\-HHMM}\.json\. If\fRjsonfile` is a file it will use that file name, an absolute path is also permitted here\.
-.
 .P
 \fB\-\-json\-pretty\fR Logs additionally to JSON file \fB${NODE}\-p${port}${YYYYMMDD\-HHMM}\.json in the current working directory of the shell\. The resulting JSON file is opposed to\fR\-\-json` non\-flat \-\- which means it is structured\. The structure contains a header similar to the banner on the screen, including the command line, scan host, openssl binary used, testssl version and epoch of the start time\. Then for every test section of testssl\.sh it contains a separate JSON object/section\. Each finding has a key/value pair identifier with the identifier for each single check, the severity and the finding\. For vulnerabilities it may contain a CVE and CWE entry too\. The footer lists the scan time in seconds\.
-.
 .P
 \fB\-\-jsonfile\-pretty <jsonfile>\fR or \fB\-oJ <jsonfile>\fR Similar to the aforementioned \fB\-\-jsonfile\fR or \fB\-\-logfile\fR it logs the output in pretty JSON format (see \fB\-\-json\-pretty\fR) into a file or a directory\. For further explanation see \fB\-\-jsonfile\fR or \fB\-\-logfile\fR\.
-.
 .P
 \fB\-\-csv\fR Logs additionally to a CSV file \fB${NODE}\-p${port}${YYYYMMDD\-HHMM}\.csv\fR in the current working directory of the shell\. The output contains a header with the keys, the values are the same as in the flat JSON format (identifier for each single check, the hostname/IP address, the port, severity, the finding and for vulnerabilities a CVE and CWE number)\.
-.
 .P
 \fB\-\-csvfile <csvfile>\fR or \fB\-oC <csvfile>\fR Similar to the aforementioned \fB\-\-jsonfile\fR or \fB\-\-logfile\fR it logs the output in CSV format (see \fB\-\-cvs\fR) additionally into a file or a directory\. For further explanation see \fB\-\-jsonfile\fR or \fB\-\-logfile\fR\.
-.
 .P
 \fB\-\-html\fR Logs additionally to an HTML file \fB${NODE}\-p${port}${YYYYMMDD\-HHMM}\.html\fR in the current working directory of the shell\. It contains a 1:1 output of the console\. In former versions there was a non\-native option to use "aha" (Ansi HTML Adapter: github\.com/theZiz/aha) like \fBtestssl\.sh [options] <URI> | aha >output\.html\fR\. This is not necessary anymore\.
-.
 .P
 \fB\-\-htmlfile <htmlfile>\fR or \fB\-oH <htmlfile>\fR Similar to the aforementioned \fB\-\-jsonfile\fR or \fB\-\-logfile\fR it logs the output in HTML format (see \fB\-\-html\fR) additionally into a file or a directory\. For further explanation see \fB\-\-jsonfile\fR or \fB\-\-logfile\fR\.
-.
 .P
-\fB\-oA <filename>\fR / \fB\-\-outFile <filename>\fR Similar to nmap it does a file output to all available file formats: LOG, JSON pretty, CSV, HTML\. If the filename supplied is equal \fBauto\fR the filename is automatically generated using \'${NODE}\-p${port}${YYYYMMDD\-HHMM}\.${EXT}\' with the according extension\. If a directory is provided all output files will put into \fB<filename>/${NODE}\-p${port}${YYYYMMDD\-HHMM}\.{log,json,csv,html}\fR\.
-.
+\fB\-oA <filename>\fR / \fB\-\-outFile <filename>\fR Similar to nmap it does a file output to all available file formats: LOG, JSON pretty, CSV, HTML\. If the filename supplied is equal \fBauto\fR the filename is automatically generated using '${NODE}\-p${port}${YYYYMMDD\-HHMM}\.${EXT}' with the according extension\. If a directory is provided all output files will put into \fB<filename>/${NODE}\-p${port}${YYYYMMDD\-HHMM}\.{log,json,csv,html}\fR\.
 .P
 \fB\-oa <filename>\fR / \fB\-\-outfile <filename>\fR Does the same as the previous option but uses flat JSON instead\.
-.
 .P
 \fB\-\-hints\fR This option is not in use yet\. This option is meant to give hints how to fix a finding or at least a help to improve something\. GIVE_HINTS is the environment variable for this\.
-.
 .P
 \fB\-\-severity <severity>\fR For CSV and both JSON outputs this will only add findings to the output file if a severity is equal or higher than the \fBseverity\fR value specified\. Allowed are \fB<LOW|MEDIUM|HIGH|CRITICAL>\fR\. WARN is another level which translates to a client\-side scanning error or problem\. Thus you will always see them in a file if they occur\.
-.
 .P
-\fB\-\-append\fR Normally, if an output file already exists and it has a file size greater zero, testssl\.sh will prompt you to manually remove the file and then exit with an error\. \fB\-\-append\fR however will append to this file, without a header\. The environment variable APPEND does the same\. Be careful using this switch/variable\.
-.
+\fB\-\-append\fR Normally, if an output file already exists and it has a file size greater zero, testssl\.sh will prompt you to manually remove the file and exit with an error\. \fB\-\-append\fR however will append to this file, without a header\. The environment variable APPEND does the same\. Be careful using this switch/variable\. A complementary option which overwrites an existing file doesn't exist per design\.
 .P
 \fB\-\-overwrite\fR Normally, if an output file already exists and it has a file size greater zero, testssl\.sh will not allow you to overwrite this file\. This option will do that \fBwithout any warning\fR\. The environment variable OVERWRITE does the same\. Be careful, you have been warned!
-.
 .P
-\fB\-\-outprefix <fname_prefix>\fR Prepend output filename prefix \fIfname_prefix\fR before \'${NODE}\-\'\. You can use as well the environment variable FNAME_PREFIX\. Using this any output files will be named \fB<fname_prefix>\-${NODE}\-p${port}${YYYYMMDD\-HHMM}\.<format>\fR when no file name of the respective output option was specified\. If you do not like the separator \'\-\' you can as well supply a \fB<fname_prefix>\fR ending in \'\.\', \'_\' or \',\'\. In this case or if you already supplied \'\-\' no additional \'\-\' will be appended to \fB<fname_prefix>\fR\.
-.
+\fB\-\-outprefix <fname_prefix>\fR Prepend output filename prefix \fIfname_prefix\fR before '${NODE}\-'\. You can use as well the environment variable FNAME_PREFIX\. Using this any output files will be named \fB<fname_prefix>\-${NODE}\-p${port}${YYYYMMDD\-HHMM}\.<format>\fR when no file name of the respective output option was specified\. If you do not like the separator '\-' you can as well supply a \fB<fname_prefix>\fR ending in '\.', '_' or ','\. In this case or if you already supplied '\-' no additional '\-' will be appended to \fB<fname_prefix>\fR\.
 .P
 A few file output options can also be preset via environment variables\.
-.
 .SS "COLOR RATINGS"
 Testssl\.sh makes use of (the eight) standard terminal colors\. The color scheme is as follows:
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 light red: a critical finding
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 red: a high finding
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 brown: a medium finding
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 yellow: a low finding
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 green (blue if COLORBLIND is set): something which is either in general a good thing or a negative result of a check which otherwise results in a high finding
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 light green (light blue if COLORBLIND is set) : something which is either in general a very good thing or a negative result of a check which otherwise results in a critical finding
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 no color at places where also a finding can be expected: a finding on an info level
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 cyan: currently only used for \fB\-\-show\-each\fR or an additional hint
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 magenta: signals a warning condition, e\.g\. either a local lack of capabilities on the client side or another problem
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 light magenta: a fatal error which either requires strict consent from the user to continue or a condition which leaves no other choice for testssl\.sh to quit
-.
 .IP "" 0
-.
 .P
 What is labeled as "light" above appears as such on the screen but is technically speaking "bold"\. Besides \fB\-\-color=3\fR will color ciphers according to an internal and rough rating\.
-.
 .P
 Markup (without any color) is used in the following manner:
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 bold: for the name of the test
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 underline + bold: for the headline of each test section
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 underline: for a sub\-headline
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 italics: for strings just reflecting a value read from the server
-.
 .IP "" 0
-.
 .SS "TUNING via ENV variables and more options"
 Except the environment variables mentioned above which can replace command line options here a some which cannot be set otherwise\. Variables used for tuning are preset with reasonable values\. \fIThere should be no reason to change them\fR unless you use testssl\.sh under special conditions\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 TERM_WIDTH is a variable which overrides the auto\-determined terminal width size\. Setting this variable normally only makes sense if you log the output to a file using the \fB\-\-log\fR, \fB\-\-logfile\fR or \fB\-oL\fR option\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 DEBUG_ALLINONE / SETX: when setting one of those to true testssl\.sh falls back to the standard bash behavior, i\.e\. calling \fBbash \-x testssl\.sh\fR it displays the bash debugging output not in an external file \fB/tmp/testssl\-<XX>\.log\fR
-.
-.IP "\(bu" 4
-DEBUGTIME: Profiling option\. When using bash\'s debug mode and when this is set to true, it generates a separate text file with epoch times in \fB/tmp/testssl\-<XX>\.time\fR\. They need to be concatenated by \fBpaste /tmp/testssl\-<XX>\.{time,log}\fR
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+DEBUGTIME: Profiling option\. When using bash's debug mode and when this is set to true, it generates a separate text file with epoch times in \fB/tmp/testssl\-<XX>\.time\fR\. They need to be concatenated by \fBpaste /tmp/testssl\-<XX>\.{time,log}\fR [comment]: # * FAST_SOCKET [comment]: # * SHOW_SIGALGO [comment]: # * FAST
+.IP "\[ci]" 4
 EXPERIMENTAL=true is an option which is sometimes used in the development process to make testing easier\. In released versions this has no effect\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 ALL_CLIENTS=true runs a client simulation with \fIall\fR (currently 126) clients when testing HTTP\.
-.
-.IP "\(bu" 4
-UNBRACKTD_IPV6: needs to be set to true for some old versions of OpenSSL (like from Gentoo) which don\'t support [bracketed] IPv6 addresses
-.
-.IP "\(bu" 4
-NO_ENGINE: if you have problems with garbled output containing the word \'engine\' you might want to set this to true\. It forces testssl\.sh not try to configure openssl\'s engine or a non existing one from libressl
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+UNBRACKTD_IPV6: needs to be set to true for some old versions of OpenSSL (like from Gentoo) which don't support [bracketed] IPv6 addresses
+.IP "\[ci]" 4
+NO_ENGINE: if you have problems with garbled output containing the word 'engine' you might want to set this to true\. It forces testssl\.sh not try to configure openssl's engine or a non existing one from libressl
+.IP "\[ci]" 4
 HEADER_MAXSLEEP: To wait how long before killing the process to retrieve a service banner / HTTP header
-.
-.IP "\(bu" 4
-MAX_WAITSOCK: It instructs testssl\.sh to wait until the specified time before declaring a socket connection dead\. Don\'t change this unless you\'re absolutely sure what you\'re doing\. Value is in seconds\.
-.
-.IP "\(bu" 4
-CCS_MAX_WAITSOCK Is the similar to above but applies only to the CCS handshakes, for both of the two the two CCS payload\. Don\'t change this unless you\'re absolutely sure what you\'re doing\. Value is in seconds\.
-.
-.IP "\(bu" 4
-HEARTBLEED_MAX_WAITSOCK Is the similar to MAX_WAITSOCK but applies only to the ServerHello after sending the Heartbleed payload\. Don\'t change this unless you\'re absolutely sure what you\'re doing\. Value is in seconds\.
-.
-.IP "\(bu" 4
-MEASURE_TIME_FILE For seldom cases when you don\'t want the scan time to be included in the output you can set this to false\.
-.
-.IP "\(bu" 4
-STARTTLS_SLEEP is per default set to 10 (seconds)\. That\'s the value testssl\.sh waits for a string in the STARTTLS handshake before giving up\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+MAX_WAITSOCK: It instructs testssl\.sh to wait until the specified time before declaring a socket connection dead\. Don't change this unless you're absolutely sure what you're doing\. Value is in seconds\.
+.IP "\[ci]" 4
+CCS_MAX_WAITSOCK Is the similar to above but applies only to the CCS handshakes, for both of the two the two CCS payload\. Don't change this unless you're absolutely sure what you're doing\. Value is in seconds\.
+.IP "\[ci]" 4
+HEARTBLEED_MAX_WAITSOCK Is the similar to MAX_WAITSOCK but applies only to the ServerHello after sending the Heartbleed payload\. Don't change this unless you're absolutely sure what you're doing\. Value is in seconds\.
+.IP "\[ci]" 4
+MEASURE_TIME_FILE For seldom cases when you don't want the scan time to be included in the output you can set this to false\.
+.IP "\[ci]" 4
+STARTTLS_SLEEP is per default set to 10 (seconds)\. That's the value testssl\.sh waits for a string in the STARTTLS handshake before giving up\.
+.IP "\[ci]" 4
 MAX_PARALLEL is the maximum number of tests to run in parallel in parallel mass testing mode\. The default value of 20 may be made larger on systems with faster processors\.
-.
-.IP "\(bu" 4
-MAX_WAIT_TEST is the maximum time (in seconds) to wait for a single test in parallel mass testing mode to complete\. The default is 1200\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+MAX_WAIT_TEST is the maximum time (in seconds) to wait for a single test in parallel mass testing mode to complete\. The default is 1200\. [comment]: # USLEEP_SND [comment]: # USLEEP_REC
+.IP "\[ci]" 4
 HSTS_MIN is preset to 179 (days)\. If you want warnings sooner or later for HTTP Strict Transport Security you can change this\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 HPKP_MIN is preset to 30 (days)\. If you want warnings sooner or later for HTTP Public Key Pinning you can change this
-.
-.IP "\(bu" 4
-DAYS2WARN1 is the first threshold when you\'ll be warning of a certificate expiration of a host, preset to 60 (days)\. For Let\'s Encrypt this value will be divided internally by 2\.
-.
-.IP "\(bu" 4
-DAYS2WARN2 is the second threshold when you\'ll be warning of a certificate expiration of a host, preset to 30 (days)\. For Let\'s Encrypt this value will be divided internally by 2\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+DAYS2WARN1 is the first threshold when you'll be warning of a certificate expiration of a host, preset to 60 (days)\. For Let's Encrypt this value will be divided internally by 2\.
+.IP "\[ci]" 4
+DAYS2WARN2 is the second threshold when you'll be warning of a certificate expiration of a host, preset to 30 (days)\. For Let's Encrypt this value will be divided internally by 2\.
+.IP "\[ci]" 4
 TESTSSL_INSTALL_DIR is the derived installation directory of testssl\.sh\. Relatively to that the \fBbin\fR and mandatory \fBetc\fR directory will be looked for\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 CA_BUNDLES_PATH: If you have an own set of CA bundles or you want to point testssl\.sh to a specific location of a CA bundle, you can use this variable to set the directory which testssl\.sh will use\. Please note that it overrides completely the builtin path of testssl\.sh which means that you will only test against the bundles you point to\. Also you might want to use \fB~/utils/create_ca_hashes\.sh\fR to create the hashes for HPKP\.
-.
-.IP "\(bu" 4
-MAX_SOCKET_FAIL: A number which tells testssl\.sh how often a TCP socket connection may fail before the program gives up and terminates\. The default is 2\. You can increase it to a higher value if you frequently see a message like \fIFatal error: repeated openssl s_client connect problem, doesn\'t make sense to continue\fR\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+MAX_SOCKET_FAIL: A number which tells testssl\.sh how often a TCP socket connection may fail before the program gives up and terminates\. The default is 2\. You can increase it to a higher value if you frequently see a message like \fIFatal error: repeated openssl s_client connect problem, doesn't make sense to continue\fR\.
+.IP "\[ci]" 4
 MAX_OSSL_FAIL: A number which tells testssl\.sh how often an OpenSSL s_client connect may fail before the program gives up and terminates\. The default is 2\. You can increase it to a higher value if you frequently see a message like \fIFatal error: repeated TCP connect problems, giving up\fR\.
-.
-.IP "\(bu" 4
-MAX_HEADER_FAIL: A number which tells testssl\.sh how often a HTTP GET request over OpenSSL may return an empty file before the program gives up and terminates\. The default is 3\. Also here you can increase the threshold when you spot messages like \fIFatal error: repeated HTTP header connect problems, doesn\'t make sense to continue\fR\.
-.
+.IP "\[ci]" 4
+MAX_HEADER_FAIL: A number which tells testssl\.sh how often a HTTP GET request over OpenSSL may return an empty file before the program gives up and terminates\. The default is 3\. Also here you can increase the threshold when you spot messages like \fIFatal error: repeated HTTP header connect problems, doesn't make sense to continue\fR\.
 .IP "" 0
-.
 .SS "RATING"
-This program has a near\-complete implementation of SSL Labs\'s \'SSL Server Rating Guide \fIhttps://github\.com/ssllabs/research/wiki/SSL\-Server\-Rating\-Guide\fR\'\.
-.
+This program has a near\-complete implementation of SSL Labs's 'SSL Server Rating Guide \fIhttps://github\.com/ssllabs/research/wiki/SSL\-Server\-Rating\-Guide\fR'\.
 .P
-This is \fInot\fR a 100% reimplementation of the SSL Lab\'s SSL Server Test \fIhttps://www\.ssllabs\.com/ssltest/analyze\.html\fR, but an implementation of the above rating specification, slight discrepancies may occur\. Please note that for now we stick to the SSL Labs rating as good as possible\. We are not responsible for their rating\. Before filing issues please inspect their Rating Guide\.
-.
+This is \fInot\fR a 100% reimplementation of the SSL Lab's SSL Server Test \fIhttps://www\.ssllabs\.com/ssltest/analyze\.html\fR, but an implementation of the above rating specification, slight discrepancies may occur\. Please note that for now we stick to the SSL Labs rating as good as possible\. We are not responsible for their rating\. Before filing issues please inspect their Rating Guide\.
 .P
-Disclaimer: Having a good grade is \fBNOT\fR necessarily equal to having good security! Don\'t start a competition for the best grade, at least not without monitoring the client handshakes and not without adding a portion of good sense to it\. Please note STARTTLS always results in a grade cap to T\. Anything else would lead to a false sense of security \- at least until we test for DANE or MTA-STS\.
-.
+Disclaimer: Having a good grade is \fBNOT\fR necessarily equal to having good security! Don't start a competition for the best grade, at least not without monitoring the client handshakes and not without adding a portion of good sense to it\. Please note STARTTLS always results in a grade cap to T\. Anything else would lead to a false sense of security \- at least until we test for DANE or MTA\-STS\.
 .P
-As of writing, these checks are missing: * GOLDENDOODLE \- should be graded \fBF\fR if vulnerable * Insecure renegotiation \- should be graded \fBF\fR if vulnerable * Padding oracle in AES\-NI CBC MAC check (CVE\-2016\-2107) \- should be graded \fBF\fR if vulnerable * Sleeping POODLE \- should be graded \fBF\fR if vulnerable * Zero Length Padding Oracle (CVE\-2019\-1559) \- should be graded \fBF\fR if vulnerable * Zombie POODLE \- should be graded \fBF\fR if vulnerable * All remaining old Symantec PKI certificates are distrusted \- should be graded \fBT\fR * Symantec certificates issued before June 2016 are distrusted \- should be graded \fBT\fR * ! A reading of DH params \- should give correct points in \fBset_key_str_score()\fR * Anonymous key exchange \- should give \fB0\fR points in \fBset_key_str_score()\fR * Exportable key exchange \- should give \fB40\fR points in \fBset_key_str_score()\fR * Weak key (Debian OpenSSL Flaw) \- should give \fB0\fR points in \fBset_key_str_score()\fR
-.
+As of writing, these checks are missing: * GOLDENDOODLE \- should be graded \fBF\fR if vulnerable * Insecure renegotiation \- should be graded \fBF\fR if vulnerable * Padding oracle in AES\-NI CBC MAC check (CVE\-2016\-2107) \- should be graded \fBF\fR if vulnerable * Sleeping POODLE \- should be graded \fBF\fR if vulnerable * Zero Length Padding Oracle (CVE\-2019\-1559) \- should be graded \fBF\fR if vulnerable * Zombie POODLE \- should be graded \fBF\fR if vulnerable * All remaining old Symantec PKI certificates are distrusted \- should be graded \fBT\fR * Symantec certificates issued before June 2016 are distrusted \- should be graded \fBT\fR * Anonymous key exchange \- should give \fB0\fR points in \fBset_key_str_score()\fR * Exportable key exchange \- should give \fB40\fR points in \fBset_key_str_score()\fR * Weak key (Debian OpenSSL Flaw) \- should give \fB0\fR points in \fBset_key_str_score()\fR
 .P
-To implement a new grading cap, simply call the \fBset_grade_cap()\fR function, with the grade and a reason: \fBbash set_grade_cap "D" "Vulnerable to documentation"\fR To implement a new grade warning, simply call the \fBset_grade_warning()\fR function, with a message: \fBbash set_grade_warning "Documentation is always right"\fR
-.
-.P
-When implementing a new check (be it vulnerability or not) that sets grade caps, the \fBset_rating_state()\fR has to be updated (i\.e\. the \fB$do_mycheck\fR variable\-name has to be added to the loop, and \fB$nr_enabled\fR if\-statement has to be incremented)
-.
+To implement a new grading cap, simply call the \fBset_grade_cap()\fR function, with the grade and a reason: \fBbash set_grade_cap "D" "Vulnerable to documentation"\fR To implement a new grade warning, simply call the \fBset_grade_warning()\fR function, with a message: \fBbash set_grade_warning "Documentation is always right"\fR #### Implementing a new check which contains grade caps When implementing a new check (be it vulnerability or not) that sets grade caps, the \fBset_rating_state()\fR has to be updated (i\.e\. the \fB$do_mycheck\fR variable\-name has to be added to the loop, and \fB$nr_enabled\fR if\-statement has to be incremented)
 .P
 The \fBset_rating_state()\fR automatically disables rating, if all the required checks are \fInot\fR enabled\. This is to prevent giving out a misleading or wrong grade\.
-.
 .P
 When a new revision of the rating specification comes around, the following has to be done: * New grade caps has to be either: 1\. Added to the script wherever relevant, or 2\. Added to the above list of missing checks (if above is not possible) * New grade warnings has to be added wherever relevant * The revision output in \fBrun_rating()\fR function has to updated
-.
 .SH "EXAMPLES"
-.
 .nf
-
   testssl\.sh testssl\.sh
-.
 .fi
-.
 .P
-does a default run on https://testssl\.sh (protocols, standard cipher lists, server\'s cipher preferences, forward secrecy, server defaults, vulnerabilities, client simulation, and rating\.
-.
+does a default run on https://testssl\.sh (protocols, standard cipher lists, server's cipher preferences, forward secrecy, server defaults, vulnerabilities, client simulation, and rating\.
 .IP "" 4
-.
 .nf
-
   testssl\.sh testssl\.net:443
-.
 .fi
-.
 .IP "" 0
-.
 .P
 does the same default run as above with the subtle difference that testssl\.net has two IPv4 addresses\. Both are tested\.
-.
 .IP "" 4
-.
 .nf
-
   testssl\.sh \-\-ip=one \-\-wide https://testssl\.net:443
-.
 .fi
-.
 .IP "" 0
-.
 .P
 does the same checks as above, with the difference that one IP address is being picked randomly\. Displayed is everything where possible in wide format\.
-.
 .IP "" 4
-.
 .nf
-
   testssl\.sh \-6 https://testssl\.net
-.
 .fi
-.
 .IP "" 0
-.
 .P
 As opposed to the first example it also tests the IPv6 part \-\- supposed you have an IPv6 network and your openssl supports IPv6 (see above)\.
-.
 .IP "" 4
-.
 .nf
-
   testssl\.sh \-t smtp smtp\.gmail\.com:25
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Checks are done via a STARTTLS handshake on the plain text port 25\. It checks every IP on smtp\.gmail\.com\.
-.
 .IP "" 4
-.
 .nf
-
     testssl\.sh \-\-starttls=imap imap\.gmx\.net:143
-.
 .fi
-.
 .IP "" 0
-.
 .P
 does the same on the plain text IMAP port\.
-.
 .P
 Please note that for plain TLS\-encrypted ports you must not specify the protocol option when no STARTTLS handshake is offered: \fBtestssl\.sh smtp\.gmail\.com:465\fR just checks the encryption on the SMTPS port, \fBtestssl\.sh imap\.gmx\.net:993\fR on the IMAPS port\. Also MongoDB which provides TLS support without STARTTLS can be tested directly\.
-.
 .SH "RFCs and other standards"
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 2246: The TLS Protocol Version 1\.0
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 2818: HTTP Over TLS
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 2595: Using TLS with IMAP, POP3 and ACAP
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 3501: INTERNET MESSAGE ACCESS PROTOCOL \- VERSION 4rev1
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 4346: The Transport Layer Security (TLS) Protocol Version 1\.1
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 4366: Transport Layer Security (TLS) Extensions
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 4492: Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 5077: Transport Layer Security (TLS) Session Resumption
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 5246: The Transport Layer Security (TLS) Protocol Version 1\.2
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 5280: Internet X\.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 5321: Simple Mail Transfer Protocol
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 5746: Transport Layer Security (TLS) Renegotiation Indication Extension
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 6066: Transport Layer Security (TLS) Extensions: Extension Definitions
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 6101: The Secure Sockets Layer (SSL) Protocol Version 3\.0
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 6120: Extensible Messaging and Presence Protocol (XMPP): Core
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 6125: Domain\-Based Application Service Identity [\.\.]
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 6797: HTTP Strict Transport Security (HSTS)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 6961: The Transport Layer Security (TLS) Multiple Certificate Status Request Extension
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7469: Public Key Pinning Extension for HTTP (HPKP)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7507: TLS Fallback Signaling Cipher Suite Value (SCSV) for Preventing Protocol Downgrade Attacks
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7627: Transport Layer Security (TLS) Session Hash and Extended Master Secret Extension
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7633: X\.509v3 Transport Layer Security (TLS) Feature Extension
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7465: Prohibiting RC4 Cipher Suites
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7685: A Transport Layer Security (TLS) ClientHello Padding Extension
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7905: ChaCha20\-Poly1305 Cipher Suites for Transport Layer Security (TLS)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 7919: Negotiated Finite Field Diffie\-Hellman Ephemeral Parameters for Transport Layer Security
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 8143: Using Transport Layer Security (TLS) with Network News Transfer Protocol (NNTP)
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 8446: The Transport Layer Security (TLS) Protocol Version 1\.3
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 RFC 8701: Applying Generate Random Extensions And Sustain Extensibility (GREASE) to TLS Extensibility
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 W3C CSP: Content Security Policy Level 1\-3
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 TLSWG Draft: The Transport Layer Security (TLS) Protocol Version 1\.3
-.
 .IP "" 0
-.
 .SH "EXIT STATUS"
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 0 testssl\.sh finished successfully without errors and without ambiguous results
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 1 testssl\.sh has encountered exactly one ambiguous situation or an error during run
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 1+n same as previous\. The errors or ambiguous results are added, also per IP\.
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 50\-200 reserved for returning a vulnerability scoring for system monitoring or a CI tools
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 242 (ERR_CHILD) Child received a signal from master
-.
-.IP "\(bu" 4
-244 (ERR_RESOURCE) Resources testssl\.sh needs couldn\'t be read
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+244 (ERR_RESOURCE) Resources testssl\.sh needs couldn't be read
+.IP "\[ci]" 4
 245 (ERR_CLUELESS) Weird state, either though user options or testssl\.sh
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 246 (ERR_CONNECT) Connectivity problem
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 247 (ERR_DNSLOOKUP) Problem with resolving IP addresses or names
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 248 (ERR_OTHERCLIENT) Other client problem
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 249 (ERR_DNSBIN) Problem with DNS lookup binaries
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 250 (ERR_OSSLBIN) Problem with OpenSSL binary
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 251 (ERR_NOSUPPORT) Feature requested is not supported
-.
-.IP "\(bu" 4
-252 (ERR_FNAMEPARSE) Input file couldn\'t be parsed
-.
-.IP "\(bu" 4
-253 (ERR_FCREATE) Output file couldn\'t be created
-.
-.IP "\(bu" 4
-254 (ERR_CMDLINE) Cmd line couldn\'t be parsed
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
+252 (ERR_FNAMEPARSE) Input file couldn't be parsed
+.IP "\[ci]" 4
+253 (ERR_FCREATE) Output file couldn't be created
+.IP "\[ci]" 4
+254 (ERR_CMDLINE) Cmd line couldn't be parsed
+.IP "\[ci]" 4
 255 (ERR_BASH) Bash version incorrect
-.
 .IP "" 0
-.
 .SH "FILES"
 \fBetc/*pem\fR are the certificate stores from Apple, Linux, Mozilla Firefox, Windows and Java\.
-.
 .P
 \fBetc/client\-simulation\.txt\fR contains client simulation data\.
-.
 .P
 \fBetc/cipher\-mapping\.txt\fR provides a mandatory file with mapping from OpenSSL cipher suites names to the ones from IANA / used in the RFCs\.
-.
 .P
 \fBetc/tls_data\.txt\fR provides a mandatory file for ciphers (bash sockets) and key material\.
-.
 .SH "AUTHORS"
 Developed by Dirk Wetter, David Cooper and many others, see CREDITS\.md \.
-.
 .SH "COPYRIGHT"
-Copyright © 2012 Dirk Wetter\. License GPLv2: Free Software Foundation, Inc\. This is free software: you are free to change and redistribute it under the terms of the license, see LICENSE\.
+Copyright \(co 2012 Dirk Wetter\. License GPLv2: Free Software Foundation, Inc\. This is free software: you are free to change and redistribute it under the terms of the license, see LICENSE\.
 .P
-Attribution is important for the future of this project - also in the internet\. Thus if you\'re offering a scanner based on testssl\.sh as a public
-and/or paid service in the internet you are strongly encouraged to mention to your audience that you\'re using this program and where to get this program
-from\. That helps us to get bugfixes, other feedback and more contributions\.
-.
+Attribution is important for the future of this project \- also in the internet\. Thus if you're offering a scanner based on testssl\.sh as a public and/or paid service in the internet you are strongly encouraged to mention to your audience that you're using this program and where to get this program from\. That helps us to get bugfixes, other feedback and more contributions\.
 .P
 Usage WITHOUT ANY WARRANTY\. USE at your OWN RISK!
-.
-.
 .SH "LIMITATION"
 All native Windows platforms emulating Linux are known to be slow\.
-.
 .SH "BUGS"
 Probably\. Current known ones and interface for filing new ones: https://testssl\.sh/bugs/ \.
-.
 .SH "SEE ALSO"
 \fBciphers\fR(1), \fBopenssl\fR(1), \fBs_client\fR(1), \fBx509\fR(1), \fBverify\fR(1), \fBocsp\fR(1), \fBcrl\fR(1), \fBbash\fR(1) and the websites https://testssl\.sh/ and https://github\.com/drwetter/testssl\.sh/ \.

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>testssl(1)</title>
   <style type='text/css' media='all'>
   /* style: man */
   body#manpage {margin:0}
-  .mp {padding:0 9ex 1ex 4ex}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
   .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
   .mp h2 {margin:10px 0 0 0}
   .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
@@ -61,7 +61,7 @@
     <a href="#GENERAL">GENERAL</a>
     <a href="#OPTIONS-AND-PARAMETERS">OPTIONS AND PARAMETERS</a>
     <a href="#EXAMPLES">EXAMPLES</a>
-    <a href="#RFCs-and-other-standards">RFCs and other standards</a>
+    <a href="#RFCS-AND-OTHER-STANDARDS">RFCs and other standards</a>
     <a href="#EXIT-STATUS">EXIT STATUS</a>
     <a href="#FILES">FILES</a>
     <a href="#AUTHORS">AUTHORS</a>
@@ -77,19 +77,20 @@
     <li class='tr'>testssl(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>testssl</code>
 </p>
 <h2 id="NAME">NAME</h2>
-
-<p>   testssl.sh -- check encryption of SSL/TLS servers</p>
+<p>testssl.sh -- check encryption of SSL/TLS servers</p>
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>testssl.sh [OPTIONS] &lt;URI></code>,   <code>testssl.sh [OPTIONS] --file &lt;FILE></code></p>
+<p><code>testssl.sh [OPTIONS] &lt;URI&gt;</code>,   <code>testssl.sh [OPTIONS] --file &lt;FILE&gt;</code></p>
 
-<p>  or</p>
+<p>or</p>
 
 <p><code>testssl.sh [BANNER OPTIONS]</code></p>
 
@@ -133,17 +134,19 @@ linked OpenSSL binaries for major operating systems are supplied in <code>./bin/
 
 <p>7) vulnerabilities</p>
 
+<p>8) testing each of 370 preconfigured ciphers</p>
+
 <p>8) client simulation</p>
 
 <p>9) rating</p>
 
 <h2 id="OPTIONS-AND-PARAMETERS">OPTIONS AND PARAMETERS</h2>
 
-<p>Options are either short or long options. Any long or short option requiring a value can be called with or without an equal sign. E.g. <code>testssl.sh -t=smtp --wide --openssl=/usr/bin/openssl &lt;URI></code> (short options with equal sign) is equivalent to <code>testssl.sh --starttls smtp --wide --openssl /usr/bin/openssl &lt;URI></code> (long option without equal sign). Some command line options can also be preset via ENV variables. <code>WIDE=true OPENSSL=/usr/bin/openssl testssl.sh --starttls=smtp &lt;URI></code> would be the equivalent to the aforementioned examples. Preference has the command line over any environment variables.</p>
+<p>Options are either short or long options. Any long or short option requiring a value can be called with or without an equal sign. E.g. <code>testssl.sh -t=smtp --wide --openssl=/usr/bin/openssl &lt;URI&gt;</code> (short options with equal sign) is equivalent to <code>testssl.sh --starttls smtp --wide --openssl /usr/bin/openssl &lt;URI&gt;</code> (long option without equal sign). Some command line options can also be preset via ENV variables. <code>WIDE=true OPENSSL=/usr/bin/openssl testssl.sh --starttls=smtp &lt;URI&gt;</code> would be the equivalent to the aforementioned examples. Preference has the command line over any environment variables.</p>
 
-<p><code>&lt;URI></code> or <code>--file &lt;FILE></code> always needs to be the last parameter.</p>
+<p><code>&lt;URI&gt;</code> or <code>--file &lt;FILE&gt;</code> always needs to be the last parameter.</p>
 
-<h3 id="BANNER-OPTIONS">BANNER OPTIONS (standalone)</h3>
+<h3 id="BANNER-OPTIONS-standalone-">BANNER OPTIONS (standalone)</h3>
 
 <p><code>--help</code> (or no arg) displays command line help</p>
 
@@ -157,7 +160,7 @@ linked OpenSSL binaries for major operating systems are supplied in <code>./bin/
 
 <p><code>URI</code> can be a hostname, an IPv4 or IPv6 address (restriction see below) or an URL. IPv6 addresses need to be in square brackets. For any given parameter port 443 is assumed unless specified by appending a colon and a port number. The only preceding protocol specifier allowed is <code>https</code>. You need to be aware that checks for an IP address might not hit the vhost you want. DNS resolution (A/AAAA record) is being performed unless you have an <code>/etc/hosts</code> entry for the hostname.</p>
 
-<p><code>--file &lt;fname></code> or the equivalent <code>-iL &lt;fname></code> are mass testing options. Per default it implicitly turns on <code>--warnings batch</code>. In its first incarnation the mass testing option reads command lines from <code>fname</code>. <code>fname</code> consists of command lines of testssl, one line per instance. Comments after <code>#</code> are ignored, <code>EOF</code> signals the end of fname any subsequent lines will be ignored too. You can also supply additional options which will be inherited to each child, e.g.  When invoking <code>testssl.sh --wide --log --file &lt;fname></code> . Each single line in <code>fname</code> is parsed upon execution. If there's a conflicting option and serial mass testing option is being performed the check will be aborted at the time it occurs and depending on the output option potentially leaving you with an output file without footer. In parallel mode the mileage varies, likely a line won't be scanned.</p>
+<p><code>--file &lt;fname&gt;</code> or the equivalent <code>-iL &lt;fname&gt;</code> are mass testing options. Per default it implicitly turns on <code>--warnings batch</code>. In its first incarnation the mass testing option reads command lines from <code>fname</code>. <code>fname</code> consists of command lines of testssl, one line per instance. Comments after <code>#</code> are ignored, <code>EOF</code> signals the end of fname any subsequent lines will be ignored too. You can also supply additional options which will be inherited to each child, e.g.  When invoking <code>testssl.sh --wide --log --file &lt;fname&gt;</code> . Each single line in <code>fname</code> is parsed upon execution. If there's a conflicting option and serial mass testing option is being performed the check will be aborted at the time it occurs and depending on the output option potentially leaving you with an output file without footer. In parallel mode the mileage varies, likely a line won't be scanned.</p>
 
 <p>Alternatively <code>fname</code> can be in <code>nmap</code>'s grep(p)able output format (<code>-oG</code>). Only open ports will be considered. Multiple ports per line are allowed. The ports can be different and will be tested by testssl.sh according to common practice in the internet, i.e. if nmap shows in its output an open port 25, automatically <code>-t smtp</code> will be added before the URI whereas port 465 will be treated as a plain TLS/SSL port, not requiring an STARTTLS SMTP handshake upfront. This is done by an internal table which correlates nmap's open port detected to the STARTTLS/plain text decision from testssl.sh.</p>
 
@@ -165,47 +168,47 @@ linked OpenSSL binaries for major operating systems are supplied in <code>./bin/
 
 <p>A typical internal conversion to testssl.sh file format from nmap's grep(p)able format could look like:</p>
 
-<pre><code>10.10.12.16:443
+<p><code>
+10.10.12.16:443
 10.10.12.16:1443
 -t smtp host.example.com:25
 host.example.com:443
 host.example.com:631
 -t ftp 10.10.12.11:21
 10.10.12.11:8443
-</code></pre>
+</code>
+Please note that <code>fname</code> has to be in Unix format. DOS carriage returns won't be accepted. Instead of the command line switch the environment variable FNAME will be honored too.</p>
 
-<p>Please note that <code>fname</code> has to be in Unix format. DOS carriage returns won't be accepted. Instead of the command line switch the environment variable FNAME will be honored too.</p>
+<p><code>--mode &lt;serial|parallel&gt;</code>. Mass testing to be done serial (default) or parallel (<code>--parallel</code> is shortcut for the latter, <code>--serial</code> is the opposite option). Per default mass testing is being run in serial mode, i.e. one line after the other is processed and invoked. The variable <code>MASS_TESTING_MODE</code> can be defined to be either equal <code>serial</code> or <code>parallel</code>.</p>
 
-<p><code>--mode &lt;serial|parallel></code>. Mass testing to be done serial (default) or parallel (<code>--parallel</code> is shortcut for the latter, <code>--serial</code> is the opposite option). Per default mass testing is being run in serial mode, i.e. one line after the other is processed and invoked. The variable <code>MASS_TESTING_MODE</code> can be defined to be either equal <code>serial</code> or <code>parallel</code>.</p>
-
-<p><code>--warnings &lt;batch|off></code>.  The warnings parameter determines how testssl.sh will deal with situations where user input normally will be necessary. There are two options. <code>batch</code> doesn't wait for a confirming keypress when a client- or server-side problem is encountered. As of 3.0 it just then terminates the particular scan.  This is automatically chosen for mass testing (<code>--file</code>). <code>off</code> just skips the warning, the confirmation but continues the scan, independent whether it makes sense or not. Please note that there are conflicts where testssl.sh will still ask for confirmation which are the ones which otherwise would have a drastic impact on the results. Almost any other decision will be made in the future as a best guess by testssl.sh.
+<p><code>--warnings &lt;batch|off&gt;</code>.  The warnings parameter determines how testssl.sh will deal with situations where user input normally will be necessary. There are two options. <code>batch</code> doesn't wait for a confirming keypress when a client- or server-side problem is encountered. As of 3.0 it just then terminates the particular scan.  This is automatically chosen for mass testing (<code>--file</code>). <code>off</code> just skips the warning, the confirmation but continues the scan, independent whether it makes sense or not. Please note that there are conflicts where testssl.sh will still ask for confirmation which are the ones which otherwise would have a drastic impact on the results. Almost any other decision will be made in the future as a best guess by testssl.sh.
 The same can be achieved by setting the environment variable <code>WARNINGS</code>.</p>
 
-<p><code>--connect-timeout &lt;seconds></code>  This is useful for socket TCP connections to a node. If the node does not complete a TCP handshake (e.g. because it is down or behind a firewall or there's an IDS or a tarpit) testssl.sh may usually hang for around 2 minutes or even much more. This parameter instructs testssl.sh to wait at most <code>seconds</code> for the handshake to complete before giving up. This option only works if your OS has a timeout binary installed. CONNECT_TIMEOUT is the corresponding environment variable.</p>
+<p><code>--connect-timeout &lt;seconds&gt;</code>  This is useful for socket TCP connections to a node. If the node does not complete a TCP handshake (e.g. because it is down or behind a firewall or there's an IDS or a tarpit) testssl.sh may usually hang for around 2 minutes or even much more. This parameter instructs testssl.sh to wait at most <code>seconds</code> for the handshake to complete before giving up. This option only works if your OS has a timeout binary installed. CONNECT_TIMEOUT is the corresponding environment variable.</p>
 
-<p><code>--openssl-timeout &lt;seconds></code> This is especially useful for all connects using openssl and practically useful for mass testing. It avoids the openssl connect to hang for ~2 minutes. The expected parameter <code>seconds</code> instructs testssl.sh to wait before the openssl connect will be terminated. The option is only available if your OS has a timeout binary installed. As there are different implementations of <code>timeout</code>: It automatically calls the binary with the right parameters. OPENSSL_TIMEOUT is the equivalent environment variable.</p>
+<p><code>--openssl-timeout &lt;seconds&gt;</code> This is especially useful for all connects using openssl and practically useful for mass testing. It avoids the openssl connect to hang for ~2 minutes. The expected parameter <code>seconds</code> instructs testssl.sh to wait before the openssl connect will be terminated. The option is only available if your OS has a timeout binary installed. As there are different implementations of <code>timeout</code>: It automatically calls the binary with the right parameters. OPENSSL_TIMEOUT is the equivalent environment variable.</p>
 
 <p><code>--basicauth &lt;user:pass&gt;</code> This can be set to provide HTTP basic auth credentials which are used during checks for security headers. BASICAUTH is the ENV variable you can use instead.</p>
 
-<p><code>--reqheader &lt;header&gt;</code> This can be used to add additional HTTP request headers in the correct format <code>Headername: headercontent</code>. This parameter can be called multiple times if required. For example: <code>--reqheader &#39;Proxy-Authorization: Basic dGVzdHNzbDpydWxlcw==&#39; --reqheader &#39;ClientID: 0xDEADBEAF&#39;</code>. REQHEADER is the corresponding environment variable.</p>
+<p><code>--reqheader &lt;header&gt;</code> This can be used to add additional HTTP request headers in the correct format <code>Headername: headercontent</code>. This parameter can be called multiple times if required. For example: <code>--reqheader 'Proxy-Authorization: Basic dGVzdHNzbDpydWxlcw==' --reqheader 'ClientID: 0xDEADBEAF'</code>. REQHEADER is the corresponding environment variable.</p>
 
 <h3 id="SPECIAL-INVOCATIONS">SPECIAL INVOCATIONS</h3>
 
-<p><code>-t &lt;protocol>, --starttls &lt;protocol></code>    does a default run against a STARTTLS enabled <code>protocol</code>. <code>protocol</code> must be one of <code>ftp</code>, <code>smtp</code>,  <code>pop3</code>, <code>imap</code>, <code>xmpp</code>, <code>xmpp-server</code>, <code>telnet</code>, <code>ldap</code>, <code>irc</code>, <code>lmtp</code>, <code>nntp</code>, <code>postgres</code>, <code>mysql</code>. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with <code>--ssl-native</code>. <code>telnet</code> and <code>irc</code> is WIP.</p>
+<p><code>-t &lt;protocol&gt;, --starttls &lt;protocol&gt;</code>    does a default run against a STARTTLS enabled <code>protocol</code>. <code>protocol</code> must be one of <code>ftp</code>, <code>smtp</code>,  <code>pop3</code>, <code>imap</code>, <code>xmpp</code>, <code>sieve</code>, <code>xmpp-server</code>, <code>telnet</code>, <code>ldap</code>, <code>irc</code>, <code>lmtp</code>, <code>nntp</code>, <code>postgres</code>, <code>mysql</code>. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with <code>--ssl-native</code>. <code>telnet</code> and <code>irc</code> is WIP.</p>
 
-<p><code>--xmpphost &lt;jabber_domain></code> is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter. This is only needed if the domain is different from the URI supplied.</p>
+<p><code>--xmpphost &lt;jabber_domain&gt;</code> is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter. This is only needed if the domain is different from the URI supplied.</p>
 
-<p><code>--mx &lt;domain|host></code> tests all MX records (STARTTLS on port 25) from high to low priority, one after the other.</p>
+<p><code>--mx &lt;domain|host&gt;</code> tests all MX records (STARTTLS on port 25) from high to low priority, one after the other.</p>
 
-<p><code>--ip &lt;ip></code> tests either the supplied IPv4 or IPv6 address instead of resolving host(s) in <code>&lt;URI></code>. IPv6 addresses need to be supplied in square brackets. <code>--ip=one</code> means: just test the first A record DNS returns (useful for multiple IPs). If <code>-6</code> and  <code>--ip=one</code> was supplied an AAAA record will be picked if available. The <code>--ip</code> option might be also useful if you want to resolve the supplied hostname to a different IP, similar as if you would edit <code>/etc/hosts</code> or <code>/c/Windows/System32/drivers/etc/hosts</code>. <code>--ip=proxy</code> tries a DNS resolution via proxy.</p>
+<p><code>--ip &lt;ip&gt;</code> tests either the supplied IPv4 or IPv6 address instead of resolving host(s) in <code>&lt;URI&gt;</code>. IPv6 addresses need to be supplied in square brackets. <code>--ip=one</code> means: just test the first A record DNS returns (useful for multiple IPs). If <code>-6</code> and  <code>--ip=one</code> was supplied an AAAA record will be picked if available. The <code>--ip</code> option might be also useful if you want to resolve the supplied hostname to a different IP, similar as if you would edit <code>/etc/hosts</code> or <code>/c/Windows/System32/drivers/etc/hosts</code>. <code>--ip=proxy</code> tries a DNS resolution via proxy.</p>
 
-<p><code>--proxy &lt;host>:&lt;port></code>  does ANY check via the specified proxy. <code>--proxy=auto</code> inherits the proxy setting from the environment. The hostname supplied will be resolved to the first A record. In addition if you want lookups via proxy you can specify <code>DNS_VIA_PROXY=true</code>. OCSP revocation checking (<code>-S --phone-out</code>) is not supported by OpenSSL via proxy. As supplying a proxy is an indicator for port 80 and 443 outgoing being blocked in your network an OCSP revocation check won't be performed. However if <code>IGN_OCSP_PROXY=true</code> has been supplied it will be tried directly. Authentication to the proxy is not supported. Proxying via IPv6 addresses is not possible, no HTTPS or SOCKS proxy is supported.</p>
+<p><code>--proxy &lt;host&gt;:&lt;port&gt;</code>  does ANY check via the specified proxy. <code>--proxy=auto</code> inherits the proxy setting from the environment. The hostname supplied will be resolved to the first A record. In addition if you want lookups via proxy you can specify <code>DNS_VIA_PROXY=true</code>. OCSP revocation checking (<code>-S --phone-out</code>) is not supported by OpenSSL via proxy. As supplying a proxy is an indicator for port 80 and 443 outgoing being blocked in your network an OCSP revocation check won't be performed. However if <code>IGN_OCSP_PROXY=true</code> has been supplied it will be tried directly. Authentication to the proxy is not supported. Proxying via IPv6 addresses is not possible, no HTTPS or SOCKS proxy is supported.</p>
 
-<p><code>-6</code> does (also) IPv6 checks. Please note that testssl.sh doesn't perform checks on an IPv6 address automatically, because of two reasons: testssl.sh does no connectivity checks for IPv6 and it cannot determine reliably whether the OpenSSL binary you're using has IPv6 s_client support. <code>-6</code> assumes both is the case. If both conditions are met and you in general prefer to test for IPv6 branches as well you can add <code>HAS_IPv6</code> to your shell environment. Besides the OpenSSL binary supplied IPv6 is known to work with vanilla OpenSSL &ge; 1.1.0 and older versions &ge;1.0.2 in RHEL/CentOS/FC and Gentoo.</p>
+<p><code>-6</code> does (also) IPv6 checks. Please note that testssl.sh doesn't perform checks on an IPv6 address automatically, because of two reasons: testssl.sh does no connectivity checks for IPv6 and it cannot determine reliably whether the OpenSSL binary you're using has IPv6 s_client support. <code>-6</code> assumes both is the case. If both conditions are met and you in general prefer to test for IPv6 branches as well you can add <code>HAS_IPv6</code> to your shell environment. Besides the OpenSSL binary supplied IPv6 is known to work with vanilla OpenSSL &gt;= 1.1.0 and older versions &gt;=1.0.2 in RHEL/CentOS/FC and Gentoo.</p>
 
 <p><code>--ssl-native</code>  Instead of using a mixture of bash sockets and a few openssl s_client connects, testssl.sh uses the latter (almost) only. This is faster at the moment but provides less accurate results, especially for the client simulation and for cipher support. For all checks you will see a warning if testssl.sh cannot tell if a particular check cannot be performed. For some checks however you might end up getting false negatives without a warning. This option is only recommended if you prefer speed over accuracy or you know that your target has sufficient overlap with the protocols and cipher provided by your openssl binary.</p>
 
-<p><code>--openssl &lt;path_to_openssl></code>           testssl.sh tries very hard to find automagically the binary supplied (where the tree of testssl.sh resides, from the directory where testssl.sh has been started from, etc.). If all that doesn't work it falls back to openssl supplied from the OS (<code>$PATH</code>). With this option you can point testssl.sh to your binary of choice and override any internal magic to find the openssl binary. (Environment preset via <code>OPENSSL=&lt;path_to_openssl></code>).</p>
+<p><code>--openssl &lt;path_to_openssl&gt;</code>           testssl.sh tries very hard to find automagically the binary supplied (where the tree of testssl.sh resides, from the directory where testssl.sh has been started from, etc.). If all that doesn't work it falls back to openssl supplied from the OS (<code>$PATH</code>). With this option you can point testssl.sh to your binary of choice and override any internal magic to find the openssl binary. (Environment preset via <code>OPENSSL=&lt;path_to_openssl&gt;</code>).</p>
 
 <h3 id="TUNING-OPTIONS">TUNING OPTIONS</h3>
 
@@ -213,20 +216,18 @@ The same can be achieved by setting the environment variable <code>WARNINGS</cod
 
 <p><code>--assuming-http</code>  testssl.sh normally does upfront an application protocol detection. In cases where HTTP cannot be automatically detected you may want to use this option. It enforces testssl.sh not to skip HTTP specific tests (HTTP header) and to run a browser based client simulation. Please note that sometimes also the severity depends on the application protocol, e.g. SHA1 signed certificates, the lack of any SAN matches and some vulnerabilities will be punished harder when checking a web server as opposed to a mail server.</p>
 
-<p><code>-n, --nodns &lt;min|none></code> tells testssl.sh which DNS lookups should be performed. <code>min</code> uses only forward DNS resolution (A and AAAA record or MX record) and skips CAA lookups and PTR records from the IP address back to a DNS name.  <code>none</code> performs no DNS lookups at all. For the latter you either have to supply the IP address as a target, to use <code>--ip</code> or have the IP address
+<p><code>-n, --nodns &lt;min|none&gt;</code> tells testssl.sh which DNS lookups should be performed. <code>min</code> uses only forward DNS resolution (A and AAAA record or MX record) and skips CAA lookups and PTR records from the IP address back to a DNS name.  <code>none</code> performs no DNS lookups at all. For the latter you either have to supply the IP address as a target, to use <code>--ip</code> or have the IP address
 in <code>/etc/hosts</code>.  The use of the switch is only useful if you either can't or are not willing to perform DNS lookups. The latter can apply e.g. to some pentests. In general this option could e.g. help you to avoid timeouts by DNS lookups. <code>NODNS</code> is the environment variable for this.</p>
 
 <p><code>--sneaky</code> For HTTP header checks testssl.sh uses normally the server friendly HTTP user agent <code>TLS tester from ${URL}</code>. With this option your traces are less verbose and a Firefox user agent is being used. Be aware that it doesn't hide your activities. That is just not possible (environment preset via <code>SNEAKY=true</code>).</p>
 
-<p><code>--user-agent &lt;user agent></code> tells testssl.sh to use the supplied HTTP user agent instead of the standard user agent <code>TLS tester from ${URL}</code>.</p>
+<p><code>--user-agent &lt;user agent&gt;</code> tells testssl.sh to use the supplied HTTP user agent instead of the standard user agent <code>TLS tester from ${URL}</code>.</p>
 
 <p><code>--ids-friendly</code> is a switch which may help to get a scan finished which otherwise would be blocked by a server side IDS. This switch skips tests for the following vulnerabilities: Heartbleed, CCS Injection, Ticketbleed and ROBOT. The environment variable OFFENSIVE set to false will achieve the same result. Please be advised that as an alternative or as a general approach you can try to apply evasion techniques by changing the variables USLEEP_SND and / or USLEEP_REC and maybe MAX_WAITSOCK.</p>
 
 <p><code>--phone-out</code> Checking for revoked certificates via CRL and OCSP is not done per default. This switch instructs testssl.sh to query external -- in a sense of the current run -- URIs. By using this switch you acknowledge that the check might have privacy issues, a download of several megabytes (CRL file) may happen and there may be network connectivity problems while contacting the endpoint which testssl.sh doesn't handle. PHONE_OUT is the environment variable for this which needs to be set to true if you want this.</p>
 
-<p><code>--add-ca &lt;CAfile></code> enables you to add your own CA(s) in PEM format for trust chain checks. <code>CAfile</code> can be a directory
-containing files with a .pem extension, a single file or multiple files as a comma separated list of root CAs. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates are issued by internal CAs. Alternatively ADDTL_CA_FILES is the environment variable for this.</p>
-
+<p><code>--add-ca &lt;CAfile&gt;</code> enables you to add your own CA(s) in PEM format for trust chain checks. <code>CAfile</code> can be a directory containing files with a .pem extension, a single file or multiple files as a comma separated list of root CAs. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates are issued by internal CAs. Alternatively ADDTL_CA_FILES is the environment variable for this.</p>
 
 <h3 id="SINGLE-CHECK-OPTIONS">SINGLE CHECK OPTIONS</h3>
 
@@ -236,18 +237,24 @@ containing files with a .pem extension, a single file or multiple files as a com
 
 <p><code>-E, --cipher-per-proto</code>  is similar to <code>-e, --each-cipher</code>. It checks each of the possible ciphers, here: per protocol. If you want to display each cipher tested you need to add <code>--show-each</code>. The output is sorted by security strength, it lists the encryption bits though.</p>
 
-<p><code>-s, --std, --categories</code>   tests certain lists of cipher suites / cipher categories by strength. (<code>--standard</code> is deprecated.) Those lists are (<code>openssl ciphers $LIST</code>, $LIST from below:)</p>
+<p><code>-s, --std, --categories</code>   tests certain lists of cipher suites / cipher categories by strength. (<code>--standard</code> is deprecated.)  Those lists are (<code>openssl ciphers $LIST</code>, $LIST from below:)</p>
 
 <ul>
-<li><code>NULL encryption ciphers</code>: 'NULL:eNULL'</li>
-<li><code>Anonymous NULL ciphers</code>: 'aNULL:ADH'</li>
-<li><code>Export ciphers</code> (w/o the preceding ones): 'EXPORT:!ADH:!NULL'</li>
-<li><code>LOW</code> (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'</li>
-<li><code>3DES + IDEA Ciphers</code>: '3DES:IDEA:!aNULL:!ADH'</li>
-<li><code>Average grade Ciphers</code>: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'</li>
-<li><code>Strong grade Ciphers</code> (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM8:AESCCM'</li>
+  <li>
+<code>NULL encryption ciphers</code>: 'NULL:eNULL'</li>
+  <li>
+<code>Anonymous NULL ciphers</code>: 'aNULL:ADH'</li>
+  <li>
+<code>Export ciphers</code> (w/o the preceding ones): 'EXPORT:!ADH:!NULL'</li>
+  <li>
+<code>LOW</code> (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'</li>
+  <li>
+<code>3DES + IDEA Ciphers</code>: '3DES:IDEA:!aNULL:!ADH'</li>
+  <li>
+<code>Average grade Ciphers</code>: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'</li>
+  <li>
+<code>Strong grade Ciphers</code> (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM8:AESCCM'</li>
 </ul>
-
 
 <p><code>-f, --fs, --nsa, --forward-secrecy</code> Checks robust forward secrecy key exchange. "Robust" means that ciphers having intrinsic severe weaknesses like Null Authentication or Encryption, 3DES and RC4 won't be considered here. There shouldn't be the wrong impression that a secure key exchange has been taking place and everything is fine when in reality the encryption sucks. Also this section lists the available elliptical curves and Diffie Hellman groups, as well as FFDHE groups (TLS 1.2 and TLS 1.3).</p>
 
@@ -258,53 +265,50 @@ containing files with a .pem extension, a single file or multiple files as a com
 <p><code>-S, --server_defaults</code>  displays information from the server hello(s):</p>
 
 <ul>
-<li>Available TLS extensions,</li>
-<li>TLS ticket + session ID information/capabilities,</li>
-<li>session resumption capabilities,</li>
-<li>Time skew relative to localhost (most server implementations return random values).</li>
-<li>Several certificate information
-
-<ul>
-<li>signature algorithm,</li>
-<li>key size,</li>
-<li>key usage and extended key usage,</li>
-<li>fingerprints and serial</li>
-<li>Common Name (CN), Subject Alternative Name (SAN), Issuer,</li>
-<li>Trust via hostname + chain of trust against supplied certificates</li>
-<li>EV certificate detection</li>
-<li>experimental "eTLS" detection</li>
-<li>validity: start + end time, how many days to go (warning for certificate lifetime >=5 years)</li>
-<li>revocation info (CRL, OCSP, OCSP stapling + must staple). When <code>--phone-out</code> supplied it checks against the certificate issuer whether the host certificate has been revoked (plain OCSP, CRL).</li>
-<li>displaying DNS Certification Authority Authorization resource record</li>
-<li>Certificate Transparency info (if provided by server).</li>
+  <li>Available TLS extensions,</li>
+  <li>TLS ticket + session ID information/capabilities,</li>
+  <li>session resumption capabilities,</li>
+  <li>Time skew relative to localhost (most server implementations return random values).</li>
+  <li>Several certificate information
+    <ul>
+      <li>signature algorithm,</li>
+      <li>key size,</li>
+      <li>key usage and extended key usage,</li>
+      <li>fingerprints and serial</li>
+      <li>Common Name (CN), Subject Alternative Name (SAN), Issuer,</li>
+      <li>Trust via hostname + chain of trust against supplied certificates</li>
+      <li>EV certificate detection</li>
+      <li>experimental "eTLS" detection</li>
+      <li>validity: start + end time, how many days to go (warning for certificate lifetime &gt;=5 years)</li>
+      <li>revocation info (CRL, OCSP, OCSP stapling + must staple). When <code>--phone-out</code> supplied it checks against the certificate issuer whether the host certificate has been revoked (plain OCSP, CRL).</li>
+      <li>displaying DNS Certification Authority Authorization resource record</li>
+      <li>Certificate Transparency info (if provided by server).</li>
+    </ul>
+  </li>
 </ul>
-</li>
-</ul>
-
 
 <p>For the trust chain check 5 certificate stores are provided. If the test against one of the trust stores failed, the one is being identified and the reason for the failure is displayed - in addition the ones which succeeded are displayed too.
 You can configure your own CA via ADDTL_CA_FILES, see section <code>FILES</code> below.  If the server provides no matching record in Subject Alternative Name (SAN) but in Common Name (CN), it will be indicated as this is deprecated.
 Also for multiple server certificates are being checked for as well as for the certificate reply to a non-SNI (Server Name Indication) client hello to the IP address. Regarding the TLS clock skew: it displays the time difference to the client. Only a few TLS stacks nowadays still support this and return the local clock <code>gmt_unix_time</code>, e.g. IIS, openssl &lt; 1.0.1f. In addition to the HTTP date you could e.g. derive that there are different hosts where your TLS and your HTTP request ended -- if the time deltas differ significantly.</p>
 
-<p><code>-x &lt;pattern>, --single-cipher &lt;pattern></code> tests matched <code>pattern</code> of ciphers against a server. Patterns are similar to <code>-V pattern , --local pattern</code>, see above about matching.</p>
+<p><code>-x &lt;pattern&gt;, --single-cipher &lt;pattern&gt;</code> tests matched <code>pattern</code> of ciphers against a server. Patterns are similar to <code>-V pattern , --local pattern</code>, see above about matching.</p>
 
 <p><code>-h, --header, --headers</code>       if the service is HTTP (either by detection or by enforcing via <code>--assume-http</code>. It tests several HTTP headers like</p>
 
 <ul>
-<li>HTTP Strict Transport Security (HSTS)</li>
-<li>HTTP Public Key Pinning (HPKP)</li>
-<li>Server banner</li>
-<li>HTTP date+time</li>
-<li>Server banner like Linux or other Unix vendor headers</li>
-<li>Application banner (PHP, RoR, OWA, SharePoint, Wordpress, etc)</li>
-<li>Reverse proxy headers</li>
-<li>Web server modules</li>
-<li>IPv4 address in header</li>
-<li>Cookie (including Secure/HTTPOnly flags)</li>
-<li>Decodes BIG IP F5 non-encrypted cookies</li>
-<li>Security headers (X-Frame-Options, X-XSS-Protection, Expect-CT,... , CSP headers). Nonsense is not yet detected here.</li>
+  <li>HTTP Strict Transport Security (HSTS)</li>
+  <li>HTTP Public Key Pinning (HPKP)</li>
+  <li>Server banner</li>
+  <li>HTTP date+time</li>
+  <li>Server banner like Linux or other Unix vendor headers</li>
+  <li>Application banner (PHP, RoR, OWA, SharePoint, Wordpress, etc)</li>
+  <li>Reverse proxy headers</li>
+  <li>Web server modules</li>
+  <li>IPv4 address in header</li>
+  <li>Cookie (including Secure/HTTPOnly flags)</li>
+  <li>Decodes BIG IP F5 non-encrypted cookies</li>
+  <li>Security headers (X-Frame-Options, X-XSS-Protection, Expect-CT,... , CSP headers). Nonsense is not yet detected here.</li>
 </ul>
-
 
 <p><code>-c, --client-simulation</code>     This simulates a handshake with a number of standard clients so that you can figure out which client cannot or can connect to your site. For the latter case the protocol, cipher and curve is displayed, also if there's Forward Secrecy. testssl.sh uses a handselected set of clients which are retrieved by the SSLlabs API. The output is aligned in columns when combined with the <code>--wide</code> option. If you want the full nine yards of clients displayed use the environment variable ALL_CLIENTS.</p>
 
@@ -322,13 +326,13 @@ Also for multiple server certificates are being checked for as well as for the c
 
 <p><code>--BB, --robot</code>          Checks for vulnerability to ROBOT / (<em>Return Of Bleichenbacher's Oracle Threat</em>) attack.</p>
 
-<p><code>--SI, --starttls-injection</code>          Checks for STARTTLS injection vulnerabilities (SMTP, IMAP, POP3 only). <code>socat</code> and OpenSSL &ge;1.1.0 is needed.</p>
+<p><code>--SI, --starttls-injection</code>          Checks for STARTTLS injection vulnerabilities (SMTP, IMAP, POP3 only). <code>socat</code> and OpenSSL &gt;=1.1.0 is needed.</p>
 
 <p><code>-R, --renegotiation</code>           Tests renegotiation vulnerabilities. Currently there's a check for <em>Secure Renegotiation</em> and for <em>Secure Client-Initiated Renegotiation</em>. Please be aware that vulnerable servers to the latter can likely be DoSed very easily (HTTP). A check for <em>Insecure Client-Initiated Renegotiation</em> is not yet implemented.</p>
 
 <p><code>-C, --compression, --crime</code>    Checks for CRIME (<em>Compression Ratio Info-leak Made Easy</em>) vulnerability in TLS. CRIME in SPDY is not yet being checked for.</p>
 
-<p><code>-B, --breach</code>                  Checks for BREACH (<em>Browser Reconnaissance and Exfiltration via Adaptive Compression of Hypertext</em>) vulnerability. As for this vulnerability HTTP level compression is a prerequisite it'll be not tested if HTTP cannot be detected or the detection is not enforced via <code>`--assume-http</code>. Please note that only the URL supplied (normally "/" ) is being tested.</p>
+<p><code>-B, --breach</code>                  Checks for BREACH (<em>Browser Reconnaissance and Exfiltration via Adaptive Compression of Hypertext</em>) vulnerability. As for this vulnerability HTTP level compression is a prerequisite it'll be not tested if HTTP cannot be detected or the detection is not enforced via ``--assume-http`. Please note that only the URL supplied (normally "/" ) is being tested.</p>
 
 <p><code>-O, --poodle</code>                  Tests for SSL POODLE (<em>Padding Oracle On Downgraded Legacy Encryption</em>) vulnerability. It basically checks for the existence of CBC ciphers in SSLv3.</p>
 
@@ -356,35 +360,37 @@ Also for multiple server certificates are being checked for as well as for the c
 
 <p><code>--wide</code> Except the "each cipher output" all tests displays the single cipher name (scheme see below). This option enables testssl.sh to display also for the following sections the same output as for testing each ciphers: BEAST, FS, RC4. The client simulation has also a wide mode. The difference here is restricted to a column aligned output and a proper headline. The environment variable <code>WIDE</code> can be used instead.</p>
 
-<p><code>--mapping &lt;openssl|iana|no-openssl|no-iana></code></p>
+<p><code>--mapping &lt;openssl|iana|no-openssl|no-iana&gt;</code></p>
 
 <ul>
-<li><code>openssl</code>: use the OpenSSL cipher suite name as the primary name cipher suite name form (default),</li>
-<li><code>iana</code>: use the IANA cipher suite name as the primary name cipher suite name form.</li>
-<li><code>no-openssl</code>: don't display the OpenSSL cipher suite name, display IANA names only.</li>
-<li><code>no-iana</code>: don't display the IANA cipher suite name, display OpenSSL names only.</li>
+  <li>
+<code>openssl</code>: use the OpenSSL cipher suite name as the primary name cipher suite name form (default),</li>
+  <li>
+<code>iana</code>: use the IANA cipher suite name as the primary name cipher suite name form.</li>
+  <li>
+<code>no-openssl</code>: don't display the OpenSSL cipher suite name, display IANA names only.</li>
+  <li>
+<code>no-iana</code>: don't display the IANA cipher suite name, display OpenSSL names only.</li>
 </ul>
-
 
 <p>Please note that in testssl.sh 3.0 you can still use <code>rfc</code> instead of <code>iana</code> and <code>no-rfc</code> instead of <code>no-iana</code> but it'll disappear after 3.0.</p>
 
 <p><code>--show-each</code> This is an option for all wide modes only: it displays all ciphers tested -- not only succeeded ones.  <code>SHOW_EACH_C</code> is your friend if you prefer to set this via the shell environment.</p>
 
-<p><code>--color &lt;0|1|2|3></code> determines the use of colors on the screen and in the log file: <code>2</code> is the default and makes use of ANSI and termcap escape codes on your terminal. <code>1</code> just uses non-colored mark-up like bold, italics, underline, reverse.  <code>0</code> means no mark-up at all = no escape codes. This is also what you want when you want a log file without any escape codes. <code>3</code> will color ciphers and EC according to an internal (not yet perfect) rating. Setting the environment variable <code>COLOR</code> to the value achieves the same result. Please not that OpenBSD and early FreeBSD do not support italics.</p>
+<p><code>--color &lt;0|1|2|3&gt;</code> determines the use of colors on the screen and in the log file: <code>2</code> is the default and makes use of ANSI and termcap escape codes on your terminal. <code>1</code> just uses non-colored mark-up like bold, italics, underline, reverse.  <code>0</code> means no mark-up at all = no escape codes. This is also what you want when you want a log file without any escape codes. <code>3</code> will color ciphers and EC according to an internal (not yet perfect) rating. Setting the environment variable <code>COLOR</code> to the value achieves the same result. Please not that OpenBSD and early FreeBSD do not support italics.</p>
 
 <p><code>--colorblind</code>                  Swaps green and blue colors in the output, so that this percentage of folks (up to 8% of males, see https://en.wikipedia.org/wiki/Color_blindness) can distinguish those findings better. <code>COLORBLIND</code> is the according variable if you want to set this in the environment.</p>
 
-<p><code>--debug &lt;0-6></code>                 This gives you additional output on the screen (2-6), only useful for debugging. <code>DEBUG</code> is the according environment variable which you can use. There are six levels (0 is the default, thus it has no effect):</p>
+<p><code>--debug &lt;0-6&gt;</code>                 This gives you additional output on the screen (2-6), only useful for debugging. <code>DEBUG</code> is the according environment variable which you can use. There are six levels (0 is the default, thus it has no effect):</p>
 
 <ol>
-<li>screen output normal but leaves useful debug output in <strong>/tmp/testssl.XXXXXX/</strong> . The info about the exact directory is included in the screen output in the end of the run.</li>
-<li>lists more what's going on, status (high level) and connection errors, a few general debug output</li>
-<li>even slightly more info: hexdumps + other info</li>
-<li>display bytes sent via sockets</li>
-<li>display bytes received via sockets</li>
-<li>whole 9 yards</li>
+  <li>screen output normal but leaves useful debug output in <strong>/tmp/testssl.XXXXXX/</strong> . The info about the exact directory is included in the screen output in the end of the run.</li>
+  <li>lists more what's going on, status (high level) and connection errors, a few general debug output</li>
+  <li>even slightly more info: hexdumps + other info</li>
+  <li>display bytes sent via sockets</li>
+  <li>display bytes received via sockets</li>
+  <li>whole 9 yards</li>
 </ol>
-
 
 <p><code>--disable-rating</code> disables rating.
 Rating automatically gets disabled, to not give a wrong or misleading grade, when not all required functions are executed (e.g when checking for a single vulnerabilities).</p>
@@ -393,38 +399,37 @@ Rating automatically gets disabled, to not give a wrong or misleading grade, whe
 
 <p><code>--log, --logging</code>      Logs stdout also to <code>${NODE}-p${port}${YYYYMMDD-HHMM}.log</code> in current working directory of the shell. Depending on the color output option (see above) the output file will contain color and other markup escape codes, unless you specify <code>--color 0</code> too. <code>cat</code> and -- if properly configured <code>less</code> -- will show the output properly formatted on your terminal. The output shows a banner with the almost the same information as on the screen. In addition it shows the command line of the testssl.sh instance. Please note that the resulting log file is formatted according to the width of your screen while running testssl.sh. You can override the width with the environment variable TERM_WIDTH.</p>
 
-<p><code>--logfile &lt;logfile></code> or <code>-oL &lt;logfile></code>  Instead of the previous option you may want to use this one if you want to log into a directory or if you rather want to specify the log file name yourself. If <code>logfile</code> is a directory the output will put into <code>logfile/${NODE}-p${port}${YYYYMMDD-HHMM}.log</code>. If <code>logfile</code> is a file it will use that file name, an absolute path is also permitted here. LOGFILE is the variable you need to set if you prefer to work environment variables instead. Please note that the resulting log file is formatted according to the width of your screen while running testssl.sh. You can override the width with the environment variable TERM_WIDTH.</p>
+<p><code>--logfile &lt;logfile&gt;</code> or <code>-oL &lt;logfile&gt;</code>  Instead of the previous option you may want to use this one if you want to log into a directory or if you rather want to specify the log file name yourself. If <code>logfile</code> is a directory the output will put into <code>logfile/${NODE}-p${port}${YYYYMMDD-HHMM}.log</code>. If <code>logfile</code> is a file it will use that file name, an absolute path is also permitted here. LOGFILE is the variable you need to set if you prefer to work environment variables instead. Please note that the resulting log file is formatted according to the width of your screen while running testssl.sh. You can override the width with the environment variable TERM_WIDTH.</p>
 
 <p><code>--json</code>                Logs additionally to JSON file <code>${NODE}-p${port}${YYYYMMDD-HHMM}.json</code> in the current working directory of the shell. The resulting JSON file is opposed to <code>--json-pretty</code> flat -- which means each section is self contained and has an identifier for each single check, the hostname/IP address, the port, severity and the finding. For vulnerabilities it may contain a CVE and CWE entry too. The output doesn't contain a banner or a footer.</p>
 
-<p><code>--jsonfile &lt;jsonfile></code> or <code>-oj &lt;jsonfile></code> Instead of the previous option you may want to use this one if you want to log the JSON out put into a directory or if you rather want to specify the log file name yourself. If <code>jsonfile</code> is a directory the output will put into <code>logfile/${NODE}-p${port}${YYYYMMDD-HHMM}.json. If</code>jsonfile` is a file it will use that file name, an absolute path is also permitted here.</p>
+<p><code>--jsonfile &lt;jsonfile&gt;</code> or <code>-oj &lt;jsonfile&gt;</code> Instead of the previous option you may want to use this one if you want to log the JSON out put into a directory or if you rather want to specify the log file name yourself. If <code>jsonfile</code> is a directory the output will put into <code>logfile/${NODE}-p${port}${YYYYMMDD-HHMM}.json. If </code>jsonfile` is a file it will use that file name, an absolute path is also permitted here.</p>
 
-<p><code>--json-pretty</code> Logs additionally to JSON file <code>${NODE}-p${port}${YYYYMMDD-HHMM}.json in the current working directory of the shell. The resulting JSON file is opposed to</code>--json` non-flat -- which means it is structured. The structure contains a header similar to the banner on the screen, including the command line, scan host, openssl binary used, testssl version and epoch of the start time. Then for every test section of testssl.sh it contains a separate JSON object/section. Each finding has a key/value pair identifier with the identifier for each single check, the severity and the finding. For vulnerabilities it may contain a CVE and CWE entry too.  The footer lists the scan time in seconds.</p>
+<p><code>--json-pretty</code> Logs additionally to JSON file <code>${NODE}-p${port}${YYYYMMDD-HHMM}.json in the current working directory of the shell. The resulting JSON file is opposed to </code>--json` non-flat -- which means it is structured. The structure contains a header similar to the banner on the screen, including the command line, scan host, openssl binary used, testssl version and epoch of the start time. Then for every test section of testssl.sh it contains a separate JSON object/section. Each finding has a key/value pair identifier with the identifier for each single check, the severity and the finding. For vulnerabilities it may contain a CVE and CWE entry too.  The footer lists the scan time in seconds.</p>
 
-<p><code>--jsonfile-pretty &lt;jsonfile></code> or <code>-oJ &lt;jsonfile></code>  Similar to the aforementioned <code>--jsonfile</code> or <code>--logfile</code> it logs the output in pretty JSON format (see <code>--json-pretty</code>) into a file or a directory. For further explanation see <code>--jsonfile</code> or <code>--logfile</code>.</p>
+<p><code>--jsonfile-pretty &lt;jsonfile&gt;</code> or <code>-oJ &lt;jsonfile&gt;</code>  Similar to the aforementioned <code>--jsonfile</code> or <code>--logfile</code> it logs the output in pretty JSON format (see <code>--json-pretty</code>) into a file or a directory. For further explanation see <code>--jsonfile</code> or <code>--logfile</code>.</p>
 
 <p><code>--csv</code>  Logs additionally to a CSV file <code>${NODE}-p${port}${YYYYMMDD-HHMM}.csv</code> in the current working directory of the shell. The output contains a header with the keys, the values are the same as in the flat JSON format (identifier for each single check, the hostname/IP address, the port, severity, the finding and for vulnerabilities a CVE and CWE number).</p>
 
-<p><code>--csvfile &lt;csvfile></code> or <code>-oC &lt;csvfile></code> Similar to  the aforementioned <code>--jsonfile</code> or <code>--logfile</code> it logs the output in CSV format (see <code>--cvs</code>) additionally into a file or a directory. For further explanation see <code>--jsonfile</code> or <code>--logfile</code>.</p>
+<p><code>--csvfile &lt;csvfile&gt;</code> or <code>-oC &lt;csvfile&gt;</code> Similar to  the aforementioned <code>--jsonfile</code> or <code>--logfile</code> it logs the output in CSV format (see <code>--cvs</code>) additionally into a file or a directory. For further explanation see <code>--jsonfile</code> or <code>--logfile</code>.</p>
 
-<p><code>--html</code> Logs additionally to an HTML file <code>${NODE}-p${port}${YYYYMMDD-HHMM}.html</code> in the current working directory of the shell. It contains a 1:1 output of the console. In former versions there was a non-native option to use "aha" (Ansi HTML Adapter: github.com/theZiz/aha) like <code>testssl.sh [options] &lt;URI> | aha &gt;output.html</code>. This is not necessary anymore.</p>
+<p><code>--html</code> Logs additionally to an HTML file <code>${NODE}-p${port}${YYYYMMDD-HHMM}.html</code> in the current working directory of the shell. It contains a 1:1 output of the console. In former versions there was a non-native option to use "aha" (Ansi HTML Adapter: github.com/theZiz/aha) like <code>testssl.sh [options] &lt;URI&gt; | aha &gt;output.html</code>. This is not necessary anymore.</p>
 
-<p><code>--htmlfile &lt;htmlfile></code> or <code>-oH &lt;htmlfile></code>         Similar to  the aforementioned <code>--jsonfile</code> or <code>--logfile</code> it logs the output in HTML format (see <code>--html</code>) additionally into a file or a directory. For further explanation see <code>--jsonfile</code> or <code>--logfile</code>.</p>
+<p><code>--htmlfile &lt;htmlfile&gt;</code> or <code>-oH &lt;htmlfile&gt;</code>         Similar to  the aforementioned <code>--jsonfile</code> or <code>--logfile</code> it logs the output in HTML format (see <code>--html</code>) additionally into a file or a directory. For further explanation see <code>--jsonfile</code> or <code>--logfile</code>.</p>
 
-<p><code>-oA &lt;filename></code> / <code>--outFile &lt;filename></code>    Similar to nmap it does a file output to all available file formats: LOG, JSON pretty, CSV, HTML. If the filename supplied is equal <code>auto</code> the filename is automatically generated using '${NODE}-p${port}${YYYYMMDD-HHMM}.${EXT}' with the according extension. If a directory is provided all output files will put into <code>&lt;filename>/${NODE}-p${port}${YYYYMMDD-HHMM}.{log,json,csv,html}</code>.</p>
+<p><code>-oA &lt;filename&gt;</code> / <code>--outFile &lt;filename&gt;</code>    Similar to nmap it does a file output to all available file formats: LOG, JSON pretty, CSV, HTML. If the filename supplied is equal <code>auto</code> the filename is automatically generated using '${NODE}-p${port}${YYYYMMDD-HHMM}.${EXT}' with the according extension. If a directory is provided all output files will put into <code>&lt;filename&gt;/${NODE}-p${port}${YYYYMMDD-HHMM}.{log,json,csv,html}</code>.</p>
 
-<p><code>-oa &lt;filename></code> / <code>--outfile &lt;filename></code> Does the same as the previous option but uses flat JSON instead.</p>
+<p><code>-oa &lt;filename&gt;</code> / <code>--outfile &lt;filename&gt;</code> Does the same as the previous option but uses flat JSON instead.</p>
 
 <p><code>--hints</code>  This option is not in use yet. This option is meant to give hints how to fix a finding or at least a help to improve something. GIVE_HINTS is the environment variable for this.</p>
 
-<p><code>--severity &lt;severity></code> For CSV and both JSON outputs this will only add findings to the output file if a severity is equal or higher than the <code>severity</code> value specified. Allowed are <code>&lt;LOW|MEDIUM|HIGH|CRITICAL></code>. WARN is another level which translates to a client-side scanning error or problem. Thus you will always see them in a file if they occur.</p>
+<p><code>--severity &lt;severity&gt;</code> For CSV and both JSON outputs this will only add findings to the output file if a severity is equal or higher than the <code>severity</code> value specified. Allowed are <code>&lt;LOW|MEDIUM|HIGH|CRITICAL&gt;</code>. WARN is another level which translates to a client-side scanning error or problem. Thus you will always see them in a file if they occur.</p>
 
 <p><code>--append</code> Normally, if an output file already exists and it has a file size greater zero, testssl.sh will prompt you to manually remove the file and exit with an error. <code>--append</code> however will append to this file, without a header. The environment variable APPEND does the same. Be careful using this switch/variable. A complementary option which overwrites an existing file doesn't exist per design.</p>
 
-<p><code>--overwrite</code> Normally, if an output file already exists and it has a file size greater zero, testssl.sh will not allow you to overwrite this file. This option will do that <b>without any warning</b>. The environment variable OVERWRITE does the same. Be careful, you have been warned!</p>
+<p><code>--overwrite</code> Normally, if an output file already exists and it has a file size greater zero, testssl.sh will not allow you to overwrite this file. This option will do that <strong>without any warning</strong>. The environment variable OVERWRITE does the same. Be careful, you have been warned!</p>
 
-
-<p><code>--outprefix &lt;fname_prefix></code> Prepend output filename prefix <var>fname_prefix</var> before '${NODE}-'. You can use as well the environment variable FNAME_PREFIX. Using this any output files will be named <code>&lt;fname_prefix>-${NODE}-p${port}${YYYYMMDD-HHMM}.&lt;format></code> when no file name of the respective output option was specified. If you do not like the separator '-' you can as well supply a <code>&lt;fname_prefix></code> ending in '.',  '_' or ','. In this case or if you already supplied '-' no additional '-' will be appended to <code>&lt;fname_prefix></code>.</p>
+<p><code>--outprefix &lt;fname_prefix&gt;</code> Prepend output filename prefix <var>fname_prefix</var> before '${NODE}-'. You can use as well the environment variable FNAME_PREFIX. Using this any output files will be named <code>&lt;fname_prefix&gt;-${NODE}-p${port}${YYYYMMDD-HHMM}.&lt;format&gt;</code> when no file name of the respective output option was specified. If you do not like the separator '-' you can as well supply a <code>&lt;fname_prefix&gt;</code> ending in '.',  '_' or ','. In this case or if you already supplied '-' no additional '-' will be appended to <code>&lt;fname_prefix&gt;</code>.</p>
 
 <p>A few file output options can also be preset via environment variables.</p>
 
@@ -433,70 +438,73 @@ Rating automatically gets disabled, to not give a wrong or misleading grade, whe
 <p>Testssl.sh makes use of (the eight) standard terminal colors. The color scheme is as follows:</p>
 
 <ul>
-<li>light red: a critical finding</li>
-<li>red: a high finding</li>
-<li>brown: a medium finding</li>
-<li>yellow: a low finding</li>
-<li>green (blue if COLORBLIND is set): something which is either in general a good thing or a negative result of a check which otherwise results in a high finding</li>
-<li>light green (light blue if COLORBLIND is set) : something which is either in general a very good thing or a negative result of a check which otherwise results in a critical finding</li>
-<li>no color at places where also a finding can be expected: a finding on an info level</li>
-<li>cyan: currently only used for <code>--show-each</code> or an additional hint</li>
-<li>magenta: signals a warning condition, e.g. either a local lack of capabilities on the client side or another problem</li>
-<li>light magenta: a fatal error which either requires strict consent from the user to continue or a condition which leaves no other choice for testssl.sh to quit</li>
+  <li>light red: a critical finding</li>
+  <li>red: a high finding</li>
+  <li>brown: a medium finding</li>
+  <li>yellow: a low finding</li>
+  <li>green (blue if COLORBLIND is set): something which is either in general a good thing or a negative result of a check which otherwise results in a high finding</li>
+  <li>light green (light blue if COLORBLIND is set) : something which is either in general a very good thing or a negative result of a check which otherwise results in a critical finding</li>
+  <li>no color at places where also a finding can be expected: a finding on an info level</li>
+  <li>cyan: currently only used for <code>--show-each</code> or an additional hint</li>
+  <li>magenta: signals a warning condition, e.g. either a local lack of capabilities on the client side or another problem</li>
+  <li>light magenta: a fatal error which either requires strict consent from the user to continue or a condition which leaves no other choice for testssl.sh to quit</li>
 </ul>
-
 
 <p>What is labeled as "light" above appears as such on the screen but is technically speaking "bold". Besides <code>--color=3</code> will color ciphers according to an internal and rough rating.</p>
 
 <p>Markup (without any color) is used in the following manner:</p>
 
 <ul>
-<li>bold: for the name of the test</li>
-<li>underline + bold: for the headline of each test section</li>
-<li>underline: for a sub-headline</li>
-<li>italics: for strings just reflecting a value read from the server</li>
+  <li>bold: for the name of the test</li>
+  <li>underline + bold: for the headline of each test section</li>
+  <li>underline: for a sub-headline</li>
+  <li>italics: for strings just reflecting a value read from the server</li>
 </ul>
-
 
 <h3 id="TUNING-via-ENV-variables-and-more-options">TUNING via ENV variables and more options</h3>
 
 <p>Except the environment variables mentioned above which can replace command line options here a some which cannot be set otherwise. Variables used for tuning are preset with reasonable values. <em>There should be no reason to change them</em> unless you use testssl.sh under special conditions.</p>
 
 <ul>
-<li>TERM_WIDTH is a variable which overrides the auto-determined terminal width size. Setting this variable normally only makes sense if you log the output to a file using the <code>--log</code>, <code>--logfile</code> or <code>-oL</code> option.</li>
-<li>DEBUG_ALLINONE / SETX: when setting one of those to true testssl.sh falls back to the standard bash behavior, i.e. calling <code>bash -x testssl.sh</code> it displays the bash debugging output not in an external file <code>/tmp/testssl-&lt;XX>.log</code></li>
-<li>DEBUGTIME: Profiling option. When using bash's debug mode and when this is set to true, it generates a separate text file with epoch times in <code>/tmp/testssl-&lt;XX>.time</code>. They need to be concatenated by <code>paste /tmp/testssl-&lt;XX>.{time,log}</code></li>
-<li>EXPERIMENTAL=true is an option which is sometimes used in the development process to make testing easier. In released versions this has no effect.</li>
-<li>ALL_CLIENTS=true runs a client simulation with <em>all</em> (currently 126) clients when testing HTTP.</li>
-<li>UNBRACKTD_IPV6: needs to be set to true for some old versions of OpenSSL (like from Gentoo) which don't support [bracketed] IPv6 addresses</li>
-<li>NO_ENGINE: if you have problems with garbled output containing the word 'engine' you might want to set this to true. It forces testssl.sh not try to configure openssl's engine or a non existing one from libressl</li>
-<li>HEADER_MAXSLEEP: To wait how long before killing the process to retrieve a service banner / HTTP header</li>
-<li>MAX_WAITSOCK: It instructs testssl.sh to wait until the specified time before declaring a socket connection dead. Don't change this unless you're absolutely sure what you're doing. Value is in seconds.</li>
-<li>CCS_MAX_WAITSOCK Is the similar to above but applies only to the CCS handshakes, for both of the two the two CCS payload. Don't change this unless you're absolutely sure what you're doing. Value is in seconds.</li>
-<li>HEARTBLEED_MAX_WAITSOCK  Is the similar to MAX_WAITSOCK but applies only to the ServerHello after sending the Heartbleed payload. Don't change this unless you're absolutely sure what you're doing. Value is in seconds.</li>
-<li>MEASURE_TIME_FILE For seldom cases when you don't want the scan time to be included in the output you can set this to false.</li>
-<li>STARTTLS_SLEEP is per default set to 10 (seconds). That's the value testssl.sh waits for a string in the STARTTLS handshake before giving up.</li>
-<li>MAX_PARALLEL is the maximum number of tests to run in parallel in parallel mass testing mode. The default value of 20 may be made larger on systems with faster processors.</li>
-<li>MAX_WAIT_TEST is the maximum time (in seconds) to wait for a single test in parallel mass testing mode to complete. The default is 1200.</li>
-<li>HSTS_MIN is preset to 179 (days). If you want warnings sooner or later for HTTP Strict Transport Security you can change this.</li>
-<li>HPKP_MIN is preset to 30 (days). If you want warnings sooner or later for HTTP Public Key Pinning you can change this</li>
-<li>DAYS2WARN1 is the first threshold when you'll be warning of a certificate expiration of a host, preset to 60 (days). For Let's Encrypt this value will be divided internally by 2.</li>
-<li>DAYS2WARN2 is the second threshold when you'll be warning of a certificate expiration of a host, preset to 30 (days). For Let's Encrypt this value will be divided internally by 2.</li>
-<li>TESTSSL_INSTALL_DIR is the derived installation directory of testssl.sh. Relatively to that the <code>bin</code> and mandatory <code>etc</code> directory will be looked for.</li>
-<li>CA_BUNDLES_PATH: If you have an own set of CA bundles or you want to point testssl.sh to a specific location of a CA bundle, you can use this variable to set the directory which testssl.sh will use. Please note that it overrides completely the builtin path of testssl.sh which means that you will only test against the bundles you point to. Also you might want to use <code>~/utils/create_ca_hashes.sh</code> to create the hashes for HPKP.</li>
-<li>MAX_SOCKET_FAIL: A number which tells testssl.sh how often a TCP socket connection may fail before the program gives up and terminates. The default is 2. You can increase it to a higher value if you frequently see a message like <em>Fatal error: repeated openssl s_client connect problem, doesn't make sense to continue</em>.</li>
-<li>MAX_OSSL_FAIL: A number which tells testssl.sh how often an OpenSSL s_client connect may fail before the program gives up and terminates. The default is 2. You can increase it to a higher value if you frequently see a message like <em>Fatal error: repeated TCP connect problems, giving up</em>.</li>
-<li>MAX_HEADER_FAIL: A number which tells testssl.sh how often a HTTP GET request over OpenSSL may return an empty file before the program gives up and terminates. The default is 3. Also here you can increase the threshold when you spot messages like <em>Fatal error: repeated HTTP header connect problems, doesn't make sense to continue</em>.</li>
+  <li>TERM_WIDTH is a variable which overrides the auto-determined terminal width size. Setting this variable normally only makes sense if you log the output to a file using the <code>--log</code>, <code>--logfile</code> or <code>-oL</code> option.</li>
+  <li>DEBUG_ALLINONE / SETX: when setting one of those to true testssl.sh falls back to the standard bash behavior, i.e. calling <code>bash -x testssl.sh</code> it displays the bash debugging output not in an external file <code>/tmp/testssl-&lt;XX&gt;.log</code>
+</li>
+  <li>DEBUGTIME: Profiling option. When using bash's debug mode and when this is set to true, it generates a separate text file with epoch times in <code>/tmp/testssl-&lt;XX&gt;.time</code>. They need to be concatenated by <code>paste /tmp/testssl-&lt;XX&gt;.{time,log}</code>
+[comment]: # * FAST_SOCKET
+[comment]: # * SHOW_SIGALGO
+[comment]: # * FAST</li>
+  <li>EXPERIMENTAL=true is an option which is sometimes used in the development process to make testing easier. In released versions this has no effect.</li>
+  <li>ALL_CLIENTS=true runs a client simulation with <em>all</em> (currently 126) clients when testing HTTP.</li>
+  <li>UNBRACKTD_IPV6: needs to be set to true for some old versions of OpenSSL (like from Gentoo) which don't support [bracketed] IPv6 addresses</li>
+  <li>NO_ENGINE: if you have problems with garbled output containing the word 'engine' you might want to set this to true. It forces testssl.sh not try to configure openssl's engine or a non existing one from libressl</li>
+  <li>HEADER_MAXSLEEP: To wait how long before killing the process to retrieve a service banner / HTTP header</li>
+  <li>MAX_WAITSOCK: It instructs testssl.sh to wait until the specified time before declaring a socket connection dead. Don't change this unless you're absolutely sure what you're doing. Value is in seconds.</li>
+  <li>CCS_MAX_WAITSOCK Is the similar to above but applies only to the CCS handshakes, for both of the two the two CCS payload. Don't change this unless you're absolutely sure what you're doing. Value is in seconds.</li>
+  <li>HEARTBLEED_MAX_WAITSOCK  Is the similar to MAX_WAITSOCK but applies only to the ServerHello after sending the Heartbleed payload. Don't change this unless you're absolutely sure what you're doing. Value is in seconds.</li>
+  <li>MEASURE_TIME_FILE For seldom cases when you don't want the scan time to be included in the output you can set this to false.</li>
+  <li>STARTTLS_SLEEP is per default set to 10 (seconds). That's the value testssl.sh waits for a string in the STARTTLS handshake before giving up.</li>
+  <li>MAX_PARALLEL is the maximum number of tests to run in parallel in parallel mass testing mode. The default value of 20 may be made larger on systems with faster processors.</li>
+  <li>MAX_WAIT_TEST is the maximum time (in seconds) to wait for a single test in parallel mass testing mode to complete. The default is 1200.
+[comment]: # USLEEP_SND
+[comment]: # USLEEP_REC</li>
+  <li>HSTS_MIN is preset to 179 (days). If you want warnings sooner or later for HTTP Strict Transport Security you can change this.</li>
+  <li>HPKP_MIN is preset to 30 (days). If you want warnings sooner or later for HTTP Public Key Pinning you can change this</li>
+  <li>DAYS2WARN1 is the first threshold when you'll be warning of a certificate expiration of a host, preset to 60 (days). For Let's Encrypt this value will be divided internally by 2.</li>
+  <li>DAYS2WARN2 is the second threshold when you'll be warning of a certificate expiration of a host, preset to 30 (days). For Let's Encrypt this value will be divided internally by 2.</li>
+  <li>TESTSSL_INSTALL_DIR is the derived installation directory of testssl.sh. Relatively to that the <code>bin</code> and mandatory <code>etc</code> directory will be looked for.</li>
+  <li>CA_BUNDLES_PATH: If you have an own set of CA bundles or you want to point testssl.sh to a specific location of a CA bundle, you can use this variable to set the directory which testssl.sh will use. Please note that it overrides completely the builtin path of testssl.sh which means that you will only test against the bundles you point to. Also you might want to use <code>~/utils/create_ca_hashes.sh</code> to create the hashes for HPKP.</li>
+  <li>MAX_SOCKET_FAIL: A number which tells testssl.sh how often a TCP socket connection may fail before the program gives up and terminates. The default is 2. You can increase it to a higher value if you frequently see a message like <em>Fatal error: repeated openssl s_client connect problem, doesn't make sense to continue</em>.</li>
+  <li>MAX_OSSL_FAIL: A number which tells testssl.sh how often an OpenSSL s_client connect may fail before the program gives up and terminates. The default is 2. You can increase it to a higher value if you frequently see a message like <em>Fatal error: repeated TCP connect problems, giving up</em>.</li>
+  <li>MAX_HEADER_FAIL: A number which tells testssl.sh how often a HTTP GET request over OpenSSL may return an empty file before the program gives up and terminates. The default is 3. Also here you can increase the threshold when you spot messages like <em>Fatal error: repeated HTTP header connect problems, doesn't make sense to continue</em>.</li>
 </ul>
 
-
 <h3 id="RATING">RATING</h3>
-
 <p>This program has a near-complete implementation of SSL Labs's '<a href="https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide">SSL Server Rating Guide</a>'.</p>
 
 <p>This is <em>not</em> a 100% reimplementation of the <a href="https://www.ssllabs.com/ssltest/analyze.html">SSL Lab's SSL Server Test</a>, but an implementation of the above rating specification, slight discrepancies may occur. Please note that for now we stick to the SSL Labs rating as good as possible. We are not responsible for their rating. Before filing issues please inspect their Rating Guide.</p>
 
-<p>Disclaimer: Having a good grade is <strong>NOT</strong> necessarily equal to having good security! Don't start a competition for the best grade, at least not without monitoring the client handshakes and not without adding a portion of good sense to it. Please note STARTTLS always results in a grade cap to T. Anything else would lead to a false sense of security - at least until we test for DANE or MTA-STS.</p>
+<p>Disclaimer: Having a good grade is <strong>NOT</strong> necessarily equal to having good security! Don't start a competition for the best grade, at least not without monitoring the client handshakes and not without adding a portion of good sense to it. Please note STARTTLS always results in a grade cap to T. Anything else
+would lead to a false sense of security - at least until we test for DANE or MTA-STS.</p>
 
 <p>As of writing, these checks are missing:
 * GOLDENDOODLE - should be graded <strong>F</strong> if vulnerable
@@ -507,13 +515,11 @@ Rating automatically gets disabled, to not give a wrong or misleading grade, whe
 * Zombie POODLE - should be graded <strong>F</strong> if vulnerable
 * All remaining old Symantec PKI certificates are distrusted - should be graded <strong>T</strong>
 * Symantec certificates issued before June 2016 are distrusted - should be graded <strong>T</strong>
-* ! A reading of DH params - should give correct points in <code>set_key_str_score()</code>
 * Anonymous key exchange - should give <strong>0</strong> points in <code>set_key_str_score()</code>
 * Exportable key exchange - should give <strong>40</strong> points in <code>set_key_str_score()</code>
 * Weak key (Debian OpenSSL Flaw) - should give <strong>0</strong> points in <code>set_key_str_score()</code></p>
 
 <h4 id="Implementing-new-grades-caps-or-warnings">Implementing new grades caps or -warnings</h4>
-
 <p>To implement a new grading cap, simply call the <code>set_grade_cap()</code> function, with the grade and a reason:
 <code>bash
 set_grade_cap "D" "Vulnerable to documentation"
@@ -521,17 +527,14 @@ set_grade_cap "D" "Vulnerable to documentation"
 To implement a new grade warning, simply call the <code>set_grade_warning()</code> function, with a message:
 <code>bash
 set_grade_warning "Documentation is always right"
-</code></p>
-
-<h4 id="Implementing-a-new-check-which-contains-grade-caps">Implementing a new check which contains grade caps</h4>
-
-<p>When implementing a new check (be it vulnerability or not) that sets grade caps, the <code>set_rating_state()</code> has to be updated (i.e. the <code>$do_mycheck</code> variable-name has to be added to the loop, and <code>$nr_enabled</code> if-statement has to be incremented)</p>
+</code>
+#### Implementing a new check which contains grade caps
+When implementing a new check (be it vulnerability or not) that sets grade caps, the <code>set_rating_state()</code> has to be updated (i.e. the <code>$do_mycheck</code> variable-name has to be added to the loop, and <code>$nr_enabled</code> if-statement has to be incremented)</p>
 
 <p>The <code>set_rating_state()</code> automatically disables rating, if all the required checks are <em>not</em> enabled.
 This is to prevent giving out a misleading or wrong grade.</p>
 
 <h4 id="Implementing-a-new-revision">Implementing a new revision</h4>
-
 <p>When a new revision of the rating specification comes around, the following has to be done:
 * New grade caps has to be either:
   1. Added to the script wherever relevant, or
@@ -576,63 +579,61 @@ This is to prevent giving out a misleading or wrong grade.</p>
 <h2 id="RFCs-and-other-standards">RFCs and other standards</h2>
 
 <ul>
-<li>RFC 2246: The TLS Protocol Version 1.0</li>
-<li>RFC 2818: HTTP Over TLS</li>
-<li>RFC 2595: Using TLS with IMAP, POP3 and ACAP</li>
-<li>RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security</li>
-<li>RFC 3501: INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1</li>
-<li>RFC 4346: The Transport Layer Security (TLS) Protocol Version 1.1</li>
-<li>RFC 4366: Transport Layer Security (TLS) Extensions</li>
-<li>RFC 4492: Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)</li>
-<li>RFC 5077: Transport Layer Security (TLS) Session Resumption</li>
-<li>RFC 5246: The Transport Layer Security (TLS) Protocol Version 1.2</li>
-<li>RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</li>
-<li>RFC 5321: Simple Mail Transfer Protocol</li>
-<li>RFC 5746: Transport Layer Security (TLS) Renegotiation Indication Extension</li>
-<li>RFC 6066: Transport Layer Security (TLS) Extensions: Extension Definitions</li>
-<li>RFC 6101: The Secure Sockets Layer (SSL) Protocol Version 3.0</li>
-<li>RFC 6120: Extensible Messaging and Presence Protocol (XMPP): Core</li>
-<li>RFC 6125: Domain-Based Application Service Identity [..]</li>
-<li>RFC 6797: HTTP Strict Transport Security (HSTS)</li>
-<li>RFC 6961: The Transport Layer Security (TLS) Multiple Certificate Status Request Extension</li>
-<li>RFC 7469: Public Key Pinning Extension for HTTP (HPKP)</li>
-<li>RFC 7507: TLS Fallback Signaling Cipher Suite Value (SCSV) for Preventing Protocol Downgrade Attacks</li>
-<li>RFC 7627: Transport Layer Security (TLS) Session Hash and Extended Master Secret Extension</li>
-<li>RFC 7633: X.509v3 Transport Layer Security (TLS) Feature Extension</li>
-<li>RFC 7465: Prohibiting RC4 Cipher Suites</li>
-<li>RFC 7685: A Transport Layer Security (TLS) ClientHello Padding Extension</li>
-<li>RFC 7905: ChaCha20-Poly1305 Cipher Suites for Transport Layer Security (TLS)</li>
-<li>RFC 7919: Negotiated Finite Field Diffie-Hellman Ephemeral Parameters for Transport Layer Security</li>
-<li>RFC 8143: Using Transport Layer Security (TLS) with Network News Transfer Protocol (NNTP)</li>
-<li>RFC 8446: The Transport Layer Security (TLS) Protocol Version 1.3</li>
-<li>RFC 8701: Applying Generate Random Extensions And Sustain Extensibility (GREASE) to TLS Extensibility</li>
-<li>W3C CSP: Content Security Policy Level 1-3</li>
-<li>TLSWG Draft: The Transport Layer Security (TLS) Protocol Version 1.3</li>
+  <li>RFC 2246: The TLS Protocol Version 1.0</li>
+  <li>RFC 2818: HTTP Over TLS</li>
+  <li>RFC 2595: Using TLS with IMAP, POP3 and ACAP</li>
+  <li>RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security</li>
+  <li>RFC 3501: INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1</li>
+  <li>RFC 4346: The Transport Layer Security (TLS) Protocol Version 1.1</li>
+  <li>RFC 4366: Transport Layer Security (TLS) Extensions</li>
+  <li>RFC 4492: Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)</li>
+  <li>RFC 5077: Transport Layer Security (TLS) Session Resumption</li>
+  <li>RFC 5246: The Transport Layer Security (TLS) Protocol Version 1.2</li>
+  <li>RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</li>
+  <li>RFC 5321: Simple Mail Transfer Protocol</li>
+  <li>RFC 5746: Transport Layer Security (TLS) Renegotiation Indication Extension</li>
+  <li>RFC 6066: Transport Layer Security (TLS) Extensions: Extension Definitions</li>
+  <li>RFC 6101: The Secure Sockets Layer (SSL) Protocol Version 3.0</li>
+  <li>RFC 6120: Extensible Messaging and Presence Protocol (XMPP): Core</li>
+  <li>RFC 6125: Domain-Based Application Service Identity [..]</li>
+  <li>RFC 6797: HTTP Strict Transport Security (HSTS)</li>
+  <li>RFC 6961: The Transport Layer Security (TLS) Multiple Certificate Status Request Extension</li>
+  <li>RFC 7469: Public Key Pinning Extension for HTTP (HPKP)</li>
+  <li>RFC 7507: TLS Fallback Signaling Cipher Suite Value (SCSV) for Preventing Protocol Downgrade Attacks</li>
+  <li>RFC 7627: Transport Layer Security (TLS) Session Hash and Extended Master Secret Extension</li>
+  <li>RFC 7633: X.509v3 Transport Layer Security (TLS) Feature Extension</li>
+  <li>RFC 7465: Prohibiting RC4 Cipher Suites</li>
+  <li>RFC 7685: A Transport Layer Security (TLS) ClientHello Padding Extension</li>
+  <li>RFC 7905: ChaCha20-Poly1305 Cipher Suites for Transport Layer Security (TLS)</li>
+  <li>RFC 7919: Negotiated Finite Field Diffie-Hellman Ephemeral Parameters for Transport Layer Security</li>
+  <li>RFC 8143: Using Transport Layer Security (TLS) with Network News Transfer Protocol (NNTP)</li>
+  <li>RFC 8446: The Transport Layer Security (TLS) Protocol Version 1.3</li>
+  <li>RFC 8701: Applying Generate Random Extensions And Sustain Extensibility (GREASE) to TLS Extensibility</li>
+  <li>W3C CSP: Content Security Policy Level 1-3</li>
+  <li>TLSWG Draft: The Transport Layer Security (TLS) Protocol Version 1.3</li>
 </ul>
-
 
 <h2 id="EXIT-STATUS">EXIT STATUS</h2>
 
 <ul>
-<li>0    testssl.sh finished successfully without errors and without ambiguous results</li>
-<li>1    testssl.sh has encountered exactly one ambiguous situation or an error during run</li>
-<li>1+n  same as previous. The errors or ambiguous results are added, also per IP.</li>
-<li>50-200 reserved for returning a vulnerability scoring for system monitoring or a CI tools</li>
-<li>242 (ERR_CHILD)       Child received a signal from master</li>
-<li>244 (ERR_RESOURCE)    Resources testssl.sh needs couldn't be read</li>
-<li>245 (ERR_CLUELESS)    Weird state, either though user options or testssl.sh</li>
-<li>246 (ERR_CONNECT)     Connectivity problem</li>
-<li>247 (ERR_DNSLOOKUP)   Problem with resolving IP addresses or names</li>
-<li>248 (ERR_OTHERCLIENT) Other client problem</li>
-<li>249 (ERR_DNSBIN)      Problem with DNS lookup binaries</li>
-<li>250 (ERR_OSSLBIN)     Problem with OpenSSL binary</li>
-<li>251 (ERR_NOSUPPORT)   Feature requested is not supported</li>
-<li>252 (ERR_FNAMEPARSE)  Input file couldn't be parsed</li>
-<li>253 (ERR_FCREATE)     Output file couldn't be created</li>
-<li>254 (ERR_CMDLINE)     Cmd line couldn't be parsed</li>
-<li>255 (ERR_BASH)       Bash version incorrect</li>
+  <li>0    testssl.sh finished successfully without errors and without ambiguous results</li>
+  <li>1    testssl.sh has encountered exactly one ambiguous situation or an error during run</li>
+  <li>1+n  same as previous. The errors or ambiguous results are added, also per IP.</li>
+  <li>50-200 reserved for returning a vulnerability scoring for system monitoring or a CI tools</li>
+  <li>242 (ERR_CHILD)       Child received a signal from master</li>
+  <li>244 (ERR_RESOURCE)    Resources testssl.sh needs couldn't be read</li>
+  <li>245 (ERR_CLUELESS)    Weird state, either though user options or testssl.sh</li>
+  <li>246 (ERR_CONNECT)     Connectivity problem</li>
+  <li>247 (ERR_DNSLOOKUP)   Problem with resolving IP addresses or names</li>
+  <li>248 (ERR_OTHERCLIENT) Other client problem</li>
+  <li>249 (ERR_DNSBIN)      Problem with DNS lookup binaries</li>
+  <li>250 (ERR_OSSLBIN)     Problem with OpenSSL binary</li>
+  <li>251 (ERR_NOSUPPORT)   Feature requested is not supported</li>
+  <li>252 (ERR_FNAMEPARSE)  Input file couldn't be parsed</li>
+  <li>253 (ERR_FCREATE)     Output file couldn't be created</li>
+  <li>254 (ERR_CMDLINE)     Cmd line couldn't be parsed</li>
+  <li>255 (ERR_BASH)       Bash version incorrect</li>
 </ul>
-
 
 <h2 id="FILES">FILES</h2>
 
@@ -653,16 +654,13 @@ This is to prevent giving out a misleading or wrong grade.</p>
 <p>Copyright © 2012 Dirk Wetter. License GPLv2: Free Software Foundation, Inc.
        This is free software: you are free to change and redistribute it under the terms of the license, see LICENSE.</p>
 
-<p>
-Attribution is important for the future of this project - also in the
+<p>Attribution is important for the future of this project - also in the
 internet. Thus if you're offering a scanner based on testssl.sh as a public
 and/or paid service in the internet you are strongly encouraged to mention to
 your audience that you're using this program and where to get this program
-from. That helps us to get bugfixes, other feedback and more contributions.
-</p>
+from. That helps us to get bugfixes, other feedback and more contributions.</p>
 
-<p> Usage WITHOUT ANY WARRANTY. USE at your OWN RISK!</p>
-
+<p>Usage WITHOUT ANY WARRANTY. USE at your OWN RISK!</p>
 
 <h2 id="LIMITATION">LIMITATION</h2>
 
@@ -674,12 +672,13 @@ from. That helps us to get bugfixes, other feedback and more contributions.
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p><code>ciphers</code>(1), <code>openssl</code>(1), <code>s_client</code>(1), <code>x509</code>(1), <code>verify</code>(1), <code>ocsp</code>(1), <code>crl</code>(1), <code>bash</code>(1) and the websites https://testssl.sh/ and https://github.com/drwetter/testssl.sh/ .</p>
-
+<p><span class="man-ref"><code>ciphers</code><span class="s">(1)</span></span>, <span class="man-ref"><code>openssl</code><span class="s">(1)</span></span>, <span class="man-ref"><code>s_client</code><span class="s">(1)</span></span>, <span class="man-ref"><code>x509</code><span class="s">(1)</span></span>, <span class="man-ref"><code>verify</code><span class="s">(1)</span></span>, <span class="man-ref"><code>ocsp</code><span class="s">(1)</span></span>, <span class="man-ref"><code>crl</code><span class="s">(1)</span></span>, <span class="man-ref"><code>bash</code><span class="s">(1)</span></span> and the websites https://testssl.sh/ and https://github.com/drwetter/testssl.sh/ .</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2020</li> <li class='tr'>testssl(1)</li> </ol>
+    <li class='tc'>December 2021</li>
+    <li class='tr'>testssl(1)</li>
+  </ol>
 
   </div>
 </body>

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -115,7 +115,7 @@ The same can be achieved by setting the environment variable `WARNINGS`.
 
 ### SPECIAL INVOCATIONS
 
-`-t <protocol>, --starttls <protocol>`    does a default run against a STARTTLS enabled `protocol`. `protocol` must be one of `ftp`, `smtp`,  `pop3`, `imap`, `xmpp`, `xmpp-server`, `telnet`, `ldap`, `irc`, `lmtp`, `nntp`, `postgres`, `mysql`. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with `--ssl-native`. `telnet` and `irc` is WIP.
+`-t <protocol>, --starttls <protocol>`    does a default run against a STARTTLS enabled `protocol`. `protocol` must be one of `ftp`, `smtp`,  `pop3`, `imap`, `xmpp`, `sieve`, `xmpp-server`, `telnet`, `ldap`, `irc`, `lmtp`, `nntp`, `postgres`, `mysql`. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with `--ssl-native`. `telnet` and `irc` is WIP.
 
 `--xmpphost <jabber_domain>` is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter. This is only needed if the domain is different from the URI supplied.
 

--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -86,6 +86,16 @@ unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
 
 
+$uri="mail.tigertech.net:4190";
+
+# unlink "tmp.json";
+printf "\n%s\n", "STARTTLS MANAGE(SIEVE) unit tests via sockets --> $uri ...";
+$socket_out = `./testssl.sh $check2run -t sieve $uri 2>&1`;
+# $socket_json = json('tmp.json');
+unlike($openssl_out, qr/$openssl_regex_bl/, "");
+$tests++;
+
+
 $uri="jabber.org:5222";
 
 # unlink "tmp.json";

--- a/testssl.sh
+++ b/testssl.sh
@@ -344,6 +344,7 @@ HAS_XMPP_SERVER=false
 HAS_POSTGRES=false
 HAS_MYSQL=false
 HAS_LMTP=false
+HAS_SIEVE=false
 HAS_NNTP=false
 HAS_IRC=false
 HAS_CHACHA20=false
@@ -11005,6 +11006,22 @@ starttls_imap_dialog() {
      return $ret
 }
 
+# argv1: payload for STARTTLS injection test
+#
+starttls_sieve_dialog() {
+     local -i ret=0
+     local starttls="STARTTLS"
+
+     [[ -n "$1" ]] && starttls="$starttls\r\n$1"            # this adds a payload if supplied
+     debugme echo "=== starting sieve STARTTLS dialog ==="
+     starttls_full_read '^"' '^OK '   '"STARTTLS"'          "received server capabilities and checked STARTTLS availability" &&
+     starttls_just_send "$starttls"                         "initiated STARTTLS" &&
+     starttls_full_read '^OK ' '^OK ' ''                    "received ack for STARTTLS"
+     ret=$?
+     debugme echo "=== finished sieve STARTTLS dialog with ${ret} ==="
+     return $ret
+}
+
 starttls_xmpp_dialog() {
      local -i ret=0
 
@@ -11160,6 +11177,9 @@ fd_socket() {
                     ;;
                imap|imaps) # IMAP, https://tools.ietf.org/html/rfc2595, https://tools.ietf.org/html/rfc3501
                     starttls_imap_dialog "$payload"
+                    ;;
+               sieve) # MANAGESIEVE, https://tools.ietf.org/html/rfc5804
+                    starttls_sieve_dialog "$payload"
                     ;;
                irc|ircs) # IRC, https://ircv3.net/specs/extensions/tls-3.1.html, https://ircv3.net/specs/core/capability-negotiation.html
                     fatal "FIXME: IRC+STARTTLS not yet supported" $ERR_NOSUPPORT
@@ -19399,6 +19419,7 @@ find_openssl_binary() {
      HAS_POSTGRES=false
      HAS_MYSQL=false
      HAS_LMTP=false
+     HAS_SIEVE=false
      HAS_NNTP=false
      HAS_IRC=false
      HAS_CHACHA20=false
@@ -19473,6 +19494,7 @@ find_openssl_binary() {
      grep -q 'postgres' $s_client_starttls_has && HAS_POSTGRES=true
      grep -q 'mysql' $s_client_starttls_has && HAS_MYSQL=true
      grep -q 'lmtp' $s_client_starttls_has && HAS_LMTP=true
+     grep -q 'sieve' $s_client_starttls_has && HAS_SIEVE=true
      grep -q 'nntp' $s_client_starttls_has && HAS_NNTP=true
      grep -q 'irc' $s_client_starttls_has && HAS_IRC=true
 
@@ -19638,7 +19660,7 @@ help() {
   and [options] is/are:
 
      -t, --starttls <protocol>     Does a run against a STARTTLS enabled service which is one of ftp, smtp, lmtp, pop3, imap,
-                                   xmpp, xmpp-server, telnet, ldap, nntp, postgres, mysql
+                                   sieve, xmpp, xmpp-server, telnet, ldap, nntp, postgres, mysql
      --xmpphost <to_domain>        For STARTTLS xmpp or xmpp-server checks it supplies the domainname (like SNI)
      --mx <domain/host>            Tests MX records from high to low priority (STARTTLS, port 25)
      --file/-iL <fname>            Mass testing option: Reads one testssl.sh command line per line from <fname>.
@@ -19824,6 +19846,7 @@ HAS_XMPP_SERVER2: $HAS_XMPP_SERVER2
 HAS_POSTGRES: $HAS_POSTGRES
 HAS_MYSQL: $HAS_MYSQL
 HAS_LMTP: $HAS_LMTP
+HAS_SIEVE: $HAS_SIEVE
 HAS_NNTP: $HAS_NNTP
 HAS_IRC: $HAS_IRC
 HAS_UDS: $HAS_UDS
@@ -21117,7 +21140,7 @@ determine_optimal_proto() {
 }
 
 
-# arg1 (optional): ftp smtp, lmtp, pop3, imap, xmpp, xmpp-server, telnet, ldap, postgres, mysql, irc, nntp (maybe with trailing s)
+# arg1 (optional): ftp smtp, lmtp, pop3, imap, sieve, xmpp, xmpp-server, telnet, ldap, postgres, mysql, irc, nntp (maybe with trailing s)
 #
 determine_service() {
      local ua
@@ -21158,14 +21181,14 @@ determine_service() {
           # returns always 0:
           service_detection $OPTIMAL_PROTO
      else # STARTTLS
-          if [[ "$1" == postgres ]]; then
-               protocol="postgres"
+          if [[ "$1" == postgres ]] || [[ "$1" == sieve ]]; then
+               protocol="$1"
           else
                protocol=${1%s}     # strip trailing 's' in ftp(s), smtp(s), pop3(s), etc
           fi
 
           case "$protocol" in
-               ftp|smtp|lmtp|pop3|imap|xmpp|xmpp-server|telnet|ldap|postgres|mysql|nntp)
+               ftp|smtp|lmtp|pop3|imap|sieve|xmpp|xmpp-server|telnet|ldap|postgres|mysql|nntp)
                     STARTTLS="-starttls $protocol"
                     if [[ "$protocol" == xmpp ]] || [[ "$protocol" == xmpp-server ]]; then
                          if [[ -n "$XMPP_HOST" ]]; then
@@ -21213,6 +21236,11 @@ determine_service() {
                          if ! "$HAS_LMTP"; then
                               fatal "Your $OPENSSL does not support the \"-starttls lmtp\" option" $ERR_OSSLBIN
                          fi
+                    elif [[ "$protocol" == sieve ]]; then
+                         # Check if openssl version supports sieve.
+                         if ! "$HAS_SIEVE"; then
+                              fatal "Your $OPENSSL does not support the \"-starttls sieve\" option" $ERR_OSSLBIN
+                         fi
                     elif [[ "$protocol" == nntp ]]; then
                          # Check if openssl version supports lmtp.
                          if ! "$HAS_NNTP"; then
@@ -21230,7 +21258,7 @@ determine_service() {
                     outln
                     ;;
                *)   outln
-                    fatal "momentarily only ftp, smtp, lmtp, pop3, imap, xmpp, xmpp-server, telnet, ldap, nntp, postgres and mysql allowed" $ERR_CMDLINE
+                    fatal "momentarily only ftp, smtp, lmtp, pop3, imap, sieve, xmpp, xmpp-server, telnet, ldap, nntp, postgres and mysql allowed" $ERR_CMDLINE
                     ;;
           esac
           # It comes handy later also for STARTTLS injection to define this global. When we do banner grabbing
@@ -22418,7 +22446,7 @@ parse_cmd_line() {
                     STARTTLS_PROTOCOL="$(parse_opt_equal_sign "$1" "$2")"
                     [[ $? -eq 0 ]] && shift
                     case $STARTTLS_PROTOCOL in
-                         ftp|smtp|lmtp|pop3|imap|xmpp|xmpp-server|telnet|ldap|irc|nntp|postgres|mysql) ;;
+                         ftp|smtp|lmtp|pop3|imap|sieve|xmpp|xmpp-server|telnet|ldap|irc|nntp|postgres|mysql) ;;
                          ftps|smtps|lmtps|pop3s|imaps|xmpps|telnets|ldaps|ircs|nntps|mysqls) ;;
                          *)   tmln_magenta "\nunrecognized STARTTLS protocol \"$1\", see help" 1>&2
                               help 1 ;;

--- a/testssl.sh
+++ b/testssl.sh
@@ -21650,6 +21650,7 @@ ports2starttls() {
           3306)     echo "-t mysql " ;;
           5222)     echo "-t xmpp " ;;   # domain of jabber server maybe needed
           5432)     echo "-t postgres " ;;
+          4190)     echo "-t sieve " ;;
           563)                ;;  # NNTPS
           636)                ;;  # LDAP
           1443|8443|443|981)  ;;  # HTTPS


### PR DESCRIPTION
This PR add support for the (manage)sieve protocol while using STARTTLS (if the underlying openssl supports it).