### PR TITLE
refactor(dockerfile): Change base Alpine (3.17) => openSUSE Leap (15.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,18 @@ ARG INSTALL_ROOT=/rootfs
 FROM opensuse/leap:${LEAP_VERSION} as builder
 ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT
-# Usually you could source this from /etc/os-release
-# Might not always match the image tag:
-ARG VERSION_ID=15.4
-RUN  zypper --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" \
-       --gpg-auto-import-keys refresh \
-  && zypper --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" \
-       --non-interactive install --download-in-advance --no-recommends \
+# /etc/os-release provides $VERSION_ID
+RUN source /etc/os-release \
+  && export ZYPPER_OPTIONS=( --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" ) \
+  && zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh \
+  && zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
        bash procps grep gawk sed coreutils busybox-util-linux busybox-vi ldns libidn2-0 socat openssl curl \
-  && zypper --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" \
-       clean --all
+  && zypper "${ZYPPER_OPTIONS[@]}" clean --all
 ## Cleanup (reclaim approx 13 MiB):
 # None of this content should be relevant to the container:
 RUN  rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info}
 # Functionality that the container doesn't need:
-RUN  rm "${INSTALL_ROOT}/usr/share/misc/termcap" \
+RUN  rm    "${INSTALL_ROOT}/usr/share/misc/termcap" \
   && rm -r "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,87 @@
-FROM alpine:3.17
+# syntax=docker.io/docker/dockerfile:1
+# HereDoc (EOF) feature (avoids needing `&& \`) requires BuildKit:
+# https://docs.docker.com/engine/reference/builder/#here-documents
+ARG LEAP_VERSION=15.4
+ARG CACHE_ZYPPER=/tmp/cache/zypper
+ARG INSTALL_ROOT=/rootfs
 
-RUN apk update && \
-    apk upgrade && \
-    apk add bash procps drill git coreutils libidn curl socat openssl xxd && \
-    rm -rf /var/cache/apk/* && \
-    adduser -D -s /bin/bash testssl && \
-    ln -s /home/testssl/testssl.sh /usr/local/bin/ 
+FROM opensuse/leap:${LEAP_VERSION} as builder
+ARG CACHE_ZYPPER
+ARG INSTALL_ROOT
+# --mount is only necessary for persisting the zypper cache on the build host,
+# Paired with --cache-dir below, RUN layer invalidation does not clear this cache.
+# Not useful for CI, only local builds that retain the storage.
+RUN --mount=type=cache,target="${CACHE_ZYPPER}",sharing=locked <<EOF
+  INSTALL_DEPS=()
+
+  # Mandatory commands. coreutils required over busybox for date command:
+  # https://github.com/drwetter/testssl.sh/commit/d1f03801738c87b6af39372c45e048af78c73c09
+  INSTALL_DEPS+=(bash procps grep gawk sed coreutils)
+
+  # Support better performance and debugging than hexdump via xxd:
+  # https://github.com/drwetter/testssl.sh/pull/1862
+  # busybox-util-linux (mandatory: hexdump) + busybox-vi (optional: xxd)
+  INSTALL_DEPS+=( busybox-util-linux busybox-vi )
+
+  # Support IDN (Internationalized Domain Names) lookups with drill:
+  # https://github.com/drwetter/testssl.sh/pull/1326
+  INSTALL_DEPS+=( ldns libidn2-0 )
+
+  # Support StartTLS injection:
+  # https://github.com/drwetter/testssl.sh/pull/1810
+  INSTALL_DEPS+=( socat openssl )
+
+  # Support --phone-out checks:
+  # https://github.com/drwetter/testssl.sh/commit/a66f5cfdbcd93427f4408bdd8cfc336488c02bb8
+  INSTALL_DEPS+=( curl )
+
+
+  # Provides $VERSION_ID
+  source /etc/os-release
+
+  # --releasever required due to no version info in install root.
+  # --installroot installs to location as if it was the system root.
+  # --cache-dir with above `RUN --mount` speeds this step up.
+  ZYPPER_OPTIONS=(
+    --releasever "${VERSION_ID}"
+    --installroot "${INSTALL_ROOT}"
+    --cache-dir "${CACHE_ZYPPER}"
+  )
+
+  # Sync package repos to get latest updates:
+  zypper ${ZYPPER_OPTIONS[@]} --gpg-auto-import-keys refresh
+
+  zypper ${ZYPPER_OPTIONS[@]} --non-interactive install \
+    --download-in-advance --no-recommends ${INSTALL_DEPS[@]}
+
+
+  # Clears the cache, but this is not stored in the install root location (like DNF does), thus not useful.
+  # zypper ${ZYPPER_OPTIONS[@]} clean --all
+
+  # Unlike DNF, there isn't a `--nodocs` install option, manually remove some excess weight (9 MiB):
+  rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info}
+  # Neither of these should be needed in the container, removes 4MiB
+  rm "${INSTALL_ROOT}/usr/share/misc/termcap"
+  rm -r "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
+EOF
+
+
+# Create a new image with the contents of $INSTALL_ROOT
+FROM scratch
+ARG INSTALL_ROOT
+COPY --link --from=builder ${INSTALL_ROOT} /
+
+# zypper package `busybox-adduser` fails to install with `--installroot`,
+# while the `shadow` package is too heavy just to add a user.
+#
+# Temporarily bind mount the `/bin` dir from another image that already
+# has the `adduser` command, and it'll update `/etc/{group,passwd,shadow}` for us:
+# Absolute path provided as some base images PATH would use those binaries instead,
+# `adduser` varies in supported args, so this should avoid any surprises:
+RUN --mount=type=bind,from=busybox:latest,source=/bin,target=/bin <<EOF
+  /bin/adduser -D -s /bin/bash testssl
+  /bin/ln -s /home/testssl/testssl.sh /usr/local/bin/
+EOF
 
 USER testssl
 WORKDIR /home/testssl/
@@ -14,5 +90,4 @@ WORKDIR /home/testssl/
 COPY --chown=testssl:testssl . /home/testssl/
 
 ENTRYPOINT ["testssl.sh"]
-
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,66 +1,35 @@
 # syntax=docker.io/docker/dockerfile:1
-# HereDoc (EOF) feature (avoids needing `&& \`) requires BuildKit:
-# https://docs.docker.com/engine/reference/builder/#here-documents
+
 ARG LEAP_VERSION=15.4
-ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT=/rootfs
 
 FROM opensuse/leap:${LEAP_VERSION} as builder
-ARG CACHE_ZYPPER
+ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT
 # --mount is only necessary for persisting the zypper cache on the build host,
 # Paired with --cache-dir below, RUN layer invalidation does not clear this cache.
 # Not useful for CI, only local builds that retain the storage.
 RUN --mount=type=cache,target="${CACHE_ZYPPER}",sharing=locked <<EOF
-  INSTALL_DEPS=()
-
-  # Mandatory commands. coreutils required over busybox for date command:
-  # https://github.com/drwetter/testssl.sh/commit/d1f03801738c87b6af39372c45e048af78c73c09
-  INSTALL_DEPS+=(bash procps grep gawk sed coreutils)
-
-  # Support better performance and debugging than hexdump via xxd:
-  # https://github.com/drwetter/testssl.sh/pull/1862
-  # busybox-util-linux (mandatory: hexdump) + busybox-vi (optional: xxd)
-  INSTALL_DEPS+=( busybox-util-linux busybox-vi )
-
-  # Support IDN (Internationalized Domain Names) lookups with drill:
-  # https://github.com/drwetter/testssl.sh/pull/1326
-  INSTALL_DEPS+=( ldns libidn2-0 )
-
-  # Support StartTLS injection:
-  # https://github.com/drwetter/testssl.sh/pull/1810
-  INSTALL_DEPS+=( socat openssl )
-
-  # Support --phone-out checks:
-  # https://github.com/drwetter/testssl.sh/commit/a66f5cfdbcd93427f4408bdd8cfc336488c02bb8
-  INSTALL_DEPS+=( curl )
-
-
   # Provides $VERSION_ID
   source /etc/os-release
-
-  # --releasever required due to no version info in install root.
-  # --installroot installs to location as if it was the system root.
-  # --cache-dir with above `RUN --mount` speeds this step up.
   ZYPPER_OPTIONS=(
     --releasever "${VERSION_ID}"
     --installroot "${INSTALL_ROOT}"
     --cache-dir "${CACHE_ZYPPER}"
   )
 
-  # Sync package repos to get latest updates:
+  # Sync package repos:
   zypper ${ZYPPER_OPTIONS[@]} --gpg-auto-import-keys refresh
 
   zypper ${ZYPPER_OPTIONS[@]} --non-interactive install \
-    --download-in-advance --no-recommends ${INSTALL_DEPS[@]}
+    --download-in-advance --no-recommends \
+    bash procps grep gawk sed coreutils busybox-util-linux busybox-vi ldns libidn2-0 socat openssl curl
 
 
-  # Clears the cache, but this is not stored in the install root location (like DNF does), thus not useful.
-  # zypper ${ZYPPER_OPTIONS[@]} clean --all
-
-  # Unlike DNF, there isn't a `--nodocs` install option, manually remove some excess weight (9 MiB):
+  ## Cleanup (reclaim approx 13 MiB):
+  # None of this content should be relevant to the container:
   rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info}
-  # Neither of these should be needed in the container, removes 4MiB
+  # Functionality that the container doesn't need:
   rm "${INSTALL_ROOT}/usr/share/misc/termcap"
   rm -r "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,44 +6,34 @@ ARG INSTALL_ROOT=/rootfs
 FROM opensuse/leap:${LEAP_VERSION} as builder
 ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT
-# --mount is only necessary for persisting the zypper cache on the build host,
-# Paired with --cache-dir below, RUN layer invalidation does not clear this cache.
-# Not useful for CI, only local builds that retain the storage.
-RUN --mount=type=cache,target="${CACHE_ZYPPER}",sharing=locked <<EOF
-  # Provides $VERSION_ID
-  source /etc/os-release
-  ZYPPER_OPTIONS=(
-    --releasever "${VERSION_ID}"
-    --installroot "${INSTALL_ROOT}"
-    --cache-dir "${CACHE_ZYPPER}"
-  )
-
-  # Sync package repos:
-  zypper ${ZYPPER_OPTIONS[@]} --gpg-auto-import-keys refresh
-
-  zypper ${ZYPPER_OPTIONS[@]} --non-interactive install \
-    --download-in-advance --no-recommends \
-    bash procps grep gawk sed coreutils busybox-util-linux busybox-vi ldns libidn2-0 socat openssl curl
-
-
-  ## Cleanup (reclaim approx 13 MiB):
-  # None of this content should be relevant to the container:
-  rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info}
-  # Functionality that the container doesn't need:
-  rm "${INSTALL_ROOT}/usr/share/misc/termcap"
-  rm -r "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
-EOF
+# Usually you could source this from /etc/os-release
+# Might not always match the image tag:
+ARG VERSION_ID=15.4
+RUN  zypper --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" \
+       --gpg-auto-import-keys refresh \
+  && zypper --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" \
+       --non-interactive install --download-in-advance --no-recommends \
+       bash procps grep gawk sed coreutils busybox-util-linux busybox-vi ldns libidn2-0 socat openssl curl \
+  && zypper --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" \
+       clean --all
+## Cleanup (reclaim approx 13 MiB):
+# None of this content should be relevant to the container:
+RUN  rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info}
+# Functionality that the container doesn't need:
+RUN  rm "${INSTALL_ROOT}/usr/share/misc/termcap" \
+  && rm -r "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
 
 
 # Create a new image with the contents of $INSTALL_ROOT
 FROM scratch
 ARG INSTALL_ROOT
 COPY --link --from=builder ${INSTALL_ROOT} /
-WORKDIR /home/testssl
-RUN --mount=type=bind,from=busybox:latest,source=/bin,target=/bin <<EOF
-  /bin/adduser -D -s /bin/bash testssl
-  /bin/ln -s /home/testssl/testssl.sh /usr/local/bin/
-EOF
+# Create user + (home with SGID set):
+RUN  echo 'testssl:x:1000:1000::/home/testssl:/bin/bash' >> /etc/passwd \
+  && echo 'testssl:x:1000:' >> /etc/group \
+  && echo 'testssl:!::0:::::' >> /etc/shadow \
+  && install --mode 2755 --owner testssl --group testssl --directory /home/testssl \
+  && ln -s /home/testssl/testssl.sh /usr/local/bin/
 
 # Copy over build context (after filtered by .dockerignore): bin/ etc/ testssl.sh
 COPY --chown=testssl:testssl . /home/testssl/


### PR DESCRIPTION
Based on feedback at: https://github.com/drwetter/testssl.sh/issues/2299#issuecomment-1471704041

Image size on disk:
- Alpine: `36.6 MiB`
- Leap: `55.5 MiB`

Main benefit is to move off `musl`, this comes at the expense of a slightly larger image.

One issue related to this was the static built `openssl` relies on `glibc` for some DNS logic which would fail on Alpine (_non-issue when using the `openssl` package from Alpine_).

Commits have messages for context on changes. Some inline docs have been dropped but could be brought back if desired. Less practical without the BuildKit features that were dropped though.

---

`docker run --rm -it drwetter/testssl.sh:3.1dev --openssl /usr/bin/openssl google.com`:
- Alpine (OpenSSL 3.0.8): 196 sec
- Leap (OpenSSL 1.1.1l): 108 sec

Run on a Fedora 37 VPS host with 2 vCPU.

---

For reference, since `git blame` becomes less helpful, these links should assist with any traceability going forward:

- Dependencies were documented in [this earlier commit](https://github.com/drwetter/testssl.sh/blob/0b86094ab99cdbb1e07df7699108af67d0260559/Dockerfile), while [this commit](https://github.com/drwetter/testssl.sh/pull/2344/commits/718eb3461c3ebf12e3c458444fbd6e02aea63232) was the version prior to dropping BuildKit features if a maintainer decides to adopt them in future.
- Original image history (Debian to Alpine) and [dependencies were also documented in an earlier PR of mine](https://github.com/drwetter/testssl.sh/pull/2305).