### PR TITLE
Add prototype for STARTTLS+ LDAP via sockets

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -82,7 +82,7 @@ A typical internal conversion to testssl\.sh file format from nmap's grep(p)able
 .P
 \fB\-\-reqheader <header>\fR This can be used to add additional HTTP request headers in the correct format \fBHeadername: headercontent\fR\. This parameter can be called multiple times if required\. For example: \fB\-\-reqheader 'Proxy\-Authorization: Basic dGVzdHNzbDpydWxlcw==' \-\-reqheader 'ClientID: 0xDEADBEAF'\fR\. REQHEADER is the corresponding environment variable\.
 .SS "SPECIAL INVOCATIONS"
-\fB\-t <protocol>, \-\-starttls <protocol>\fR does a default run against a STARTTLS enabled \fBprotocol\fR\. \fBprotocol\fR must be one of \fBftp\fR, \fBsmtp\fR, \fBpop3\fR, \fBimap\fR, \fBxmpp\fR, \fBsieve\fR, \fBxmpp\-server\fR, \fBtelnet\fR, \fBldap\fR, \fBirc\fR, \fBlmtp\fR, \fBnntp\fR, \fBpostgres\fR, \fBmysql\fR\. For the latter four you need e\.g\. the supplied OpenSSL or OpenSSL version 1\.1\.1\. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with \fB\-\-ssl\-native\fR\. \fBtelnet\fR and \fBirc\fR is WIP\.
+\fB\-t <protocol>, \-\-starttls <protocol>\fR does a default run against a STARTTLS enabled \fBprotocol\fR\. \fBprotocol\fR must be one of \fBftp\fR, \fBsmtp\fR, \fBpop3\fR, \fBimap\fR, \fBxmpp\fR, \fBsieve\fR, \fBxmpp\-server\fR, \fBtelnet\fR, \fBldap\fR, \fBirc\fR, \fBlmtp\fR, \fBnntp\fR, \fBpostgres\fR, \fBmysql\fR\. For the latter four you need e\.g\. the supplied OpenSSL or OpenSSL version 1\.1\.1\. Please note: MongoDB doesn't offer a STARTTLS connection, IRC currently only works with \fB\-\-ssl\-native\fR\. \fBtelnet\fR and \fBirc\fR are WIP\.
 .P
 \fB\-\-xmpphost <jabber_domain>\fR is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter\. This is only needed if the domain is different from the URI supplied\.
 .P
@@ -478,9 +478,11 @@ Please note that for plain TLS\-encrypted ports you must not specify the protoco
 .IP "\[ci]" 4
 RFC 2246: The TLS Protocol Version 1\.0
 .IP "\[ci]" 4
+RFC 2595: Using TLS with IMAP, POP3 and ACAP
+.IP "\[ci]" 4
 RFC 2818: HTTP Over TLS
 .IP "\[ci]" 4
-RFC 2595: Using TLS with IMAP, POP3 and ACAP
+RFC 2830: Lightweight Directory Access Protocol (v3): Extension for Transport Layer Security
 .IP "\[ci]" 4
 RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security
 .IP "\[ci]" 4
@@ -501,6 +503,8 @@ RFC 5280: Internet X\.509 Public Key Infrastructure Certificate and Certificate 
 RFC 5321: Simple Mail Transfer Protocol
 .IP "\[ci]" 4
 RFC 5746: Transport Layer Security (TLS) Renegotiation Indication Extension
+.IP "\[ci]" 4
+RFC 5804: A Protocol for Remotely Managing Sieve Scripts
 .IP "\[ci]" 4
 RFC 6066: Transport Layer Security (TLS) Extensions: Extension Definitions
 .IP "\[ci]" 4

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -194,7 +194,7 @@ The same can be achieved by setting the environment variable <code>WARNINGS</cod
 
 <h3 id="SPECIAL-INVOCATIONS">SPECIAL INVOCATIONS</h3>
 
-<p><code>-t &lt;protocol&gt;, --starttls &lt;protocol&gt;</code>    does a default run against a STARTTLS enabled <code>protocol</code>. <code>protocol</code> must be one of <code>ftp</code>, <code>smtp</code>,  <code>pop3</code>, <code>imap</code>, <code>xmpp</code>, <code>sieve</code>, <code>xmpp-server</code>, <code>telnet</code>, <code>ldap</code>, <code>irc</code>, <code>lmtp</code>, <code>nntp</code>, <code>postgres</code>, <code>mysql</code>. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with <code>--ssl-native</code>. <code>telnet</code> and <code>irc</code> is WIP.</p>
+<p><code>-t &lt;protocol&gt;, --starttls &lt;protocol&gt;</code>    does a default run against a STARTTLS enabled <code>protocol</code>. <code>protocol</code> must be one of <code>ftp</code>, <code>smtp</code>,  <code>pop3</code>, <code>imap</code>, <code>xmpp</code>, <code>sieve</code>, <code>xmpp-server</code>, <code>telnet</code>, <code>ldap</code>, <code>irc</code>, <code>lmtp</code>, <code>nntp</code>, <code>postgres</code>, <code>mysql</code>. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, IRC currently only works with <code>--ssl-native</code>. <code>telnet</code> and <code>irc</code> are WIP.</p>
 
 <p><code>--xmpphost &lt;jabber_domain&gt;</code> is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter. This is only needed if the domain is different from the URI supplied.</p>
 
