### PR TITLE
Minor changes to banner

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1526,7 +1526,7 @@ html_banner() {
      if "$CHILD_MASS_TESTING" && "$HTMLHEADER"; then
           html_out "## Scan started as: \"$PROG_NAME $CMDLINE\"\n"
           html_out "## at $HNAME:$OPENSSL_LOCATION\n"
-          html_out "## version testssl: $VERSION ${GIT_REL_SHORT:-$CVS_REL_SHORT} from $REL_DATE\n"
+          html_out "## version testssl: $VERSION ${GIT_REL_SHORT} from $REL_DATE\n"
           html_out "## version openssl: \"$OSSL_NAME $OSSL_VER\" from \"$OSSL_BUILD_DATE\")\n\n"
      fi
 }
@@ -1577,7 +1577,7 @@ prepare_logging() {
      fi
      tmln_out "## Scan started as: \"$PROG_NAME $CMDLINE\"" >>"$LOGFILE"
      tmln_out "## at $HNAME:$OPENSSL_LOCATION" >>"$LOGFILE"
-     tmln_out "## version testssl: $VERSION ${GIT_REL_SHORT:-$CVS_REL_SHORT} from $REL_DATE" >>"$LOGFILE"
+     tmln_out "## version testssl: $VERSION ${GIT_REL_SHORT} from $REL_DATE" >>"$LOGFILE"
      tmln_out "## version openssl: \"$OSSL_VER\" from \"$OSSL_BUILD_DATE\")\n" >>"$LOGFILE"
      exec > >(tee -a -i "$LOGFILE")
 }
@@ -20064,7 +20064,6 @@ prepare_debug() {
           cat >$TEMPDIR/environment.txt << EOF
 
 
-CVS_REL: $CVS_REL
 GIT_REL: $GIT_REL
 
 PID: $$
@@ -20221,15 +20220,11 @@ prepare_arrays() {
 
 
 mybanner() {
-     local idtag
      local bb1 bb2 bb3
 
      "$QUIET" && return
      "$CHILD_MASS_TESTING" && return
      OPENSSL_NR_CIPHERS=$(count_ciphers "$(actually_supported_osslciphers 'ALL:COMPLEMENTOFALL:@STRENGTH' 'ALL')")
-     [[ -z "$GIT_REL" ]] && \
-          idtag="$CVS_REL" || \
-          idtag="$GIT_REL -- $CVS_REL_SHORT"
      bb1=$(cat <<EOF
 
 ###########################################################
@@ -20252,11 +20247,9 @@ EOF
 )
      pr_bold "$bb1 "
      pr_boldurl "$SWURL"; outln
-     if [[ -n "$idtag" ]]; then
-          #FIXME: if we run it not off the git dir we miss the version tag.
-          # at least we don't want to display empty brackets here...
+     if [[ -n "$GIT_REL" ]]; then
           pr_bold "    ("
-          pr_grey "$idtag"
+          pr_litegrey "$GIT_REL"
           prln_bold ")"
      fi
      pr_bold "$bb2 "


### PR DESCRIPTION
On macOS in dark mode the git tag in grey wasn't visible. It was
changed now to light grey but it has to be tested how it looks
on a white terminal background. **Update**: On Linux using several
terminal windows, also with white background it worked fine.

Also CVS variables were removed which had no meaning.