### PR TITLE
Fix HTML output in Bash 5.2 and newer

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -535,11 +535,11 @@ html_reserved(){
      local output
      "$do_html" || return 0
      #sed  -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g" <<< "$1"
-     output="${1//&/&amp;}"
-     output="${output//</&lt;}"
-     output="${output//>/&gt;}"
-     output="${output//\"/&quot;}"
-     output="${output//\'/&apos;}"
+     output="${1//&/$'&'amp;}"
+     output="${output//</$'&'lt;}"
+     output="${output//>/$'&'gt;}"
+     output="${output//\"/$'&'quot;}"
+     output="${output//\'/$'&'apos;}"
      printf -- "%s" "$output"
      return 0
 }


### PR DESCRIPTION
As noted in #2304, the way that the '&' character is treated in the string part of a pattern substitution changed in Bash 5.2. As a result, the change that was made in #1481 to accommodate older versions of Bash (e.g., on MacOS) now causes testssl.sh to produce incorrect HTML output when run on Bash 5.2.

This PR encodes the '&' characters in the substitution strings in a way that produces correct results on multiple versions of Bash (3.2 on MacOS, 5.2 on Ubuntu 23.10, 5.0 on Ubuntu 20.04).