@@ -580,8 +580,9 @@ This is to prevent giving out a misleading or wrong grade.</p>
 
 <ul>
   <li>RFC 2246: The TLS Protocol Version 1.0</li>
-  <li>RFC 2818: HTTP Over TLS</li>
   <li>RFC 2595: Using TLS with IMAP, POP3 and ACAP</li>
+  <li>RFC 2818: HTTP Over TLS</li>
+  <li>RFC 2830: Lightweight Directory Access Protocol (v3): Extension for Transport Layer Security</li>
   <li>RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security</li>
   <li>RFC 3501: INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1</li>
   <li>RFC 4346: The Transport Layer Security (TLS) Protocol Version 1.1</li>
@@ -592,6 +593,7 @@ This is to prevent giving out a misleading or wrong grade.</p>
   <li>RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile</li>
   <li>RFC 5321: Simple Mail Transfer Protocol</li>
   <li>RFC 5746: Transport Layer Security (TLS) Renegotiation Indication Extension</li>
+  <li>RFC 5804: A Protocol for Remotely Managing Sieve Scripts</li>
   <li>RFC 6066: Transport Layer Security (TLS) Extensions: Extension Definitions</li>
   <li>RFC 6101: The Secure Sockets Layer (SSL) Protocol Version 3.0</li>
   <li>RFC 6120: Extensible Messaging and Presence Protocol (XMPP): Core</li>

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -115,7 +115,7 @@ The same can be achieved by setting the environment variable `WARNINGS`.
 
 ### SPECIAL INVOCATIONS
 
-`-t <protocol>, --starttls <protocol>`    does a default run against a STARTTLS enabled `protocol`. `protocol` must be one of `ftp`, `smtp`,  `pop3`, `imap`, `xmpp`, `sieve`, `xmpp-server`, `telnet`, `ldap`, `irc`, `lmtp`, `nntp`, `postgres`, `mysql`. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, LDAP currently only works with `--ssl-native`. `telnet` and `irc` is WIP.
+`-t <protocol>, --starttls <protocol>`    does a default run against a STARTTLS enabled `protocol`. `protocol` must be one of `ftp`, `smtp`,  `pop3`, `imap`, `xmpp`, `sieve`, `xmpp-server`, `telnet`, `ldap`, `irc`, `lmtp`, `nntp`, `postgres`, `mysql`. For the latter four you need e.g. the supplied OpenSSL or OpenSSL version 1.1.1. Please note: MongoDB doesn't offer a STARTTLS connection, IRC currently only works with `--ssl-native`. `telnet` and `irc` are WIP.
 
 `--xmpphost <jabber_domain>` is an additional option for STARTTLS enabled XMPP: It expects the jabber domain as a parameter. This is only needed if the domain is different from the URI supplied.
 
@@ -473,8 +473,9 @@ Please note that for plain TLS-encrypted ports you must not specify the protocol
 ## RFCs and other standards
 
 * RFC 2246: The TLS Protocol Version 1.0
-* RFC 2818: HTTP Over TLS
 * RFC 2595: Using TLS with IMAP, POP3 and ACAP
+* RFC 2818: HTTP Over TLS
+* RFC 2830: Lightweight Directory Access Protocol (v3): Extension for Transport Layer Security
 * RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security
 * RFC 3501: INTERNET MESSAGE ACCESS PROTOCOL - VERSION 4rev1
 * RFC 4346: The Transport Layer Security (TLS) Protocol Version 1.1
@@ -485,6 +486,7 @@ Please note that for plain TLS-encrypted ports you must not specify the protocol
 * RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
 * RFC 5321: Simple Mail Transfer Protocol
 * RFC 5746: Transport Layer Security (TLS) Renegotiation Indication Extension
+* RFC 5804: A Protocol for Remotely Managing Sieve Scripts
 * RFC 6066: Transport Layer Security (TLS) Extensions: Extension Definitions
 * RFC 6101: The Secure Sockets Layer (SSL) Protocol Version 3.0
 * RFC 6120: Extensible Messaging and Presence Protocol (XMPP): Core

