### PR TITLE
chore(Dockerfile): Simplify `testssl` user creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN apk update && \
     apk upgrade && \
     apk add bash procps drill git coreutils libidn curl socat openssl xxd && \
     rm -rf /var/cache/apk/* && \
-    addgroup testssl && \
-    adduser -G testssl -g "testssl user" -s /bin/bash -D testssl && \
+    adduser -D -s /bin/bash testssl && \
     ln -s /home/testssl/testssl.sh /usr/local/bin/ && \
     mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
 


### PR DESCRIPTION
Extracted from https://github.com/drwetter/testssl.sh/pull/2305 (_specifically [this commit](https://github.com/drwetter/testssl.sh/pull/2305/commits/77eba8d02626bb5c3c7a03b32ddee729837c50fe)_)

Create a `testssl` user (_and group_) with no password (`-D`) and default their shell to bash (`-s`):
- A group will implicitly be created with the same value as the user. `addgroup testssl` and `-G testssl` are not needed.
- Gecos data (`-g "testssl user"`) doesn't appear relevant to the project to be required? The default gecos value (`Linux User,,,`) should be fine.