### PR TITLE
Fix sclient_auth

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21004,6 +21004,7 @@ sclient_auth() {
                return 1
           fi
      fi
+     return 1
 }
 
 # Determine the best parameters to use with tls_sockets():


### PR DESCRIPTION
If `$connect_success` is false, then `sclient_auth()` does not "return" any value, and the calling function treats this as if `sclient_auth()` had returned 0.

This PR fixes `sclient_auth()` so that 1 is returned if `$client_success` is false.