### PR TITLE
Fix alignment in neat_list()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3568,6 +3568,7 @@ neat_list(){
      local how2show="$6"
 
      kx="${3//Kx=/}"
+     kx="$(strip_trailing_space "$kx")"
      enc="${4//Enc=/}"
      # In two cases LibreSSL uses very long names for encryption algorithms
      # and doesn't include the number of bits.


### PR DESCRIPTION
When `neat_list()` is printing information about a cipher suite that uses (EC)DH key exchange where the information was obtained using an old version of OpenSSL (one for which $HAS_DH_BITS is false) the rows are not properly aligned, since the key exchange input includes an unexpected trailing space. This PR fixes the problem by removing any trailing spaces from $kx.