### PR TITLE
Relax STARTTLS FTP requirement

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11044,7 +11044,7 @@ starttls_full_read(){
 
 starttls_ftp_dialog() {
      local -i ret=0
-     local reSTARTTLS='^ AUTH TLS'
+     local reSTARTTLS='^ AUTH'
 
      debugme echo "=== starting ftp STARTTLS dialog ==="
      starttls_full_read '^220-' '^220 '     ''                   "received server greeting" &&


### PR DESCRIPTION
In rare? occassions where the STARTTLS FEAT request only displays AUTH instead
of AUTH TLS, testssl.sh fails as it cannot upgrade to TLS.

Required by RFC 4217 is only AUTH ("MUST"), AUTH TLS is optional ("should"), see section 6.
This PR relaxes the presence of TLS after AUTH and fixes #2132.