### PR TITLE
Fix CI error

### DIFF
--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -157,7 +157,7 @@ $tests++;
 
 
 
-$uri="140.238.219.117:119";
+$uri="144.76.182.167:119";
 
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS NNTP unit tests via sockets --> $uri ...";


### PR DESCRIPTION
I found a working NNTP server on http://vivil.free.fr/nntpeng.htm. I'm not sure if it's a reliable server to test against, but it at least temporarily fixes the error in CI testing.