### PR TITLE
Fix infinite loop in run_fs()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10557,7 +10557,12 @@ run_fs() {
                               fi
                          fi
                     done
-                    [[ -z "$ciphers_to_test" ]] && [[ -z "$tls13_ciphers_to_test" ]] && break
+                    if "$HAS_TLS13"; then
+                         [[ "$proto" == -no_ssl2 ]] && [[ -z "$tls13_ciphers_to_test" ]] && break
+                         [[ "$proto" =~ -no_tls1_3 ]] && [[ -z "$ciphers_to_test" ]] && break
+                    else
+                         [[ -z "$ciphers_to_test" ]] && break
+                    fi
                     if [[ "$proto" =~ curves1 ]]; then
                          curves_option="-curves $curves_list1"
                     elif [[ "$proto" =~ curves2 ]]; then


### PR DESCRIPTION
This PR fixes an infinite loop in `run_fs()` that occurs in cases in which $OPENSSL supports TLS 1.3 and the server supports all of the non-TLS 1.3 FS ciphers that $OPENSSL supports but not all of the TLS 1.3 ciphers that $OPENSSL supports.

The problem is that testing for supported ciphers using $OPENSSL, testing should stop if there are no more ciphers to test (because all of the ciphers supported by $OPENSSL have been determined to be supported by the server). However, currently testing only stops if both the list of TLS 1.3 ciphers and non-TLS 1.3 ciphers is empty. In the problematic case, only the list of non-TLS 1.3 ciphers is empty. Instead of stopping, `s_client_options()` is called with a `-cipher` option with an empty list, and `s_client_options()` simply removes the `-cipher` option from the command, resulting in a call to $OPENSSL s_client with a full list of non-TLS 1.3 ciphers. Since this call succeeds, the loop continues.

This PR fixes the problem by stopping TLS 1.3 ClientHello testing when the list of TLS 1.3 ciphers is empty and stopping non-TLS 1.3 ClientHello testing when the list of non-TLS 1.3 ciphers is empty.