### PR TITLE
Add support for brainpool curves with TLS 1.3

### DIFF
--- a/etc/curves.txt
+++ b/etc/curves.txt
@@ -28,4 +28,7 @@
 27, brainpoolP384r1, 
 28, brainpoolP512r1, 
 29, curve25519,
-30, curve448
+30, curve448,
+31, brainpoolP256r1tls13,
+32, brainpoolP384r1tls13,
+33, brainpoolP512r1tls13

--- a/etc/tls_data.txt
+++ b/etc/tls_data.txt
@@ -124,8 +124,29 @@ MC4CAQAwBQYDK2VuBCIEIDhCPq41ufKeHdfVAp6KeS7qo8E43pd+ee+npH0sOqxL
 MEYCAQAwBQYDK2VvBDoEONDoNojolTC5A5LwJmEfj/NqVrkG2PsagQ0IxZJcwyhC
 CrAkCbaEfSIdjRVr2ODIC8ByiHjIzqDu
 -----END PRIVATE KEY-----
-" "1f"
- "20" "21" "22" "23" "24" "25" "26" "27" "28" "29" "2a" "2b" "2c" "2d" "2e" "2f"
+"
+"-----BEGIN PRIVATE KEY-----
+MIGIAgEAMBQGByqGSM49AgEGCSskAwMCCAEBBwRtMGsCAQEEID/S1T+6vhaiWJT6
+2qbAFBlBi7Bd2fe6eRJlw6I2zm0eoUQDQgAEdk7i/WWNR873mVlffUL/XYPW04fd
+eVf2KlfRUi8aoINfkxsw/yVVOuVfT8GivrEs1kT2iiy0Z+gyXDrYiSqP1w==
+-----END PRIVATE KEY-----
+"
+"-----BEGIN PRIVATE KEY-----
+MIG6AgEAMBQGByqGSM49AgEGCSskAwMCCAEBCwSBnjCBmwIBAQQwbV1IckTIgFs6
+YOOLLFeLmc6BLjqHUbLHLwZjI8TKNMIzYahhc9n5wgSyn+Psu3NWoWQDYgAEA/NN
+eFinukOQpX+Alpccd0NnRL59YdYmhI5VSdQECDyUym4hH2L7uHXdOZaC/qxvPQxz
+QDY3nqerDkwIB+rFj1qWOKzqyZt2KlVk2jE3Omsrhuo92Ai94X0LyW2SMRyh
+-----END PRIVATE KEY-----
+"
+"-----BEGIN PRIVATE KEY-----
+MIHsAgEAMBQGByqGSM49AgEGCSskAwMCCAEBDQSB0DCBzQIBAQRAmfrMGcK0wj3D
+QNMCwBQaQHY03cTJuQbjjFr1Mrqn73ARDxUel6xdklEWx3SE9gbG0KVGnCx/nslG
+xS6XqyNhhqGBhQOBggAEDjRvgELV732xXBsz5NJuirkmran6haJy2Phqqc4qPROm
+0iUjpSOrq0DV5MUE/0HhvzvOSqkSWr7nAefO1bovml+Fo5YT+KUsZJMYK7DlDtCb
+79ZjkNvTbrsL9GVNvOmyUJv+PyxG1Zn6OsIxck747cJ/IGeOv7hcA+/J728TfWk=
+-----END PRIVATE KEY-----
+"
+ "22" "23" "24" "25" "26" "27" "28" "29" "2a" "2b" "2c" "2d" "2e" "2f"
  "30" "31" "32" "33" "34" "35" "36" "37" "38" "39" "3a" "3b" "3c" "3d" "3e" "3f"
  "40" "41" "42" "43" "44" "45" "46" "47" "48" "49" "4a" "4b" "4c" "4d" "4e" "4f"
  "50" "51" "52" "53" "54" "55" "56" "57" "58" "59" "5a" "5b" "5c" "5d" "5e" "5f"
