### PR TITLE
Fix broken HTML entities in html output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -535,11 +535,11 @@ html_reserved(){
      local output
      "$do_html" || return 0
      #sed  -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g" <<< "$1"
-     output="${1//&/&amp;}"
-     output="${output//</&lt;}"
-     output="${output//>/&gt;}"
-     output="${output//\"/&quot;}"
-     output="${output//\'/&apos;}"
+     output="${1//&/\&amp;}"
+     output="${output//</\&lt;}"
+     output="${output//>/\&gt;}"
+     output="${output//\"/\&quot;}"
+     output="${output//\'/\&apos;}"
      printf -- "%s" "$output"
      return 0
 }


### PR DESCRIPTION
 * Output is missing the & in the html entities leading to incorrect display.

The `--html` flag currently produces html output with broken HTML entities

``` html
<span style="color:white;background-color:black;"> Start 2023-01-31 10:40:32        -->gt;>gt; 192.0.2.123:443 (example.com) <lt;<lt;--</span>
```

The patch fixes this for me

``` html
<span style="color:white;background-color:black;"> Start 2023-01-31 10:51:37        --&gt;&gt; 192.0.2.123:443 (example.com) &lt;&lt;--</span>
```
