### PR TITLE
Relax STARTTLS FTP requirement (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10297,7 +10297,7 @@ starttls_full_read(){
 
 starttls_ftp_dialog() {
      debugme echo "=== starting ftp STARTTLS dialog ==="
-     local reAUTHTLS='^ AUTH TLS'
+     local reAUTHTLS='^ AUTH'
      starttls_full_read '^220-' '^220 '                    && debugme echo "received server greeting" &&
      starttls_just_send 'FEAT'                             && debugme echo "sent FEAT" &&
      starttls_full_read '^(211-| )' '^211 ' "${reAUTHTLS}" && debugme echo "received server features and checked STARTTLS availability" &&


### PR DESCRIPTION
In rare? occassions where the STARTTLS FEAT request only displays AUTH instead
of AUTH TLS, testssl.sh fails as it cannot upgrade to TLS.

Required by RFC 4217 is only AUTH ("MUST"), AUTH TLS is optional ("should"), see section 6.
This PR relaxes the presence of TLS after AUTH and fixes #2132 for the 3.0 branch.