@@ -296,8 +317,10 @@ readonly -a TLS13_PUBLIC_KEY_SHARES=(
  "1a" "1b" "1c"
  "00,1d,00,20,4d,fa,57,44,b7,f7,48,b8,95,77,5a,c1,ff,86,bf,ae,f7,3a,33,69,54,de,6a,f5,2e,89,84,6c,f2,d8,b2,43"
  "00,1e,00,38,6d,6d,67,a7,4e,3d,45,dd,ec,7e,a0,70,88,56,54,d8,c5,7c,4d,f3,8f,8b,f8,f2,14,06,1b,a0,4f,f7,ad,6b,3f,3a,90,42,41,8e,74,28,32,4a,a7,50,4a,7a,8e,42,55,eb,94,96,de,83,37,d6"
- "1f"
- "20" "21" "22" "23" "24" "25" "26" "27" "28" "29" "2a" "2b" "2c" "2d" "2e" "2f"
+ "00,1f,00,41,04,76,4e,e2,fd,65,8d,47,ce,f7,99,59,5f,7d,42,ff,5d,83,d6,d3,87,dd,79,57,f6,2a,57,d1,52,2f,1a,a0,83,5f,93,1b,30,ff,25,55,3a,e5,5f,4f,c1,a2,be,b1,2c,d6,44,f6,8a,2c,b4,67,e8,32,5c,3a,d8,89,2a,8f,d7"
+ "00,20,00,61,04,03,f3,4d,78,58,a7,ba,43,90,a5,7f,80,96,97,1c,77,43,67,44,be,7d,61,d6,26,84,8e,55,49,d4,04,08,3c,94,ca,6e,21,1f,62,fb,b8,75,dd,39,96,82,fe,ac,6f,3d,0c,73,40,36,37,9e,a7,ab,0e,4c,08,07,ea,c5,8f,5a,96,38,ac,ea,c9,9b,76,2a,55,64,da,31,37,3a,6b,2b,86,ea,3d,d8,08,bd,e1,7d,0b,c9,6d,92,31,1c,a1"
+ "00,21,00,81,04,0e,34,6f,80,42,d5,ef,7d,b1,5c,1b,33,e4,d2,6e,8a,b9,26,ad,a9,fa,85,a2,72,d8,f8,6a,a9,ce,2a,3d,13,a6,d2,25,23,a5,23,ab,ab,40,d5,e4,c5,04,ff,41,e1,bf,3b,ce,4a,a9,12,5a,be,e7,01,e7,ce,d5,ba,2f,9a,5f,85,a3,96,13,f8,a5,2c,64,93,18,2b,b0,e5,0e,d0,9b,ef,d6,63,90,db,d3,6e,bb,0b,f4,65,4d,bc,e9,b2,50,9b,fe,3f,2c,46,d5,99,fa,3a,c2,31,72,4e,f8,ed,c2,7f,20,67,8e,bf,b8,5c,03,ef,c9,ef,6f,13,7d,69"
+ "22" "23" "24" "25" "26" "27" "28" "29" "2a" "2b" "2c" "2d" "2e" "2f"
  "30" "31" "32" "33" "34" "35" "36" "37" "38" "39" "3a" "3b" "3c" "3d" "3e" "3f"
  "40" "41" "42" "43" "44" "45" "46" "47" "48" "49" "4a" "4b" "4c" "4d" "4e" "4f"
  "50" "51" "52" "53" "54" "55" "56" "57" "58" "59" "5a" "5b" "5c" "5d" "5e" "5f"

--- a/testssl.sh
+++ b/testssl.sh
@@ -6396,9 +6396,9 @@ pr_ecdh_curve_quality() {
           "prime256v1") bits=256  ;;
           "secp384r1") bits=384  ;;
           "secp521r1") bits=521  ;;
-          "brainpoolP256r1") bits=256  ;;
-          "brainpoolP384r1") bits=384  ;;
-          "brainpoolP512r1") bits=512  ;;
+          "brainpoolP256r1"*) bits=256  ;;
+          "brainpoolP384r1"*) bits=384  ;;
+          "brainpoolP512r1"*) bits=512  ;;
           "X25519") bits=253  ;;
           "X448") bits=448  ;;
      esac
