### PR TITLE
Allow DNS via Proxy

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -196,7 +196,7 @@ TESTSSL_INSTALL_DIR="${TESTSSL_INSTALL_DIR:-""}"  # If you run testssl.sh and it
 CA_BUNDLES_PATH="${CA_BUNDLES_PATH:-""}"          # You can have your CA stores some place else
 EXPERIMENTAL=${EXPERIMENTAL:-false}     # a development hook which allows us to disable code
 PROXY_WAIT=${PROXY_WAIT:-20}            # waiting at max 20 seconds for socket reply through proxy
-DNS_VIA_PROXY=${DNS_VIA_PROXY:-true}    # do DNS lookups via proxy. --ip=proxy reverses this
+DNS_VIA_PROXY=${DNS_VIA_PROXY:-false}   # do DNS lookups via proxy. --ip=proxy reverses this
 IGN_OCSP_PROXY=${IGN_OCSP_PROXY:-false} # Also when --proxy is supplied it is ignored when testing for revocation via OCSP via --phone-out
 HEADER_MAXSLEEP=${HEADER_MAXSLEEP:-5}   # we wait this long before killing the process to retrieve a service banner / http header
 MAX_SOCKET_FAIL=${MAX_SOCKET_FAIL:-2}   # If this many failures for TCP socket connects are reached we terminate
@@ -22014,12 +22014,19 @@ display_rdns_etc() {
 
 datebanner() {
      local scan_time_f=""
+     local node_banner=""
+     
+     if [[ -n "PROXY" ]] && $DNS_VIA_PROXY;then
+     			node_banner="$NODE:$PORT"
+     else
+     			node_banner="$NODEIP:$PORT ($NODE)"
+     fi
 
      if [[ "$1" =~ Done ]] ; then
           scan_time_f="$(printf "%04ss" "$SCAN_TIME")"           # 4 digits because of windows
-          pr_reverse "$1 $(date +%F) $(date +%T) [$scan_time_f] -->> $NODEIP:$PORT ($NODE) <<--"
+          pr_reverse "$1 $(date +%F) $(date +%T) [$scan_time_f] -->> $node_banner <<--"
      else
-          pr_reverse "$1 $(date +%F) $(date +%T)        -->> $NODEIP:$PORT ($NODE) <<--"
+          pr_reverse "$1 $(date +%F) $(date +%T)        -->> $node_banner <<--"
      fi
      outln "\n"
      [[ "$1" =~ Start ]] && display_rdns_etc
@@ -23735,7 +23742,6 @@ lets_roll() {
      fi
      stopwatch initialized
 
-     [[ -z "$NODEIP" ]] && fatal "$NODE doesn't resolve to an IP address" $ERR_DNSLOOKUP
      nodeip_to_proper_ip6
      reset_hostdepended_vars
      determine_rdns                # Returns always zero or has already exited if fatal error occurred
@@ -23744,7 +23750,7 @@ lets_roll() {
      ((SERVER_COUNTER++))
      datebanner " Start"
      determine_service "$1"        # STARTTLS service? Other will be determined here too. Returns 0 if test connect was ok or has already exited if fatal error occurred
-                                   # determine_service() can return 1, it indicates that this IP cannot be reached but there are more IPs to check
+                                   # determine_service() can return 1, it indicates that this IP cannot be reached but there are more IPs to check    
      if [[ $? -eq 0 ]] ; then
           # "secret" devel options --devel:
           if "$do_tls_sockets"; then
@@ -23938,26 +23944,30 @@ lets_roll() {
      [[ -z "$NODE" ]] && parse_hn_port "${URI}"        # NODE, URL_PATH, PORT, IPADDRs and IP46ADDR is set now
      prepare_logging
 
-     if ! determine_ip_addresses; then
-          fatal "No IP address could be determined" $ERR_DNSLOOKUP
-     fi
-     if [[ $(count_words "$IPADDRs") -gt 1 ]]; then    # we have more than one ipv4 address to check
-          MULTIPLE_CHECKS=true
-          pr_bold "Testing all IPv4 addresses (port $PORT): "; outln "$IPADDRs"
-          for ip in $IPADDRs; do
-               draw_line "-" $((TERM_WIDTH * 2 / 3))
-               outln
-               NODEIP="$ip"
-               lets_roll "${STARTTLS_PROTOCOL}"
-               RET=$((RET + $?))                       # RET value per IP address
-          done
-          draw_line "-" $((TERM_WIDTH * 2 / 3))
-          outln
-          pr_bold "Done testing now all IP addresses (on port $PORT): "; outln "$IPADDRs"
-     else                                              # Just 1x ip4v to check, applies also if CMDLINE_IP was supplied
-          NODEIP="$IPADDRs"
-          lets_roll "${STARTTLS_PROTOCOL}"
-          RET=$?
-     fi
+		 if [[ -n "$PROXY" ]] && $DNS_VIA_PROXY; then
+			    NODEIP="$NODE"
+		      lets_roll "${STARTTLS_PROTOCOL}"
+		      RET=$?	 		
+		 else
+				  determine_ip_addresses
+				  if [[ $(count_words "$IPADDRs") -gt 1 ]]; then    # we have more than one ipv4 address to check
+				      MULTIPLE_CHECKS=true
+				      pr_bold "Testing all IPv4 addresses (port $PORT): "; outln "$IPADDRs"
+				      for ip in $IPADDRs; do
+				           draw_line "-" $((TERM_WIDTH * 2 / 3))
+				           outln
+				           NODEIP="$ip"
+				           lets_roll "${STARTTLS_PROTOCOL}"
+				           RET=$((RET + $?))                       # RET value per IP address
+				      done
+				      draw_line "-" $((TERM_WIDTH * 2 / 3))
+				      outln
+				      pr_bold "Done testing now all IP addresses (on port $PORT): "; outln "$IPADDRs"
+				  else                                              # Just 1x ip4v to check, applies also if CMDLINE_IP was supplied
+				      NODEIP="$IPADDRs"
+				      lets_roll "${STARTTLS_PROTOCOL}"
+				      RET=$?
+				  fi	
+		 fi
 
 exit $RET


### PR DESCRIPTION
The current version of the script returns an error when it not possible to determine IP addresses through DNS resolution, even if **--proxy** and **--ip=proxy** flags are set. The main function always tries to determine IP addresses via DNS and exits with a fatal error if it cannot do it. Although the client cannot get the IP, the proxy could, so the SSL/TLS analysis is still possible.

The version proposed allows the analysis for an HTTP service via a proxy server and the DNS traffic can be sent directly or through the proxy using the flag **--ip=proxy**. 