--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -60,14 +60,11 @@ $socket_out = `./testssl.sh $check2run -t pop3 $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-# commented out, bc of travis' limits
-#
-#printf "\n%s\n", "STARTTLS POP3 unit tests via OpenSSL --> $uri ...";
-# unlink "tmp.json";
-#$openssl_out = `./testssl.sh --ssl-native $check2run -t pop3 $uri 2>&1`;
+printf "\n%s\n", "STARTTLS POP3 unit tests via OpenSSL --> $uri ...";
+$openssl_out = `./testssl.sh --ssl-native $check2run -t pop3 $uri 2>&1`;
 # $openssl_json = json('tmp.json');
-#unlike($openssl_out, qr/$openssl_regex_bl/, "");
-#$tests++;
+unlike($openssl_out, qr/$openssl_regex_bl/, "");
+$tests++;
 
 
 $uri="imap.gmx.net:143";
@@ -146,11 +143,18 @@ $tests++;
 # https://ldapwiki.com/wiki/Public%20LDAP%20Servers
 $uri="db.debian.org:389";
 
+printf "\n%s\n", "STARTTLS LDAP unit tests via sockets --> $uri ...";
+$socket_out = `./testssl.sh $check2run -t ldap $uri 2>&1`;
+# $socket_json = json('tmp.json');
+unlike($socket_out, qr/$socket_regex_bl/, "");
+$tests++;
+
 printf "\n%s\n", "STARTTLS LDAP unit tests via OpenSSL --> $uri ...";
 $openssl_out = `./testssl.sh --ssl-native $check2run -t ldap $uri 2>&1`;
 # $openssl_json = json('tmp.json');
 unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
+
 
 
 $uri="140.238.219.117:119";

--- a/testssl.sh
+++ b/testssl.sh
@@ -7512,7 +7512,7 @@ tls_time() {
 
      pr_bold " TLS clock skew" ; out "$spaces"
 
-     if [[ "$STARTTLS_PROTOCOL" =~ ldap ]] || [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
+     if [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
           prln_local_problem "STARTTLS/$STARTTLS_PROTOCOL and --ssl-native collide here"
           return 1
      fi
@@ -7872,7 +7872,7 @@ get_server_certificate() {
                success=$?
           else
                # For STARTTLS protocols not being implemented yet via sockets this is a bypass otherwise it won't be usable at all (e.g. LDAP)
-               if [[ "$STARTTLS" =~ ldap ]] || [[ "$STARTTLS" =~ irc ]]; then
+               if [[ "$STARTTLS" =~ irc ]]; then
                     return 1
                elif [[ "$1" =~ tls1_3_RSA ]]; then
                     tls_sockets "04" "$TLS13_CIPHER" "all+" "00,12,00,00, 00,05,00,05,01,00,00,00,00, 00,0d,00,10,00,0e,08,04,08,05,08,06,04,01,05,01,06,01,02,01"
@@ -15852,7 +15852,7 @@ run_heartbleed(){
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for heartbleed vulnerability " && outln
      pr_bold " Heartbleed"; out " ($cve)                "
 
-     if [[ "$STARTTLS_PROTOCOL" =~ ldap ]] || [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
+     if [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
           prln_local_problem "STARTTLS/$STARTTLS_PROTOCOL and --ssl-native collide here"
           return 1
      fi
@@ -15962,7 +15962,7 @@ run_ccs_injection(){
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for CCS injection vulnerability " && outln
      pr_bold " CCS"; out " ($cve)                       "
 
-     if [[ "$STARTTLS_PROTOCOL" =~ ldap ]] || [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
+     if [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
           prln_local_problem "STARTTLS/$STARTTLS_PROTOCOL and --ssl-native collide here"
           return 1
      fi
@@ -17653,7 +17653,7 @@ run_drown() {
           cert_fingerprint_sha2=${cert_fingerprint_sha2/SHA256 /}
      fi
 
-     if [[ "$STARTTLS_PROTOCOL" =~ ldap ]] || [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
+     if [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
           prln_local_problem "STARTTLS/$STARTTLS_PROTOCOL and --ssl-native collide here"
           return 1
      fi
@@ -18058,7 +18058,7 @@ run_winshock() {
           outln
           return 0
      fi
-     if [[ "$STARTTLS_PROTOCOL" =~ ldap ]] || [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
+     if [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
           prln_local_problem "STARTTLS/$STARTTLS_PROTOCOL and --ssl-native collide here"
           return 1
      fi
@@ -19039,7 +19039,7 @@ run_robot() {
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for Return of Bleichenbacher's Oracle Threat (ROBOT) vulnerability " && outln
      pr_bold " ROBOT                                     "
 
-     if [[ "$STARTTLS_PROTOCOL" =~ ldap ]] || [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
+     if [[ "$STARTTLS_PROTOCOL" =~ irc ]]; then
           prln_local_problem "STARTTLS/$STARTTLS_PROTOCOL and --ssl-native collide here"
           return 1
      fi
@@ -21400,7 +21400,6 @@ determine_sizelimitbug() {
 
      # For STARTTLS protocols not being implemented yet via sockets this is a bypass otherwise it won't be usable at all (e.g. LDAP)
      # Fixme: find out whether we can't skip this in general for STARTTLS
-     [[ "$STARTTLS" =~ ldap ]] && return 0
      [[ "$STARTTLS" =~ irc ]] && return 0
 
      # Only with TLS 1.2 offered at the server side it is possible to hit this bug, in practice. Thus


### PR DESCRIPTION
See #1258

To do:
* <del>more robustness. At least the success value from the response need to be retrieved and checked via starttls_io().</del>
* <del>double check the pre-handshake before the OID whether it's correct for every case</del>
* <del>documentation</del>
* <del>inline help</del>
* <del>amend CI</del>

It seems to work though against db.debian.org