### PR TITLE
Fix banner and remove STARTTLS NNTP CI check

### DIFF
--- a/t/25_baseline_starttls.t
+++ b/t/25_baseline_starttls.t
@@ -130,24 +130,8 @@ unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
 
 
-$uri="140.238.219.117:119";
-
-# unlink "tmp.json";
-printf "\n%s\n", "STARTTLS NNTP unit tests via sockets --> $uri ...";
-$socket_out = `./testssl.sh $check2run -t nntp $uri 2>&1`;
-# $socket_json = json('tmp.json');
-unlike($socket_out, qr/$socket_regex_bl/, "");
-$tests++;
-
-printf "\n%s\n", "STARTTLS NNTP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `./testssl.sh --ssl-native $check2run -t nntp $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
-
-
 # IRC: missing
-# LTMP, mysql, postgres
+# LTMP, mysql, postgres, NNTP, telnet
 
 
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -17665,13 +17665,11 @@ prepare_arrays() {
 
 
 mybanner() {
-     local idtag
      local bb1 bb2 bb3
 
      "$QUIET" && return
      "$CHILD_MASS_TESTING" && return
      OPENSSL_NR_CIPHERS=$(count_ciphers "$(actually_supported_osslciphers 'ALL:COMPLEMENTOFALL:@STRENGTH' 'ALL')")
-     [[ -n "$GIT_REL" ]] && idtag="$GIT_REL"
      bb1=$(cat <<EOF
 
 ###########################################################
@@ -17694,11 +17692,9 @@ EOF
 )
      pr_bold "$bb1 "
      pr_boldurl "$SWURL"; outln
-     if [[ -n "$idtag" ]]; then
-          #FIXME: if we run it not off the git dir we miss the version tag.
-          # at least we don't want to display empty brackets here...
+     if [[ -n "$GIT_REL" ]]; then
           pr_bold "    ("
-          pr_grey "$idtag"
+          pr_litegrey "$GIT_REL"
           prln_bold ")"
      fi
      pr_bold "$bb2 "


### PR DESCRIPTION
On macOS in dark mode the git tag in grey wasn't visible. It was
changed now to light grey. It also works at least on Linux
using a light terminal background.

The NNTP server which we used for STARTTLS checks seems ofen
not to work. Thus this PR removes that for the 3.0 branch.

See #2167 