### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,9 @@
 ---
 name: Codespell
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors

--- a/.github/workflows/docker-3.1dev.yml
+++ b/.github/workflows/docker-3.1dev.yml
@@ -12,6 +12,9 @@ env:
   BUILD_VERSION: "3.1dev"
   DOCKER_CLI_EXPERIMENTAL: enabled
 
+permissions:
+  contents: read
+
 jobs:
 
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ on:
       - 'LICENSE'
       - 'Dockerfile'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
