### PR TITLE
Update documentation for cipherlists tests

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -128,13 +128,15 @@ Any single check switch supplied as an argument prevents testssl\.sh from doing 
 .IP "\[ci]" 4
 \fBExport ciphers\fR (w/o the preceding ones): 'EXPORT:!ADH:!NULL'
 .IP "\[ci]" 4
-\fBLOW\fR (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'
+\fBLOW\fR (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:MD5:!ADH:!EXP:!NULL:!eNULL:!AECDH'
 .IP "\[ci]" 4
-\fB3DES + IDEA Ciphers\fR: '3DES:IDEA:!aNULL:!ADH'
+\fB3DES + IDEA ciphers\fR: '3DES:IDEA:!aNULL:!ADH:!MD5'
 .IP "\[ci]" 4
-\fBAverage grade Ciphers\fR: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'
+\fBObsoleted CBC ciphers\fR: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL:!MD5'
 .IP "\[ci]" 4
-\fBStrong grade Ciphers\fR (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM8:AESCCM'
+\fBStrong ciphers with no FS\fR (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kEECDH:!kEDH:!kDHE:!kDHEPSK:!kECDHEPSK:!aNULL'
+.IP "\[ci]" 4
+\fBForward Secrecy strong ciphers\fR (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kPSK:!kRSAPSK:!kRSA:!kDH:!kECDH:!aNULL'
 .IP "" 0
 .P
 \fB\-f, \-\-fs, \-\-nsa, \-\-forward\-secrecy\fR Checks robust forward secrecy key exchange\. "Robust" means that ciphers having intrinsic severe weaknesses like Null Authentication or Encryption, 3DES and RC4 won't be considered here\. There shouldn't be the wrong impression that a secure key exchange has been taking place and everything is fine when in reality the encryption sucks\. Also this section lists the available elliptical curves and Diffie Hellman groups, as well as FFDHE groups (TLS 1\.2 and TLS 1\.3)\.

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -247,13 +247,15 @@ in <code>/etc/hosts</code>.  The use of the switch is only useful if you either 
   <li>
 <code>Export ciphers</code> (w/o the preceding ones): 'EXPORT:!ADH:!NULL'</li>
   <li>
-<code>LOW</code> (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'</li>
+<code>LOW</code> (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:MD5:!ADH:!EXP:!NULL:!eNULL:!AECDH'</li>
   <li>
-<code>3DES + IDEA Ciphers</code>: '3DES:IDEA:!aNULL:!ADH'</li>
+<code>3DES + IDEA ciphers</code>: '3DES:IDEA:!aNULL:!ADH:!MD5'</li>
   <li>
-<code>Average grade Ciphers</code>: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'</li>
+<code>Obsoleted CBC ciphers</code>: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL:!MD5'</li>
   <li>
-<code>Strong grade Ciphers</code> (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM8:AESCCM'</li>
+<code>Strong ciphers with no FS</code> (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kEECDH:!kEDH:!kDHE:!kDHEPSK:!kECDHEPSK:!aNULL'</li>
+  <li>
+<code>Forward Secrecy strong ciphers</code> (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kPSK:!kRSAPSK:!kRSA:!kDH:!kECDH:!aNULL'</li>
 </ul>
 
 <p><code>-f, --fs, --nsa, --forward-secrecy</code> Checks robust forward secrecy key exchange. "Robust" means that ciphers having intrinsic severe weaknesses like Null Authentication or Encryption, 3DES and RC4 won't be considered here. There shouldn't be the wrong impression that a secure key exchange has been taking place and everything is fine when in reality the encryption sucks. Also this section lists the available elliptical curves and Diffie Hellman groups, as well as FFDHE groups (TLS 1.2 and TLS 1.3).</p>

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -166,10 +166,11 @@ Any single check switch supplied as an argument prevents testssl.sh from doing a
 * `NULL encryption ciphers`: 'NULL:eNULL'
 * `Anonymous NULL ciphers`: 'aNULL:ADH'
 * `Export ciphers` (w/o the preceding ones): 'EXPORT:!ADH:!NULL'
-* `LOW` (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:!ADH:!EXP:!NULL:!eNULL'
-* `3DES + IDEA Ciphers`: '3DES:IDEA:!aNULL:!ADH'
-* `Average grade Ciphers`: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL'
-* `Strong grade Ciphers` (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM8:AESCCM'
+* `LOW` (64 Bit + DES ciphers, without EXPORT ciphers): 'LOW:DES:RC2:RC4:MD5:!ADH:!EXP:!NULL:!eNULL:!AECDH'
+* `3DES + IDEA ciphers`: '3DES:IDEA:!aNULL:!ADH:!MD5'
+* `Obsoleted CBC ciphers`: 'HIGH:MEDIUM:AES:CAMELLIA:ARIA:!IDEA:!CHACHA20:!3DES:!RC2:!RC4:!AESCCM8:!AESCCM:!AESGCM:!ARIAGCM:!aNULL:!MD5'
+* `Strong ciphers with no FS` (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kEECDH:!kEDH:!kDHE:!kDHEPSK:!kECDHEPSK:!aNULL'
+* `Forward Secrecy strong ciphers` (AEAD): 'AESGCM:CHACHA20:CamelliaGCM:AESCCM:ARIAGCM:!kPSK:!kRSAPSK:!kRSA:!kDH:!kECDH:!aNULL'
 
 `-f, --fs, --nsa, --forward-secrecy` Checks robust forward secrecy key exchange. "Robust" means that ciphers having intrinsic severe weaknesses like Null Authentication or Encryption, 3DES and RC4 won't be considered here. There shouldn't be the wrong impression that a secure key exchange has been taking place and everything is fine when in reality the encryption sucks. Also this section lists the available elliptical curves and Diffie Hellman groups, as well as FFDHE groups (TLS 1.2 and TLS 1.3).
 


### PR DESCRIPTION
After reading #2289, I looked at the [documentation](https://github.com/drwetter/testssl.sh/tree/3.1dev/doc) and noticed that the description of the cipherlists tests had not been updated, even though the set of cipher lists checked by `run_cipherslists()` changed in 3.1dev. This PR changes the documentation to align with the tests in 3.1dev.

One issue that #2289 raises, however, is that the JSON output for these tests may not be clear. The table below shows the text description of each of the cipher list sets that is printed to the terminal along with the corresponding JSON identifier. For the first 5 sets the relationship should be fairly clear. However, the JSON IDs `AVERAGE`, `GOOD`, and `STRONG` are not clearly aligned with the strings that are printed to the terminal.

We could consider changing the JSON IDs, but at the least we should try to add something to the documentation indicating the JSON ID that corresponds to each of these lists of cipher suites.

| terminal string | JSON ID |
| ---------------------- | ----------- |
| NULL ciphers (no encryption) | NULL |
|Anonymous NULL Ciphers (no authentication) | aNULL |
| Export ciphers (w/o ADH+NULL) | EXPORT |
| LOW: 64 Bit + DES, RC[2,4], MD5 (w/o export)  | LOW |
| Triple DES Ciphers / IDEA |3DES_IDEA |
| Obsoleted CBC ciphers (AES, ARIA etc.) |AVERAGE |
| Strong encryption (AEAD ciphers) with no FS | GOOD |
| Forward Secrecy strong encryption (AEAD ciphers) | STRONG |