### PR TITLE
Add support for TN3270/telnet STARTTLS.

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11168,12 +11168,13 @@ starttls_telnet_dialog() {
      "
      local tnres=""
      local ret=""
+
      socksend "${msg1}"            0    && debugme echo "${debugpad}initiated STARTTLS" &&
      socksend "${msg2}"            1    &&
      tnres=$(sockread_fast 20)          && debugme echo "read succeeded"
      [[ $DEBUG -ge 6 ]] && safe_echo "$debugpad $tnres\n"
      # check for START_TLS and FOLLOWS
-     if [[ ${tnres:10:2} == 2E && ${tnres:12:2} == 01 ]]; then
+     if [[ ${tnres:10:2} == 2E ]] && [[ ${tnres:12:2} == 01 ]]; then
           ret=0
      else
           ret=1
@@ -11293,7 +11294,7 @@ fd_socket() {
                mysql) # MySQL, see https://dev.mysql.com/doc/internals/en/x-protocol-lifecycle-lifecycle.html#x-protocol-lifecycle-tls-extension
                     starttls_mysql_dialog
                     ;;
-               telnet) # captured from a tn3270 negotiation against a z/VM 7.2
+               telnet) # captured from a tn3270 negotiation against z/VM 7.2. Also, see OpenSSL apps/s_client.c for the handling of PROTO_TELNET
                     starttls_telnet_dialog
                     ;;
                *) # we need to throw an error here -- otherwise testssl.sh treats the STARTTLS protocol as plain SSL/TLS which leads to FP

--- a/testssl.sh
+++ b/testssl.sh
@@ -11159,6 +11159,29 @@ starttls_mysql_dialog() {
      return $ret
 }
 
+starttls_telnet_dialog() {
+     debugme echo "=== starting telnet STARTTLS dialog ==="
+     local msg1="
+     , xff, xfb, x2e"
+     local msg2="
+     , xff, xfa, x2e, x01, xff, xf0
+     "
+     local tnres=""
+     local ret=""
+     socksend "${msg1}"            0    && debugme echo "${debugpad}initiated STARTTLS" &&
+     socksend "${msg2}"            1    &&
+     tnres=$(sockread_fast 20)          && debugme echo "read succeeded"
+     [[ $DEBUG -ge 6 ]] && safe_echo "$debugpad $tnres\n"
+     # check for START_TLS and FOLLOWS
+     if [[ ${tnres:10:2} == 2E && ${tnres:12:2} == 01 ]]; then
+          ret=0
+     else
+          ret=1
+     fi
+     debugme echo "=== finished telnet STARTTLS dialog with ${ret} ==="
+     return $ret
+}
+
 # arg1: fd for socket -- which we don't use yes as it is a hassle (not clear whether it works under every bash version)
 # arg2: optional: for STARTTLS additional command to be injected
 # returns 6 if opening the socket caused a problem, 1 if STARTTLS handshake failed, 0: all ok
@@ -11269,6 +11292,9 @@ fd_socket() {
                     ;;
                mysql) # MySQL, see https://dev.mysql.com/doc/internals/en/x-protocol-lifecycle-lifecycle.html#x-protocol-lifecycle-tls-extension
                     starttls_mysql_dialog
+                    ;;
+               telnet) # captured from a tn3270 negotiation against a z/VM 7.2
+                    starttls_telnet_dialog
                     ;;
                *) # we need to throw an error here -- otherwise testssl.sh treats the STARTTLS protocol as plain SSL/TLS which leads to FP
                     fatal "FIXME: STARTTLS protocol $STARTTLS_PROTOCOL is not supported yet" $ERR_NOSUPPORT


### PR DESCRIPTION
Modeled after what 1.1.x OpenSSL does in apps/s_client.c for PROTO_TELNET. Adding tests is bit tricky, as I am not aware of any public TN3270 servers with STARTTLS.