### PR TITLE
Fix flat JSON file

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1313,8 +1313,8 @@ fileout_insert_warning() {
           else
                echo -e ", " >>"$JSONFILE"
           fi
+          FIRST_FINDING=true
      fi
-     FIRST_FINDING=true
 }
 
 fileout_csv_finding() {


### PR DESCRIPTION
PR #2140 contains a bug when handling flat JSON files. `FIRST_FINDING` should only be set to true in the case of structured JSON output, since it is only in that case that `fileout_insert_warning()` appends a comma to the JSON file. This PR fixes the problem.