### PR TITLE
Fix locale error message when en_US.UTF-8 isn't available (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -270,7 +270,7 @@ declare -r UA_SNEAKY="Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Fi
 
 ########### Initialization part, further global vars just being declared here
 #
-LC_COLLATE=en_US.UTF-8                  # ensures certain regex patterns work as expected and aren't localized, see #1860
+LC_COLLATE=""                           # ensuree certain regex patterns work as expected and aren't localized, see setup_lc_collate()
 PRINTF=""                               # which external printf to use. Empty presets the internal one, see #1130
 IKNOW_FNAME=false
 FIRST_FINDING=true                      # is this the first finding we are outputting to file?
@@ -5036,7 +5036,7 @@ run_protocols() {
                     add_tls_offered ssl2 yes
                     ;;
                7)   prln_local_problem "$OPENSSL doesn't support \"s_client -ssl2\""
-                    fileout "$jsonID" "INFO" "not tested due to lack of local support"
+                    fileout "$jsonID" "WARN" "not tested due to lack of local support"
                     ((ret++))
                     ;;
           esac
@@ -17273,6 +17273,29 @@ check_bsd_mount() {
      fi
 }
 
+# It's important to avoid certain locales as the impact bash's pattern matching, see #1860
+# and comment in #2100
+#
+setup_lc_collate() {
+     local l=""
+     local msg='locale(1) support for any of "C, POSIX, C.UTF-8, en_US.UTF-8, en_GB.UTF-8" missing'
+     local found=false
+
+     for l in C POSIX C.UTF-8 en_US.UTF-8 en_GB.UTF-8; do
+          locale -a | grep -q $l
+          [[ $? -ne 0 ]] && continue
+          export LC_COLLATE=$l
+          found=true
+          break
+     done
+     if ! "$found"; then
+          prln_local_problem "$msg\n"
+          fileout "$jsonID" "WARN" "$msg"
+          return 1
+     fi
+     return 0
+}
+
 # This sets the PRINTF command for writing into TCP sockets. It is needed because
 # The shell builtin printf flushes the write buffer at every \n, ("\x0a") which
 # in turn means a new TCP fragment. That causes a slight performance penalty and
@@ -20303,7 +20326,7 @@ lets_roll() {
      check_proxy
      check4openssl_oldfarts
      check_bsd_mount
-
+     setup_lc_collate
 
      if "$do_display_only"; then
           prettyprint_local "$PATTERN2SHOW"

--- a/testssl.sh
+++ b/testssl.sh
@@ -270,7 +270,7 @@ declare -r UA_SNEAKY="Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Fi
 
 ########### Initialization part, further global vars just being declared here
 #
-LC_COLLATE=""                           # ensuree certain regex patterns work as expected and aren't localized, see setup_lc_collate()
+LC_COLLATE=""                           # ensures certain regex patterns work as expected and aren't localized, see setup_lc_collate()
 PRINTF=""                               # which external printf to use. Empty presets the internal one, see #1130
 IKNOW_FNAME=false
 FIRST_FINDING=true                      # is this the first finding we are outputting to file?


### PR DESCRIPTION
Therefore a new global function was declared checking whether any of
the known locales work on the client without seeting them.
C / POSIX should work as well for LC_COLLATE.

This fixes #2100 for 3.0 .