### PR TITLE
 Fix grep 3.8 warnings on unneeded escapes of hyphen, slash, space.

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2405,7 +2405,7 @@ match_httpheader_key() {
           pr_svrty_medium " ${nr}x"
           outln " -- checking first one only"
           out "$spaces"
-          HEADERVALUE="$(fgrep -Fai "$key:" $HEADERFILE | head -1)"
+          HEADERVALUE="$(grep -Fai "$key:" $HEADERFILE | head -1)"
           HEADERVALUE="${HEADERVALUE#*:}"
           HEADERVALUE="$(strip_lf "$HEADERVALUE")"
           HEADERVALUE="$(strip_leading_space "$HEADERVALUE")"

--- a/testssl.sh
+++ b/testssl.sh
@@ -1765,7 +1765,7 @@ check_revocation_crl() {
           fileout "$jsonID" "WARN" "conversion of CRL to PEM format failed"
           return 1
      fi
-     if grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TEMPDIR/intermediatecerts.pem; then
+     if grep -qe "-----BEGIN CERTIFICATE-----" $TEMPDIR/intermediatecerts.pem; then
           $OPENSSL verify -crl_check -CAfile <(cat $ADDITIONAL_CA_FILES "$GOOD_CA_BUNDLE" "${tmpfile%%.crl}.pem") -untrusted $TEMPDIR/intermediatecerts.pem $HOSTCERT &> "${tmpfile%%.crl}.err"
      else
           $OPENSSL verify -crl_check -CAfile <(cat $ADDITIONAL_CA_FILES "$GOOD_CA_BUNDLE" "${tmpfile%%.crl}.pem") $HOSTCERT &> "${tmpfile%%.crl}.err"
@@ -1813,7 +1813,7 @@ check_revocation_ocsp() {
           fileout "$jsonID" "WARN" "Revocation not tested as openssl ocsp doesn't support a proxy"
           return 0
      fi
-     grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TEMPDIR/intermediatecerts.pem || return 0
+     grep -qe "-----BEGIN CERTIFICATE-----" $TEMPDIR/intermediatecerts.pem || return 0
      tmpfile=$TEMPDIR/${NODE}-${NODEIP}.${uri##*\/} || exit $ERR_FCREATE
      if [[ -n "$stapled_response" ]]; then
           asciihex_to_binary "$stapled_response" > "$TEMPDIR/stapled_ocsp_response.dd"
@@ -2078,7 +2078,7 @@ service_detection() {
           printf "$GET_REQ11" | $OPENSSL s_client $(s_client_options "$1 -quiet $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>$ERRFILE &
           wait_kill $! $HEADER_MAXSLEEP
           was_killed=$?
-          head $TMPFILE | grep -aq '^HTTP\/' && SERVICE=HTTP
+          head $TMPFILE | grep -aq '^HTTP/' && SERVICE=HTTP
           [[ -z "$SERVICE" ]] && head $TMPFILE | grep -waq "SMTP|ESMTP|Exim|IdeaSmtpServer|Kerio Connect|Postfix" && SERVICE=SMTP   # I know some overlap here
           [[ -z "$SERVICE" ]] && head $TMPFILE | grep -Ewaq "POP|Gpop|MailEnable POP3 Server|OK Dovecot|Cyrus POP3" && SERVICE=POP  # I know some overlap here
           [[ -z "$SERVICE" ]] && head $TMPFILE | grep -Ewaq "IMAP|IMAP4|Cyrus IMAP4IMAP4rev1|IMAP4REV1|Gimap" && SERVICE=IMAP       # I know some overlap here
@@ -3620,7 +3620,7 @@ run_cipher_match(){
                               dhlen=$(read_dhbits_from_file "$TMPFILE" quiet)
                               kx[i]="${kx[i]} $dhlen"
                          fi
-                         "$SHOW_SIGALGO" && grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TMPFILE && \
+                         "$SHOW_SIGALGO" && grep -qe "-----BEGIN CERTIFICATE-----" $TMPFILE && \
                               sigalg[i]="$(read_sigalg_from_file "$TMPFILE")"
                     done
                done
@@ -3899,7 +3899,7 @@ run_allciphers() {
                          dhlen=$(read_dhbits_from_file "$TMPFILE" quiet)
                          kx[i]="${kx[i]} $dhlen"
                     fi
-                    "$SHOW_SIGALGO" && grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TMPFILE && \
+                    "$SHOW_SIGALGO" && grep -qe "-----BEGIN CERTIFICATE-----" $TMPFILE && \
                          sigalg[i]="$(read_sigalg_from_file "$TMPFILE")"
                done
           done
@@ -4183,7 +4183,7 @@ ciphers_by_strength() {
                                         dhlen=$(read_dhbits_from_file "$TMPFILE" quiet)
                                         kx[i]="${kx[i]} $dhlen"
                                    fi
-                                   "$SHOW_SIGALGO" && grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TMPFILE && \
+                                   "$SHOW_SIGALGO" && grep -qe "-----BEGIN CERTIFICATE-----" $TMPFILE && \
                                         sigalg[i]="$(read_sigalg_from_file "$TMPFILE")"
                               fi
                          fi
@@ -7040,7 +7040,7 @@ determine_trust() {
      local code
      local ca_bundles=""
      local spaces="                              "
-     local -i certificates_provided=1+$(grep -c "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TEMPDIR/intermediatecerts.pem)
+     local -i certificates_provided=1+$(grep -ce "-----BEGIN CERTIFICATE-----" $TEMPDIR/intermediatecerts.pem)
      local addtl_warning
 
      # If $json_postfix is not empty, then there is more than one certificate
@@ -8575,7 +8575,7 @@ certificate_info() {
      cnfinding=""
 
      if [[ -n "$sni_used" ]]; then
-          if grep -q "\-\-\-\-\-BEGIN" "$HOSTCERT.nosni"; then
+          if grep -qe "-----BEGIN" "$HOSTCERT.nosni"; then
                cn_nosni="$(get_cn_from_cert "$HOSTCERT.nosni")"
                [[ -z "$cn_nosni" ]] && cn_nosni="no CN field in subject"
           fi
@@ -8944,7 +8944,7 @@ certificate_info() {
           fileout "cert_validityPeriod${json_postfix}" "INFO" "No finding"
      fi
 
-     certificates_provided=1+$(grep -c "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TEMPDIR/intermediatecerts.pem)
+     certificates_provided=1+$(grep -ce "-----BEGIN CERTIFICATE-----" $TEMPDIR/intermediatecerts.pem)
      out "$indent"; pr_bold " # of certificates provided"; out "   $certificates_provided"
      fileout "certs_countServer${json_postfix}" "INFO" "${certificates_provided}"
      if "$certificate_list_ordering_problem"; then
@@ -9729,7 +9729,7 @@ run_pfs() {
                          dhlen=$(read_dhbits_from_file "$TMPFILE" quiet)
                          kx[i]="${kx[i]} $dhlen"
                     fi
-                    "$WIDE" && "$SHOW_SIGALGO" && grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TMPFILE && \
+                    "$WIDE" && "$SHOW_SIGALGO" && grep -qe "-----BEGIN CERTIFICATE-----" $TMPFILE && \
                          sigalg[i]="$(read_sigalg_from_file "$TMPFILE")"
                done
           done
@@ -11234,7 +11234,7 @@ derive-handshake-traffic-keys() {
      [[ ! -s "$pub_file" ]] && return 1
 
      priv_file="$(mktemp "$TEMPDIR/privkey.XXXXXX")" || return 7
-     if grep -q "\-\-\-\-\-BEGIN EC PARAMETERS" "$tmpfile"; then
+     if grep -qe "-----BEGIN EC PARAMETERS" "$tmpfile"; then
           awk '/-----BEGIN EC PARAMETERS/,/-----END EC PRIVATE KEY/ { print $0 }' \
                "$tmpfile" > "$priv_file"
      else
@@ -15884,7 +15884,7 @@ run_beast(){
                     dhlen=$(read_dhbits_from_file "$TMPFILE" quiet)
                     kx[i]="${kx[i]} $dhlen"
                fi
-               "$WIDE" && "$SHOW_SIGALGO" && grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TMPFILE && \
+               "$WIDE" && "$SHOW_SIGALGO" && grep -qe "-----BEGIN CERTIFICATE-----" $TMPFILE && \
                     sigalg[i]="$(read_sigalg_from_file "$TMPFILE")"
           done
           if "$using_sockets"; then
@@ -16239,7 +16239,7 @@ run_rc4() {
                     dhlen=$(read_dhbits_from_file "$TMPFILE" quiet)
                     kx[i]="${kx[i]} $dhlen"
                fi
-               "$WIDE" && "$SHOW_SIGALGO" && grep -q "\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-" $TMPFILE && \
+               "$WIDE" && "$SHOW_SIGALGO" && grep -qe "-----BEGIN CERTIFICATE-----" $TMPFILE && \
                     sigalg[i]="$(read_sigalg_from_file "$TMPFILE")"
           done
      done
@@ -17227,11 +17227,11 @@ find_openssl_binary() {
      # For the following we feel safe enough to query the s_client help functions.
      # That was not good enough for the previous lookups
      $OPENSSL s_client -help 2>$s_client_has
-     grep -qw '\-alpn' $s_client_has && HAS_ALPN=true
-     grep -qw '\-nextprotoneg' $s_client_has &&  HAS_NPN=true
-     grep -qw '\-fallback_scsv' $s_client_has && HAS_FALLBACK_SCSV=true
-     grep -q '\-proxy' $s_client_has && HAS_PROXY=true
-     grep -q '\-xmpp' $s_client_has && HAS_XMPP=true
+     grep -qwe '-alpn' $s_client_has && HAS_ALPN=true
+     grep -qwe '-nextprotoneg' $s_client_has &&  HAS_NPN=true
+     grep -qwe '-fallback_scsv' $s_client_has && HAS_FALLBACK_SCSV=true
+     grep -qe '-proxy' $s_client_has && HAS_PROXY=true
+     grep -qe '-xmpp' $s_client_has && HAS_XMPP=true
 
      $OPENSSL s_client -starttls foo </dev/null 2>$s_client_starttls_has
      grep -q 'postgres' $s_client_starttls_has && HAS_POSTGRES=true
@@ -18037,7 +18037,7 @@ check_resolver_bins() {
      fi
      if "$HAS_DIG"; then
           # Old dig versions don't have an option to ignore $HOME/.digrc
-          if ! dig -h | grep -qE '\-r.*~/.digrc'; then
+          if ! dig -h | grep -qEe '-r.*~/.digrc'; then
                HAS_DIG_R=false
                DIG_R=""
           fi
@@ -19216,7 +19216,7 @@ nmap_to_plain_file() {
      if [[ "$(head -1 "$FNAME")" =~ ( -oG )(.*) ]] || [[ "$(head -1 "$FNAME")" =~ ( -oA )(.*) ]] ; then
           # yes, greppable
           if [[ $(grep -c Status "$FNAME") -ge 1 ]]; then
-               [[ $(grep -c  '\/open\/' "$FNAME")  -eq 0 ]] && \
+               [[ $(grep -c  '/open/' "$FNAME")  -eq 0 ]] && \
                     fatal "Nmap file $FNAME should contain at least one open port" $ERR_FNAMEPARSE
           else
                fatal "strange, nmap grepable misses \"Status\"" -1


### PR DESCRIPTION
Use -e where needed to avoid confusion of expression as arguments.

Backport of https://github.com/drwetter/testssl.sh/pull/2242, fixes https://github.com/drwetter/testssl.sh/issues/2241.

Fix an invocation of fgrep as well (`fgrep` = `grep -F`).