### PR TITLE
Use `grep -E` instead of `egrep`

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6130,18 +6130,18 @@ run_cipherlists() {
      sslv2_exp_ciphers="04,00,80, 02,00,80, 00,00,00"
 
      ossl_low_ciphers='LOW:DES:RC2:RC4:MD5:!ADH:!EXP:!NULL:!eNULL:!AECDH'
-     # egrep -w '64|56|RC2|RC4|MD5' etc/cipher-mapping.txt | egrep -v 'Au=None|export'
+     # grep -Ew '64|56|RC2|RC4|MD5' etc/cipher-mapping.txt | grep -Ev 'Au=None|export'
      low_ciphers="00,04, 00,05, 00,09, 00,0C, 00,0F, 00,12, 00,15, 00,1E, 00,20, 00,22, 00, 23, 00,24, 00,25, 00,66, 00,8A, 00,8E, 00,92, C0,02, C0,07, C0,0C, C0,11, C0,33, FF,00, FE,FE, FF,E1, 00,FF"
      sslv2_low_ciphers="01,00,80, 03,00,80, 05,00,80, 06,00,40, 06,01,40, 07,00,c0, 08,00,80, FF,80,00"
 
      ossl_tdes_ciphers='3DES:IDEA:!aNULL:!ADH:!MD5'
-     # egrep -w '3DES|IDEA' etc/cipher-mapping.txt | egrep -v "Au=None|MD5"
+     # grep -Ew '3DES|IDEA' etc/cipher-mapping.txt | grep -Ev "Au=None|MD5"
      tdes_ciphers="00,07, 00,0A, 00,0D, 00,10, 00,13, 00,16, 00,1F, 00,21, 00,8B, 00,8F, 00,93, C0,03, C0,08, C0,0D, C0,12, C0,1A, C0,1B, C0,1C, C0,34, FE,FF, FF,E0, 00,FF"
      sslv2_tdes_ciphers="07,01,c0"
 
      # # Now all AES, CAMELLIA, ARIA and SEED CBC ciphers plus GOST
      ossl_obsoleted_ciphers='HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL:!MD5'
-     # egrep -w "256|128" etc/cipher-mapping.txt | egrep -v "Au=None|AEAD|RC2|RC4|IDEA|MD5"
+     # grep -Ew "256|128" etc/cipher-mapping.txt | grep -Ev "Au=None|AEAD|RC2|RC4|IDEA|MD5"
      obsoleted_ciphers="00,2F, 00,30, 00,31, 00,32, 00,33, 00,35, 00,36, 00,37, 00,38, 00,39, 00,3C, 00,3D, 00,3E, 00,3F, 00,40, 00,41, 00,42, 00,43, 00,44, 00,45, 00,67, 00,68, 00,69, 00,6A, 00,6B, 00,84, 00,85, 00,86, 00,87, 00,88, 00,8C, 00,8D, 00,90, 00,91, 00,94, 00,95, 00,96, 00,97, 00,98, 00,99, 00,9A, 00,AE, 00,AF, 00,B2, 00,B3, 00,B6, 00,B7, 00,BA, 00,BB, 00,BC, 00,BD, 00,BE, 00,C0, 00,C1, 00,C2, 00,C3, 00,C4, C0,04, C0,05, C0,09, C0,0A, C0,0E, C0,0F, C0,13, C0,14, C0,1D, C0,1E, C0,1F, C0,20, C0,21, C0,22, C0,23, C0,24, C0,25, C0,26, C0,27, C0,28, C0,29, C0,2A, C0,35, C0,36, C0,37, C0,38, C0,3C, C0,3D, C0,3E, C0,3F, C0,40, C0,41, C0,42, C0,43, C0,44, C0,45, C0,48, C0,49, C0,4A, C0,4B, C0,4C, C0,4D, C0,4E, C0,4F, C0,64, C0,65, C0,66, C0,67, C0,68, C0,69, C0,70, C0,71, C0,72, C0,73, C0,74, C0,75, C0,76, C0,77, C0,78, C0,79, C0,94, C0,95, C0,96, C0,97, C0,98, C0,99, C0,9A, C0,9B"
      # Workaround: If we use sockets and in order not to hit 131+1 ciphers we omit the GOST ciphers if SERVER_SIZE_LIMIT_BUG is true.
      # This won't be supported by Cisco ACE anyway.
@@ -6149,11 +6149,11 @@ run_cipherlists() {
      obsoleted_ciphers="${obsoleted_ciphers}, 00,FF"
 
      ossl_good_ciphers='AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kEECDH:!kEDH:!kDHE:!kDHEPSK:!kECDHEPSK:!aNULL'
-     # grep AEAD etc/cipher-mapping.txt | egrep -v 'Au=None|TLS_ECDHE|TLS_DHE|TLS_PSK_DHE|TLSv1.3'
+     # grep AEAD etc/cipher-mapping.txt | grep -Ev 'Au=None|TLS_ECDHE|TLS_DHE|TLS_PSK_DHE|TLSv1.3'
      good_ciphers="00,9C, 00,9D, 00,A0, 00,A1, 00,A4, 00,A5, 00,A8, 00,A9, 00,AC, 00,AD, C0,2D, C0,2E, C0,31, C0,32, C0,50, C0,51, C0,54, C0,55, C0,58, C0,59, C0,5E, C0,5F, C0,62, C0,63, C0,6A, C0,6B, C0,6E, C0,6F, C0,7A, C0,7B, C0,7E, C0,7F, C0,82, C0,83, C0,88, C0,89, C0,8C, C0,8D, C0,8E, C0,8F, C0,92, C0,93, C0,9C, C0,9D, C0,A0, C0,A1, C0,A4, C0,A5, C0,A8, C0,A9, CC,AB, CC,AE, 00,FF"
 
      ossl_strong_ciphers='AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kPSK:!kRSAPSK:!kRSA:!kDH:!kECDH:!aNULL'
-     # grep AEAD etc/cipher-mapping.txt | egrep 'TLS_ECDHE|TLS_DHE|TLS_PSK_DHE|TLSv1.3'
+     # grep AEAD etc/cipher-mapping.txt | grep -E 'TLS_ECDHE|TLS_DHE|TLS_PSK_DHE|TLSv1.3'
      strong_ciphers="00,9E, 00,9F, 00,A2, 00,A3, 00,AA, 00,AB, 13,01, 13,02, 13,03, 13,04, 13,05, 16,B7, 16,B8, 16,B9, 16,BA, C0,2B, C0,2C, C0,2F, C0,30, C0,52, C0,53, C0,56, C0,57, C0,5C, C0,5D, C0,60, C0,61, C0,6C, C0,6D, C0,7C, C0,7D, C0,80, C0,81, C0,86, C0,87, C0,8A, C0,8B, C0,90, C0,91, C0,9E, C0,9F, C0,A2, C0,A3, C0,A6, C0,A7, C0,AA, C0,AB, C0,AC, C0,AD, C0,AE, C0,AF, CC,13, CC,14, CC,15, CC,A8, CC,A9, CC,AA, CC,AC, CC,AD, 00,FF"
 
      # argv[1]: non-TLSv1.3 cipher list to test in OpenSSL syntax

--- a/utils/ccs-injection.bash
+++ b/utils/ccs-injection.bash
@@ -181,7 +181,7 @@ starttls_line0() {
      debugme echo "... received result: "
      cat $reply
      if [ -n "$2" ]; then
-          if egrep -q "$2" $reply; then
+          if grep -Eq "$2" $reply; then
                debugme echo "---> reply matched \"$2\""
                [ $DEBUG -eq 0 ] && rm $reply
                return 0

--- a/utils/checkcert.sh
+++ b/utils/checkcert.sh
@@ -297,8 +297,8 @@ check_revocation() {
 	openssl ocsp $CA_BUNDLE_CMD $addissuer -cert $TMPDIR/level$1.crt -url $ocsp_uri -header HOST $ocsp_hostheader &>$TMPDIR/ocsp-response$1.txt
 
 #tmpdir_escaped=`echo $TMPDIR | sed 's/\//\\\//g'`
-#cat $TMPDIR/ocsp-response.txt | egrep -v "^WARNING: no nonce|^Response Verify Failure|OCSP_basic_verify" | sed 's/'"${tmpdir_escaped}"'//'
-	cat $TMPDIR/ocsp-response$1.txt | egrep -v "^WARNING: no nonce|^Response Verify Failure|OCSP_basic_verify" | sed 's/^.*level/level/'
+#cat $TMPDIR/ocsp-response.txt | grep -Ev "^WARNING: no nonce|^Response Verify Failure|OCSP_basic_verify" | sed 's/'"${tmpdir_escaped}"'//'
+	cat $TMPDIR/ocsp-response$1.txt | grep -Ev "^WARNING: no nonce|^Response Verify Failure|OCSP_basic_verify" | sed 's/^.*level/level/'
 	if grep -q "level$1.crt.*good" $TMPDIR/ocsp-response$1.txt ; then
 		green "not revoked (OK)\c" 
 	else

--- a/utils/heartbleed.bash
+++ b/utils/heartbleed.bash
@@ -159,7 +159,7 @@ starttls_line0() {
      debugme echo "... received result: "
      cat $reply
      if [ -n "$2" ]; then
-          if egrep -q "$2" $reply; then
+          if grep -Eq "$2" $reply; then
                debugme echo "---> reply matched \"$2\""
                [ $DEBUG -eq 0 ] && rm $reply
                return 0 

--- a/utils/resume.sh
+++ b/utils/resume.sh
@@ -9,13 +9,13 @@ echo "####################### session ID ######################"
 openssl s_client -connect $1:443 -servername $1 -bugs -no_ssl2 -no_ticket -sess_out /tmp/ssl_s </dev/null &>/dev/null
 
 echo "--------------------------------------------------------"
-openssl s_client -connect $1:443 -servername $1 -bugs -no_ssl2 -no_ticket -sess_in /tmp/ssl_s </dev/null 2>/dev/null | egrep "New|Reused|SSL handshake has read"
+openssl s_client -connect $1:443 -servername $1 -bugs -no_ssl2 -no_ticket -sess_in /tmp/ssl_s </dev/null 2>/dev/null | grep -E "New|Reused|SSL handshake has read"
 echo "--------------------------------------------------------"
 
 echo "####################### session ticket ######################"
 openssl s_client -connect $1:443 -servername $1 -bugs -no_ssl2 -sess_out /tmp/ssl_s </dev/null &>/dev/null
 echo "--------------------------------------------------------"
-openssl s_client -connect $1:443 -servername $1 -bugs -no_ssl2 -sess_in /tmp/ssl_s  </dev/null 2>/dev/null| egrep "New|Reused|SSL handshake has read"
+openssl s_client -connect $1:443 -servername $1 -bugs -no_ssl2 -sess_in /tmp/ssl_s  </dev/null 2>/dev/null | grep -E "New|Reused|SSL handshake has read"
 
 echo
 


### PR DESCRIPTION
`egrep` is deprecated and latest GNU grep emits a warning message when invoking `egrep`