### PR TITLE
Stop using process substitution. On readonly or restricted disks, it …

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9357,6 +9357,7 @@ certificate_info() {
 
      determine_dates_certificate "$cert_txt" > /tmp/ddc_cert.txt
      IFS=',' read -r startdate enddate diffseconds days2expire yearstart < /tmp/ddc_cert.txt
+     rm /tmp/ddc_cert.txt
 
      # We adjust the thresholds by %50 for LE certificates, relaxing warnings for those certificates.
      # . instead of \' because it does not break syntax highlighting in vim
@@ -9698,6 +9699,7 @@ certificate_info() {
           # We don't need every value here. For the sake of being consistent here we add the rest
           determine_dates_certificate "${intermediate_certs_txt[i]}" > /tmp/ddc_intermediate_certs.txt
           IFS=',' read -r startdate enddate diffseconds days2expire yearstart < /tmp/ddc_intermediate_certs.txt
+          rm /tmp/ddc_intermediate_certs.txt
           fileout "intermediate_cert_notBefore <#${i}>${json_postfix}"  "INFO" "$startdate"
 
           if $first; then


### PR DESCRIPTION
Stop using process substitution. On readonly or restricted disks, it causes error ("/dev/fd/62 No such file or directory"). It is basically that process substitution command creates a temp file where it is only readonly directory. For example; if you build your docker images inside AWS ECR and try to run those images on AWS Lambda which allows you to write files only inside "/tmp" directory, you will face an error while using testssl.sh. 

For more info about process substitution, please have a look at [wiki](https://en.wikipedia.org/wiki/Process_substitution#:~:text=In%20computing%2C%20process%20substitution%20is,occur%2C%20by%20the%20command%20shell.)