@@ -10374,13 +10374,13 @@ run_fs() {
      local fs_cipher_list="DHE-DSS-AES128-GCM-SHA256:DHE-DSS-AES128-SHA256:DHE-DSS-AES128-SHA:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-DSS-CAMELLIA128-SHA256:DHE-DSS-CAMELLIA128-SHA:DHE-DSS-CAMELLIA256-SHA256:DHE-DSS-CAMELLIA256-SHA:DHE-DSS-SEED-SHA:DHE-RSA-AES128-CCM8:DHE-RSA-AES128-CCM:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-CCM8:DHE-RSA-AES256-CCM:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA128-SHA256:DHE-RSA-CAMELLIA128-SHA:DHE-RSA-CAMELLIA256-SHA256:DHE-RSA-CAMELLIA256-SHA:DHE-RSA-CHACHA20-POLY1305-OLD:DHE-RSA-CHACHA20-POLY1305:DHE-RSA-SEED-SHA:ECDHE-ECDSA-AES128-CCM8:ECDHE-ECDSA-AES128-CCM:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-CCM8:ECDHE-ECDSA-AES256-CCM:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-CAMELLIA128-SHA256:ECDHE-ECDSA-CAMELLIA256-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305-OLD:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-RSA-CAMELLIA128-SHA256:ECDHE-RSA-CAMELLIA256-SHA384:ECDHE-RSA-CHACHA20-POLY1305-OLD:ECDHE-RSA-CHACHA20-POLY1305"
      local fs_hex_cipher_list="" ciphers_to_test tls13_ciphers_to_test
      local ecdhe_cipher_list="" tls13_cipher_list="" ecdhe_cipher_list_hex="" ffdhe_cipher_list_hex=""
-     local curves_hex=("00,01" "00,02" "00,03" "00,04" "00,05" "00,06" "00,07" "00,08" "00,09" "00,0a" "00,0b" "00,0c" "00,0d" "00,0e" "00,0f" "00,10" "00,11" "00,12" "00,13" "00,14" "00,15" "00,16" "00,17" "00,18" "00,19" "00,1a" "00,1b" "00,1c" "00,1d" "00,1e")
-     local -a curves_ossl=("sect163k1" "sect163r1" "sect163r2" "sect193r1" "sect193r2" "sect233k1" "sect233r1" "sect239k1" "sect283k1" "sect283r1" "sect409k1" "sect409r1" "sect571k1" "sect571r1" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "prime192v1" "secp224k1" "secp224r1" "secp256k1" "prime256v1" "secp384r1" "secp521r1" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448")
-     local -a curves_ossl_output=("K-163" "sect163r1" "B-163" "sect193r1" "sect193r2" "K-233" "B-233" "sect239k1" "K-283" "B-283" "K-409" "B-409" "K-571" "B-571" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "P-192" "secp224k1" "P-224" "secp256k1" "P-256" "P-384" "P-521" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448")
-     local -ai curves_bits=(163 162 163 193 193 232 233 238 281 282 407 409 570 570 161 161 161 192 192 225 224 256 256 384 521 256 384 512 253 448)
+     local curves_hex=("00,01" "00,02" "00,03" "00,04" "00,05" "00,06" "00,07" "00,08" "00,09" "00,0a" "00,0b" "00,0c" "00,0d" "00,0e" "00,0f" "00,10" "00,11" "00,12" "00,13" "00,14" "00,15" "00,16" "00,17" "00,18" "00,19" "00,1a" "00,1b" "00,1c" "00,1d" "00,1e" "00,1f" "00,20" "00,21")
+     local -a curves_ossl=("sect163k1" "sect163r1" "sect163r2" "sect193r1" "sect193r2" "sect233k1" "sect233r1" "sect239k1" "sect283k1" "sect283r1" "sect409k1" "sect409r1" "sect571k1" "sect571r1" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "prime192v1" "secp224k1" "secp224r1" "secp256k1" "prime256v1" "secp384r1" "secp521r1" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448" "brainpoolP256r1tls13" "brainpoolP384r1tls13" "brainpoolP512r1tls13")
+     local -a curves_ossl_output=("K-163" "sect163r1" "B-163" "sect193r1" "sect193r2" "K-233" "B-233" "sect239k1" "K-283" "B-283" "K-409" "B-409" "K-571" "B-571" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "P-192" "secp224k1" "P-224" "secp256k1" "P-256" "P-384" "P-521" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448" "brainpoolP256r1tls13" "brainpoolP384r1tls13" "brainpoolP512r1tls13")
+     local -ai curves_bits=(163 162 163 193 193 232 233 238 281 282 407 409 570 570 161 161 161 192 192 225 224 256 256 384 521 256 384 512 253 448 256 384 512)
      # Many curves have been deprecated, and RFC 8446, Appendix B.3.1.4, states
      # that these curves MUST NOT be offered in a TLS 1.3 ClientHello.
-     local -a curves_deprecated=("true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "false" "false" "false" "true" "true" "true" "false" "false")
+     local -a curves_deprecated=("true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "true" "false" "false" "false" "true" "true" "true" "false" "false" "false" "false" "false")
      local -a ffdhe_groups_hex=("01,00" "01,01" "01,02" "01,03" "01,04")
      local -a ffdhe_groups_output=("ffdhe2048" "ffdhe3072" "ffdhe4096" "ffdhe6144" "ffdhe8192")
      local -a supported_curve
@@ -10740,6 +10740,9 @@ run_fs() {
                          if [[ "$curve_found" == ECDH ]]; then
                               curve_found="${temp#*, }"
                               curve_found="${curve_found%%,*}"
+                              if "$HAS_TLS13" && [[ ! "$proto" == "-no_tls1_3" ]] && [[ "$curve_found" == brainpoolP[235][581][642]r1 ]]; then
+                                   [[ "$(get_protocol "$TMPFILE")" == TLSv1.3 ]] && curve_found+="tls13"
+                              fi
                          fi
                          for (( i=low; i < high; i++ )); do
                               if ! "${supported_curve[i]}"; then
@@ -14403,6 +14406,9 @@ parse_tls_serverhello() {
                                     25) dh_bits=521 ; named_curve_str="P-521" ; named_curve_oid="06052b81040023" ;;
                                     29) dh_bits=253 ; named_curve_str="X25519" ;;
                                     30) dh_bits=448 ; named_curve_str="X448" ;;
+                                    31) dh_bits=256 ; named_curve_str="brainpoolP256r1tls13" ; named_curve_oid="06092B2403030208010107" ;;
+                                    32) dh_bits=384 ; named_curve_str="brainpoolP384r1tls13" ; named_curve_oid="06092B240303020801010B" ;;
+                                    33) dh_bits=512 ; named_curve_str="brainpoolP512r1tls13" ; named_curve_oid="06092B240303020801010D" ;;
                                     256) dh_bits=2048 ; named_curve_str="ffdhe2048" ;;
                                     257) dh_bits=3072 ; named_curve_str="ffdhe3072" ;;
                                     258) dh_bits=4096 ; named_curve_str="ffdhe4096" ;;
