### PR TITLE
chore: Remove redundant `mkdir`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apk update && \
     rm -rf /var/cache/apk/* && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user" -s /bin/bash -D testssl && \
-    ln -s /home/testssl/testssl.sh /usr/local/bin/ && \
-    mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
+    ln -s /home/testssl/testssl.sh /usr/local/bin/
 
 USER testssl
 WORKDIR /home/testssl/


### PR DESCRIPTION
Extracted from https://github.com/drwetter/testssl.sh/pull/2305 (_specifically [this commit](https://github.com/drwetter/testssl.sh/pull/2305/commits/a9d7551d8a7d2d732397d3d66064d403989e8d67)_)

- If local folder ownership is for example `644` it will fail to handle the `COPY` regardless (_while `744` would work_).
- `mkdir` with `755` permissions does not appear improve a situation when permissions are lower on the host?
- `COPY --chown=testssl` on these directories already ensures adequate permissions with `7xx`, as only the first octal is relevant to the content owner.
- [`mkdir` original reasoning](https://github.com/drwetter/testssl.sh/issues/1559#issuecomment-625894351) appears to be due to:
  > In my case the access rights for `testssl.sh` in the container weren't correct.
  > My dir it's `750`, I guess it will be copied over as `root` and executed as `testssl` user. That won't work (_can probably be changed though with `chmod` in `Dockerfile`_).