### PR TITLE
Feature Trustcor certificates being removed/disabled from root stores #2293

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9416,10 +9416,11 @@ certificate_info() {
 
      out "$indent"; pr_bold " Chain of trust"; out "               "
      jsonID="cert_chain_of_trust"
-     if [[ "$issuer_O" =~ StartCom ]] || [[ "$issuer_O" =~ WoSign ]] || [[ "$issuer_CN" =~ StartCom ]] || [[ "$issuer_CN" =~ WoSign ]]; then
-          # Shortcut for this special case here.
-          pr_italic "WoSign/StartCom"; out " are " ; prln_svrty_critical "not trusted anymore (NOT ok)"
-          fileout "${jsonID}${json_postfix}" "CRITICAL" "Issuer not trusted anymore (WoSign/StartCom)"
+     # Looks for CA's that have their trust removed by the first part of their Organization Name as they can only used verified names
+     if [[ "$issuer_O" =~ ^(TrustCor Systems|WoSign|StartCom) ]]; then
+          # Shortcut for this special case here. There is a difference between not being in a root store and being removed from a root store.
+          pr_italic "$issuer_O"; out " is " ; prln_svrty_critical "actively removed from one or more root stores (NOT ok)"
+          fileout "${jsonID}${json_postfix}" "CRITICAL" "Issuer removed from one or more root stores ($issuer_O)"
           set_grade_cap "T" "Untrusted certificate chain"
      else
           # Also handles fileout, keep error if happened

--- a/testssl.sh
+++ b/testssl.sh
@@ -9416,8 +9416,8 @@ certificate_info() {
 
      out "$indent"; pr_bold " Chain of trust"; out "               "
      jsonID="cert_chain_of_trust"
-     # Looks for CA's that have their trust removed by the first part of their Organization Name as they can only used verified names
-     if [[ "$issuer_O" =~ ^(TrustCor Systems|WoSign|StartCom) ]]; then
+     # Looks for CA's that have their trust removed by the first part of their Organization Name, add multiple with ^(TrustCor Systems|WoSign) etc.
+     if [[ "$issuer_O" =~ ^(TrustCor Systems) ]]; then
           # Shortcut for this special case here. There is a difference between not being in a root store and being removed from a root store.
           pr_italic "$issuer_O"; out " is " ; prln_svrty_critical "actively removed from one or more root stores (NOT ok)"
           fileout "${jsonID}${json_postfix}" "CRITICAL" "Issuer removed from one or more root stores ($issuer_O)"


### PR DESCRIPTION
To add feature TrustCor Certificate #2293 

Change exception for removed root certificates into easy edit multi-value regular expression for Organization name and making it clear that CA's are actively removed from 1+ root stores.

Organization is safer to search on, as it can only contain validated information, if more precise/alternative is needed hash would probably be better but more difficult to maintain.

Other CA's of interest all seem to have no more active certificates i.e. WoSign, DigiNotar, etc. so only TrustCor seems currently relevant.

An active certificate for testing can currently be found here: https://www.trustcor.ca