### PR TITLE
Add --abort-no-tls switch

### DIFF
--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -152,6 +152,7 @@ in `/etc/hosts`.  The use of the switch is only useful if you either can't or ar
 
 `--add-ca <CAfile>` enables you to add your own CA(s) in PEM format for trust chain checks. `CAfile` can be a directory containing files with a \.pem extension, a single file or multiple files as a comma separated list of root CAs. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates are issued by internal CAs. Alternatively ADDTL_CA_FILES is the environment variable for this.
 
+`--abort-no-tls` is a switch which cause testssl to abort on the first sign, that the target does not use TLS/SSL.
 
 ### SINGLE CHECK OPTIONS
 


### PR DESCRIPTION
When used in automated pipelines, processing output from other tools with testssl might cause a halt of the whole pipeline if the previous output is detected false positive as TLS/SSL enabled Server.

Enabling this switch will cause testssl to return ALLOK after the first sign, that TLS/SSL is not enabled on the server.