### PR TITLE
Fix #2271

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17998,7 +17998,7 @@ run_drown() {
      # to $CERT_FINGERPRINT_SHA2, so if $CERT_FINGERPRINT_SHA2 is not empty, but
      # $RSA_CERT_FINGERPRINT_SHA2 is empty, then the server doesn't have an RSA certificate.
      if [[ -z "$CERT_FINGERPRINT_SHA2" ]]; then
-          get_host_cert "-cipher aRSA"
+          get_host_cert "-cipher aRSA -no_ssl2"
           [[ $? -eq 0 ]] && cert_fingerprint_sha2="$($OPENSSL x509 -noout -in $HOSTCERT -fingerprint -sha256 2>>$ERRFILE | sed -e 's/^.*Fingerprint=//' -e 's/://g' )"
      else
           cert_fingerprint_sha2="$RSA_CERT_FINGERPRINT_SHA2"


### PR DESCRIPTION
This PR fixes #2271 by adding the `-no_ssl2` option to the call to `get_host_cert()` in `run_drown()`. There is at least one server that causes OpenSSL to hang if this call to get_host_cert() results in an SSLv2 ClientHello being sent. Since this call to `get_host_cert()` only needs to find the server's certificate in cases in which the server does not support SSLv2, there is no need to send an SSLv2 ClientHello.