@@ -15430,8 +15436,8 @@ prepare_tls_clienthello() {
                if [[ ! "$process_full" =~ all ]] || { "$HAS_X25519" && "$HAS_X448"; }; then
                     extension_supported_groups="
                     00,0a,                      # Type: Supported Groups, see RFC 8446
-                    00,10, 00,0e,               # lengths
-                    00,1d, 00,17, 00,1e, 00,18, 00,19,
+                    00,16, 00,14,               # lengths
+                    00,1d, 00,17, 00,1e, 00,18, 00,19, 00,1f, 00,20, 00,21,
                     01,00, 01,01"
                     # OpenSSL prior to 1.1.1 does not support X448, so list it as the least
                     # preferred option if the response needs to be decrypted, and do not
@@ -15439,14 +15445,14 @@ prepare_tls_clienthello() {
                elif "$HAS_X25519" && [[ "$process_full" == all+ ]]; then
                     extension_supported_groups="
                     00,0a,                      # Type: Supported Groups, see RFC 8446
-                    00,0e, 00,0c,               # lengths
-                    00,1d, 00,17, 00,18, 00,19,
+                    00,14, 00,12,               # lengths
+                    00,1d, 00,17, 00,18, 00,19, 00,1f, 00,20, 00,21,
                     01,00, 01,01"
                elif "$HAS_X25519"; then
                     extension_supported_groups="
                     00,0a,                      # Type: Supported Groups, see RFC 8446
-                    00,10, 00,0e,               # lengths
-                    00,1d, 00,17, 00,18, 00,19,
+                    00,16, 00,14,               # lengths
+                    00,1d, 00,17, 00,18, 00,19, 00,1f, 00,20, 00,21,
                     01,00, 01,01, 00,1e"
                     # OpenSSL prior to 1.1.0 does not support either X25519 or X448,
                     # so list them as the least referred options if the response
@@ -15455,14 +15461,14 @@ prepare_tls_clienthello() {
                elif [[ "$process_full" == all+ ]]; then
                     extension_supported_groups="
                     00,0a,                      # Type: Supported Groups, see RFC 8446
-                    00,0c, 00,0a,               # lengths
-                    00,17, 00,18, 00,19,
+                    00,12, 00,10,               # lengths
+                    00,17, 00,18, 00,19, 00,1f, 00,20, 00,21,
                     01,00, 01,01"
                else
                     extension_supported_groups="
                     00,0a,                      # Type: Supported Groups, see RFC 8446
-                    00,10, 00,0e,               # lengths
-                    00,17, 00,18, 00,19,
+                    00,16, 00,14,               # lengths
+                    00,17, 00,18, 00,19, 00,1f, 00,20, 00,21,
                     01,00, 01,01, 00,1d, 00,1e"
                fi
 
@@ -19911,7 +19917,7 @@ find_openssl_binary() {
      local openssl_location cwd=""
      local ossl_wo_dev_info
      local curve
-     local -a curves_ossl=("sect163k1" "sect163r1" "sect163r2" "sect193r1" "sect193r2" "sect233k1" "sect233r1" "sect239k1" "sect283k1" "sect283r1" "sect409k1" "sect409r1" "sect571k1" "sect571r1" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "prime192v1" "secp224k1" "secp224r1" "secp256k1" "prime256v1" "secp384r1" "secp521r1" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448" "ffdhe2048" "ffdhe3072" "ffdhe4096" "ffdhe6144" "ffdhe8192")
+     local -a curves_ossl=("sect163k1" "sect163r1" "sect163r2" "sect193r1" "sect193r2" "sect233k1" "sect233r1" "sect239k1" "sect283k1" "sect283r1" "sect409k1" "sect409r1" "sect571k1" "sect571r1" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "prime192v1" "secp224k1" "secp224r1" "secp256k1" "prime256v1" "secp384r1" "secp521r1" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448" "brainpoolP256r1tls13" "brainpoolP384r1tls13" "brainpoolP512r1tls13" "ffdhe2048" "ffdhe3072" "ffdhe4096" "ffdhe6144" "ffdhe8192")
 
      # 0. check environment variable whether it's executable
      if [[ -n "$OPENSSL" ]] && [[ ! -x "$OPENSSL" ]]; then

--- a/utils/update_client_sim_data.pl
+++ b/utils/update_client_sim_data.pl
@@ -295,6 +295,12 @@ foreach my $client ( @$ssllabs ) {
 				push @curves, "X25519"; }
 			elsif ( $curve == 30 ) {
 				push @curves, "X448"; }
+			elsif ( $curve == 31 ) {
+				push @curves, "brainpoolP256r1tls13"; }
+			elsif ( $curve == 32 ) {
+				push @curves, "brainpoolP384r1tls13"; }
+			elsif ( $curve == 33 ) {
+				push @curves, "brainpoolP512r1tls13"; }
 		}
 		$sim->{ellipticCurves} = "curves+=(\"" . (join ":", @curves) . "\")";
 	}


### PR DESCRIPTION
This PR adds support for the curves brainpoolP256r1tls13, brainpoolP384r1tls13, and brainpoolP512r1tls13.

Based on #2346, I included the "tls13" in the names that used, even though brainpoolP256r1 and brainpoolP256r1tls13 are both the same curve, just for use with different TLS versions. This is the reason for lines 10743 - 10745. OpenSSL reports the curve as just brainpoolP...r1, even if it is the brainpoolP...r1tls13 code point, so I need to look at which version of TLS was negotiated to determine which code point was used.

I was not able to test utils/update_client_sim_data.pl, but the change that I made to it seems straightforward.