### PR TITLE
Fix run_server_preference() with no default protocol

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6671,7 +6671,7 @@ run_server_preference() {
                fi
           fi
      fi
-     default_proto=$(get_protocol $TMPFILE)
+     [[ $ret -eq 0 ]] && default_proto=$(get_protocol $TMPFILE)
      [[ "$default_proto" == TLSv1.0 ]] && default_proto="TLSv1"
      # debugme tm_out " --> $default_proto\n"
 


### PR DESCRIPTION
`run_server_preference()` calls `default_proto=$(get_protocol $TMPFILE)` even if all attempts to connect to the server failed. This will result in `default_proto` incorrectly being set to TLS 1.2. This PR fixes the issue by only calling `get_protocol()` if an attempt to connect to the server was successful.