### PR TITLE
Make sure control chars from HTTP header don't end up in html,csv,json

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           skip: ca_hashes.txt,tls_data.txt,*.pem,OPENSSL-LICENSE.txt
-          ignore_words_list: borken,gost,ciph,ba,bloc,isnt,chello,fo,alle
+          ignore_words_list: borken,gost,ciph,ba,bloc,isnt,chello,fo,alle,aNULL

--- a/testssl.sh
+++ b/testssl.sh
@@ -3129,16 +3129,18 @@ run_server_banner() {
      grep -ai '^Server' $HEADERFILE >$TMPFILE
      if [[ $? -eq 0 ]]; then
           serverbanner=$(sed -e 's/^Server: //' -e 's/^server: //' $TMPFILE)
-          if [[ "$serverbanner" == $'\n' ]] || [[ "$serverbanner" == $'\r' ]] || [[ "$serverbanner" == $'\n\r' ]] || [[ -z "$serverbanner" ]]; then
+          serverbanner=${serverbanner//$'\r'}
+          serverbanner=${serverbanner//$'\n'}
+          if [[ -z "$serverbanner" ]]; then
                outln "exists but empty string"
                fileout "$jsonID" "INFO" "Server banner is empty"
           else
                emphasize_stuff_in_headers "$serverbanner"
                fileout "$jsonID" "INFO" "$serverbanner"
                if [[ "$serverbanner" == *Microsoft-IIS/6.* ]] && [[ $OSSL_VER == 1.0.2* ]]; then
-                    prln_warning "                              It's recommended to run another test w/ OpenSSL 1.0.1 !"
+                    prln_warning "                              It's recommended to run another test w/ OpenSSL >= 1.0.1 !"
                     # see https://github.com/PeterMosmans/openssl/issues/19#issuecomment-100897892
-                    fileout "${jsonID}" "WARN" "IIS6_openssl_mismatch: Recommended to rerun this test w/ OpenSSL 1.0.1. See https://github.com/PeterMosmans/openssl/issues/19#issuecomment-100897892"
+                    fileout "${jsonID}" "WARN" "IIS6_openssl_mismatch: Recommended to rerun this test w/ OpenSSL >= 1.0.1. See https://github.com/PeterMosmans/openssl/issues/19#issuecomment-100897892"
                fi
           fi
           # mozilla.github.io/server-side-tls/ssl-config-generator/

--- a/testssl.sh
+++ b/testssl.sh
@@ -555,15 +555,15 @@ html_out() {
      fi
 }
 
-# Removes on printable chars in CSV, JSON, HTML, see #2330
+# Removes non-printable chars in CSV, JSON, HTML, see #2330
 sanitize_fileout() {
-     tr -d '\000-\011,\013-\037' <<< "$1"
+     tr -d '\000-\011\013-\037' <<< "$1"
 }
 
-# Removes on printable chars in terminal output (log files)
-# We need to keep the icolor ANSI escape code, see #2330
+# Removes non-printable chars in terminal output (log files)
+# We need to keep the color ANSI escape code x1b, o33, see #2330
 sanitize_termout() {
-     tr -d '\000-\011,\013-\032,\034-\037' <<< "$1"
+     tr -d '\000-\011\013-\032\034-\037' <<< "$1"
 }
 
 # This is intentionally the same.


### PR DESCRIPTION
This addresses the bug #2330 by implementing a function which removes control characters from the file output format html,csv,json at the output.

In every instance called there's a check before whether the string contains control chars, hoping it'll save a few milli seconds.

A tr function is used, omitting LF.

It doesn't filter the terminal output and the log file output, yet. It provides a function though which is not being called. 