### PR TITLE
chore: Use a single `COPY` by better leveraging `.dockerignore` patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,11 @@
+# Exclude everything from the Docker build context:
+*
+
+# Except for this content:
+!bin/
+!etc/
+!testssl.sh
+
+# But additionally exclude this nested content:
 bin/openssl.Darwin.*
 bin/openssl.FreeBSD.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ USER testssl
 WORKDIR /home/testssl/
 
 # Copy over build context (after filtered by .dockerignore): bin/ etc/ testssl.sh
-COPY --chown=testssl . /home/testssl/
+COPY --chown=testssl:testssl . /home/testssl/
 
 ENTRYPOINT ["testssl.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ RUN apk update && \
 USER testssl
 WORKDIR /home/testssl/
 
-COPY --chown=testssl:testssl etc/. /home/testssl/etc/
-COPY --chown=testssl:testssl bin/. /home/testssl/bin/
-COPY --chown=testssl:testssl testssl.sh /home/testssl/
+# Copy over build context (after filtered by .dockerignore): bin/ etc/ testssl.sh
+COPY --chown=testssl . /home/testssl/
 
 ENTRYPOINT ["testssl.sh"]
 


### PR DESCRIPTION
Extracted from https://github.com/drwetter/testssl.sh/pull/2305 (_specifically [this commit](https://github.com/drwetter/testssl.sh/pull/2305/commits/f15ab97ebef21758737dced54baa05dd0942e58f)_)

- `--chown` can use a single value as both user and group.
- `.dockerignore` can better control what is available to the Docker build context.
- With the `.dockerignore` improvement, your Dockerfile can be a single `COPY`.
- Comments added to both files for additional context / documentation.