### PR TITLE
Update PROTOS_OFFERED

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5174,10 +5174,11 @@ run_prototest_openssl() {
 # arg2: available (yes) or not (no)
 add_proto_offered() {
      # the ":" is mandatory here (and @ other places), otherwise e.g. tls1 will match tls1_2
-     if [[ "$PROTOS_OFFERED" =~ $1: ]]; then
-          # we got that protocol already
-          :
-     else
+     if [[ "$2" == yes ]] && [[ "$PROTOS_OFFERED" =~ $1:no ]]; then
+          # In rare cases, a protocol may be marked as not available even though it is
+          # (e.g., the connection fails with tls_sockets() but succeeds with $OPENSSL.
+          PROTOS_OFFERED="${PROTOS_OFFERED/$1:no/$1:$2}"
+     elif [[ ! "$PROTOS_OFFERED" =~ $1: ]]; then
           PROTOS_OFFERED+="${1}:$2 "
      fi
 }
@@ -21341,6 +21342,10 @@ determine_optimal_proto() {
         [[ "$(has_server_protocol "tls1_1")" -ne 0 ]] && [[ "$(has_server_protocol "tls1")" -ne 0 ]] &&
         [[ "$(has_server_protocol "ssl3")" -ne 0 ]]; then
           TLS13_ONLY=true
+     elif [[ -z "$TLS12_CIPHER_OFFERED" ]] && [[ "$(has_server_protocol "tls1_2")" -eq 0 ]] && [[ "$(get_protocol $TMPFILE)" == TLSv1.2 ]]; then
+          TLS12_CIPHER_OFFERED="$(get_cipher $TMPFILE)"
+          TLS12_CIPHER_OFFERED="$(openssl2hexcode "$TLS12_CIPHER_OFFERED")"
+          [[ ${#TLS12_CIPHER_OFFERED} -eq 9 ]] && TLS12_CIPHER_OFFERED="${TLS12_CIPHER_OFFERED:2:2},${TLS12_CIPHER_OFFERED:7:2}" || TLS12_CIPHER_OFFERED=""
      fi
 
      if [[ "$optimal_proto" == -ssl2 ]]; then


### PR DESCRIPTION
In some rare cases, a connection to the server will fail with `tls_sockets()` but not with `$OPENSSL`. This can cause `determine_optimal_sockets_params()` to call `add_proto_offered()` to indicate that the protocol is not supported, and then `determine_optimal_proto()` to later call `add_proto_offered()` to indicate that it is supported. However, `PROTOS_OFFERED` does not get changed, since `add_proto_offered()` only modifies `PROTOS_OFFERED` if the protocol is not already listed.

This PR fixes the problem by allowing `add_proto_offered()` to change an entry for a protocol from "no" to "yes".

If `determine_optimal_proto()` happens to connect to the server using TLS 1.2, then this PR will set `TLS12_CIPHER_OFFERED` to the cipher from that connection, if `TLS12_CIPHER_OFFERED` was not set in `determine_optimal_sockets_params()`. This will allow `run_protocols()`'s test of a TLS 1.3 ClientHello to work better, if the problem is that no cipher supported by the server is included in `TLS12_CIPHER` or `TLS12_CIPHER_2ND_TRY`.

The following will create a server that triggers the problem:
```
/usr/bin/openssl s_client -no_tls1_3 -cipher ARIA128-GCM-SHA256 ...
```
Then try:
```
testssl.sh --openssl=/usr/bin/openssl --protocols -E ...
```
The issue is that ARIA128-GCM-SHA256 (0xC0,0x50) does not appear in either `TLS12_CIPHER` or `TLS12_CIPHER_2ND_TRY`. (Note that this PR will not help as much if the server supports TLS 1.3, since `determine_optimal_proto()` will not make a TLS 1.2 connection and so `PROTOS_OFFERED` will not be updated and will continue to incorrectly indicate that the server does not support TLS 1.2.