### PR TITLE
More OpenSSL compatibility fixes

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8181,7 +8181,9 @@ determine_cert_fingerprint_serial() {
      result="${result//serial=}"
      result="${result//:/}"
      result="${result//SHA1 /}"
+     result="${result//sha1 /}"
      result="${result//SHA256 /}"
+     result="${result//sha256 /}"
      # When the serial number is too large we'll get a 0x0a LF after 70 ASCII chars (see #2010).
      # Thus we clean them here so that it is displayed correctly.
      result="${result/[$'\n\r']/}"


### PR DESCRIPTION
This PR fixes yet another issue with using OpenSSL 3.X with the 3.0 branch. When $OPENSSL is used to obtain a fingerprint, OpenSSL 3.X prepends the fingerprint with "sha1" or "sha256" rather than "SHA1" or "SHA256".