### PR TITLE
Add openssl, offer to query OCSP responder (3.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.17
 
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache bash procps drill git coreutils libidn curl && \
+    apk add --no-cache bash procps drill coreutils libidn curl openssl1.1-compat && \
     addgroup testssl && \
     adduser -G testssl -g "testssl user"  -s /bin/bash -D testssl && \
     ln -s /home/testssl/testssl.sh /usr/local/bin/ && \


### PR DESCRIPTION
This PR includes two tweaks:

* it helps avoiding the bug querying OCSP responder #2329 by adding openssl. The openssl supplied has a mimor DNS lookup problem due to glibc / musl libc compatibilty issues
* by adding openssl also it helps a bit for some performance problems related to other projects, see #2314

Also the git binary is removed (#2315).

Thanks to @polarathene for the discussions