### PR TITLE
Fix #2249

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8918,7 +8918,7 @@ certificate_info() {
      out "$indent" ; pr_bold " Signature Algorithm          "
      jsonID="cert_signatureAlgorithm"
      case $cert_sig_algo in
-          sha1WithRSAEncryption)
+          sha1WithRSA|sha1WithRSAEncryption)
                pr_svrty_medium "SHA1 with RSA"
                if [[ "$SERVICE" == HTTP ]] || "$ASSUME_HTTP"; then
                     out " -- besides: users will receive a "; pr_svrty_high "strong browser WARNING"


### PR DESCRIPTION
This commit fixes #2249 by recognizing "sha1WithRSA" synonym for "sha1WithRSAEncryption."

OpenSSL uses "sha1WithRSAEncryption" to represent 1.2.840.113549.1.1.5 and "sha1WithRSA" to represent 1.3.14.3.2.29. While 1.2.840.113549.1.1.5 is generally recognized as the "standard" OID for RSA with SHA-1 (see, for example, [RFC 3279](https://www.rfc-editor.org/rfc/rfc3279.html)), 1.3.14.3.2.29 has been used in some places as well (https://codereview.chromium.org/1223763002, https://bugzilla.mozilla.org/show_bug.cgi?id=1042479, https://github.com/pyca/cryptography/issues/3160).