### PR TITLE
refactor: Revise `Dockerfile`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,11 @@
+# Exclude everything from the Docker build context:
+*
+
+# Except for this content:
+!bin/
+!etc/
+!testssl.sh
+
+# But additionally exclude this nested content:
 bin/openssl.Darwin.*
 bin/openssl.FreeBSD.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 RUN apk update && \
     apk upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.17
 
 RUN <<EOF
-  apk --no-cache --upgrade add bash procps drill git coreutils libidn curl socat openssl xxd
+  apk --no-cache --upgrade add bash procps coreutils drill libidn curl socat openssl openssl1.1-compat xxd
 
   # Create testssl user (and group) with no password (-D) and default shell to bash (-s):
   adduser -D -s /bin/bash testssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
+# syntax=docker.io/docker/dockerfile:1
 FROM alpine:3.17
 
-RUN apk update && \
-    apk upgrade && \
-    apk add bash procps drill git coreutils libidn curl socat openssl xxd && \
-    rm -rf /var/cache/apk/* && \
-    addgroup testssl && \
-    adduser -G testssl -g "testssl user" -s /bin/bash -D testssl && \
-    ln -s /home/testssl/testssl.sh /usr/local/bin/ && \
-    mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
+RUN <<EOF
+  apk update
+  apk upgrade
+  apk add bash procps drill git coreutils libidn curl socat openssl xxd
+  rm -rf /var/cache/apk/*
+  addgroup testssl
+  adduser -G testssl -g "testssl user" -s /bin/bash -D testssl
+  ln -s /home/testssl/testssl.sh /usr/local/bin/
+  mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
+EOF
 
 USER testssl
 WORKDIR /home/testssl/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@
 FROM alpine:3.17
 
 RUN <<EOF
-  apk update
-  apk upgrade
-  apk add bash procps drill git coreutils libidn curl socat openssl xxd
-  rm -rf /var/cache/apk/*
+  apk --no-cache --upgrade add bash procps drill git coreutils libidn curl socat openssl xxd
+
   addgroup testssl
   adduser -G testssl -g "testssl user" -s /bin/bash -D testssl
   ln -s /home/testssl/testssl.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN <<EOF
   adduser -D -s /bin/bash testssl
 
   ln -s /home/testssl/testssl.sh /usr/local/bin/
-  mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
 EOF
 
 USER testssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ EOF
 USER testssl
 WORKDIR /home/testssl/
 
-COPY --chown=testssl:testssl etc/. /home/testssl/etc/
-COPY --chown=testssl:testssl bin/. /home/testssl/bin/
-COPY --chown=testssl:testssl testssl.sh /home/testssl/
+# Copy over build context (after filtered by .dockerignore): bin/ etc/ testssl.sh
+COPY --chown=testssl . /home/testssl/
 
 ENTRYPOINT ["testssl.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ FROM alpine:3.17
 RUN <<EOF
   apk --no-cache --upgrade add bash procps drill git coreutils libidn curl socat openssl xxd
 
-  addgroup testssl
-  adduser -G testssl -g "testssl user" -s /bin/bash -D testssl
+  # Create testssl user (and group) with no password (-D) and default shell to bash (-s):
+  adduser -D -s /bin/bash testssl
+
   ln -s /home/testssl/testssl.sh /usr/local/bin/
   mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
 EOF


### PR DESCRIPTION
## Summary

PR motivated by discussion in https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1408253127

Beyond updating the base image version, I've submitted some improvements:
- I've reviewed the current Dockerfile and git history related to it (_detailed in later sections_).
- If you disagree with any particular changes they can be easily reverted due to scoped commits :+1: 
- The `RUN` is much simpler now. Using the HereDoc feature could be dropped if you prefer. [`docker-mailserver`](https://github.com/docker-mailserver/docker-mailserver/) has been using using since Oct 2022 without any problems with our user base (_most just use the built image we distribute - unless they're contributing, where our `Makefile` handles the `DOCKER_BUILDKIT=1` ENV_).
- Each change has been staged into separate commits with commit messages for added context. For your convenience these have been listed below in the next section :+1: 
- Image weight is now ~30MB or ~34MB with `openssl1.1-compat`.
  - Base image: 7MB
  - Packages (with `openssl1.1-compat`): 12.6MB
  - `COPY`: 14MB

---

## Commit Overview

- chore: Update Dockerfile base image from Alpine 3.16 to 3.17
- chore: Replace `RUN` chaining with `&& \` by using HereDoc feature
  [HereDoc (_with EOF marker_) feature](https://docs.docker.com/engine/reference/builder/#here-documents) avoids needing `&& \` requires BuildKit during build (_either `DOCKER_BUILDKIT=1 docker build` or by using `buildx`_).
- chore: Use a single `COPY` by better leveraging `.dockerignore` patterns
- chore: Collapse package install into single command
  - `--no-cache` implies `--update` (aka `apk update`) while not storing the cache to disk, so no need to manually cleanup the cache with `rm -rf` afterwards.
  - `--upgrade` updates existing dependencies of packages.
- chore: Simplify testssl user creation
  - A group will implicitly be created with the same value as the user. `addgroup testssl` and `-G testssl` are not needed.
  - Gecos data (`-g "testssl user"`) doesn't appear relevant to the project to be required? Default (`Linux User,,,`) should be fine.
  - With the HereDoc usage, an inline comment provides additional context.
- chore: Remove redundant `mkdir`
  If local folder ownership is for example `644` it will fail to handle the `COPY` regardless (while `744` would work). Creating the directory with higher permissions in the container does not appear to help.
- chore: Remove `git` (7MB) add `openssl1.1-compat` (4MB)
  - `git` isn't needed in the image.
  - Alpine 3.17 does a major version upgrade of OpenSSL to `3.x`, while keeping the `1.1.x` version may be beneficial? (_[can perform better](https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1409545691)_)

---

## Image history

Just for the benefit of not having to go through git history :)

- Docker image was originally Debian base, but [switched to Alpine in 2018](https://github.com/drwetter/testssl.sh/commit/cbe38cc4bba6004d3cfd07c58a39fe239453de9d) for a smaller file size (_performance can take a hit however due to `musl` instead of `glibc`_).

### Packages

- `drill` added for the DNS lookups with `libidn` included to support IDN (_Internationalized Domain Names_) [lookups with drill](https://github.com/drwetter/testssl.sh/pull/1326).
- `procps` [added for `ps`](https://github.com/drwetter/testssl.sh/commit/c7a0de1280c246e29f8ca4b805e505517f87cf35) (_commit from Debian base also dropped other DNS clients in favour of `drill`_).
- `socat` is also related to [supporting _"STARTTLS injection"_](https://github.com/drwetter/testssl.sh/commit/af5cad91837221abd67988b77c45416519d24dda#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) (_[full PR](https://github.com/drwetter/testssl.sh/pull/1810)_).
- `openssl` (_originally for `1.1.1g`_) was also [added to support _"STARTTLS injection"_](https://github.com/drwetter/testssl.sh/commit/4a167f6ac54984e2198139cf045a6baa58b844cf).
- `openssl1.1-compat` added in this PR itself, [was found to perform better](https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1409545691) than the newer `3.x` series (_introduced by Alpine 3.17_) which may matter for reducing CI / test feedback times. It can be used via `--openssl /usr/bin/openssl1.1`.
- `xxd` for [better performance and debugging support](https://github.com/drwetter/testssl.sh/pull/1862).
- `coreutils` (_approx 9MiB in weight_) to replace BusyBox packages, notably for [better supporting `date -d`](https://github.com/drwetter/testssl.sh/commit/d1f03801738c87b6af39372c45e048af78c73c09).
- `curl` [added for `--phone-out` checks](https://github.com/drwetter/testssl.sh/commit/a66f5cfdbcd93427f4408bdd8cfc336488c02bb8).

## Further consideration

The PR presently only covers the `3.1dev` branch `Dockerfile`. If you're happy with the proposed changes the `Dockerfile.git` can be updated and then an equivalent PR can be opened for `3.0` branch.

- `mkdir` was dropped as [despite original reasoning](https://github.com/drwetter/testssl.sh/issues/1559#issuecomment-625894351) with `750` permission and ownership, the `COPY --chown` ensures the `testssl` user is fine? 
- You may want to still run `apk upgrade` before `apk add`. Personally I'm not sure what the value of that is, since generally the base image should reflect the latest updates at the time of build.
  - Those updates are likewise only as good as when your image is built, so for example the `3.0` image was last built over 2 months ago. Chances are it's not helping much under that context?
  - Hence the decision to just upgrade only packages that are also dependencies of the new packages from `apk add` with [`--upgrade`](https://man.archlinux.org/man/apk-add.8.en).
  - For reference some official images discouraged / opt-ed out of upgrading packages due to the [risk of breaking software built and linked to earlier versions](https://github.com/docker-library/php/issues/1007#issuecomment-619150250) (_link also mentions `--no-cache` handles `apk update` + cleanup of cache_). At the time they reference official Docker docs backing that up as a best practice (_that stance [later changed for several reputable sources](https://github.com/grafana/grafana/issues/24132#issuecomment-827389019), but [they do not encourage upgrading packages either](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)_). 

### Removing the need for `Dockerfile.git` and simplifying CI maintenance

However, we can easily remove the `Dockerfile.git` for [simpler maintenance by using a multi-stage build](https://docs.docker.com/build/building/multi-stage/#use-multi-stage-builds). That can default to local `COPY`, or when building specifying an alternative target / ARG to get the files via git.

I have little information to go by the PR that introduced [the current approach beyond the PR](https://github.com/drwetter/testssl.sh/pull/1968) (_and [this commit](https://github.com/drwetter/testssl.sh/commit/4df60052af6d09df8e18c5db700cbb27bad18cbd) prior to a separate PR being raised that covers both branches / builds_). I'm a bit confused with the approach. You would ideally centralize your Github Actions into a single branch to keep maintenance simple.
- The `Dockerfile.git` appears to be only intended for serving this CI purpose? If so, you could just have the checkout action checkout the branch and `COPY` the files, making `Dockerfile.git` redundant. You could then have a single branch that **maintains a single `Dockerfile` only for builds**, not needing to keep it in sync across multiple branches if that appeals to you?
- `ARG ARCHIVE_URL` doesn't appear to be relevant or used for anything? I found nothing in the PR, or several search engine queries regarding it and the URL itself appears to be a dud?
- `git` package with an actual repo cloned was apparently [only for benefit of `git log` to provide a commit hash to display in the `testssl.sh` banner output](https://github.com/drwetter/testssl.sh/issues/1559#issuecomment-626153384)?. But that adds not only the weight of `git` package, but also some extra `bin/` files you usually exclude from the build. You can just extract this information during the CI build and supply it as a build ARG? I understand if you want to keep it simple as-is though.
- The `git` package could also be avoided via an [`ADD` instruction to pull in the same git content](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) if you're not going to remove any of it via `RUN`?
- Another option is to build the image with [git URL as the build context](https://docs.docker.com/build/building/context/):
  
  ```bash
  DOCKER_BUILDKIT=1 docker build -t testssl:pr https://github.com/drwetter/testssl.sh.git#3.1dev
  ```
  **NOTE:** If the `.dockerignore` is important, [the one in target remote git repo won't used](https://docs.docker.com/engine/reference/builder/#dockerignore-file). For the CI it wouldn't matter as you'd be checking out the repo and have a local `.dockerignore` file that does apply to the remote build context. Otherwise the extra `bin/` files are included like with `Dockerfile.git` already.