### PR TITLE
Extended the dns caa rr functionality

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21126,9 +21126,22 @@ get_caa_rr_record() {
           #caa_property_value="$(awk '{ print $3 }' <<< "$raw_caa")"
           safe_echo "$(sort <<< "$(awk '{ print $2"="$3 }' <<< "$raw_caa")")"
           return 0
+     elif [[ "$(echo "$raw_caa" | sed 's/[[:space:]]*$//g')" == *. ]]; then
+          # trimmed caa ends with a . which indicates, that the caa should be found by querying the caa for the returned url (remove . at the end to align with the normal call convention)
+          NEW_CAA_HOST="$(echo "$raw_caa" | sed 's/[[:space:]]*$//g' | sed 's/.$//')"
+          outln "CAA for $1 points to the CAA for $NEW_CAA_HOST"
+          get_caa_rr_record $NEW_CAA_HOST
+          return $?
      else
-          # no caa record
-          return 1
+          # no caa record ... according to rfc8659, we should "climb the DNS tree" if no caa was found (will only go up to x.y e.g. google.com and not all the way to com)
+          if [ $(tr -cd '.' <<< $1 | wc -c) -gt 1 ]; then
+               NEW_CAA_HOST="$(echo "$1" | sed 's/^[^\.]*\.//')"
+               outln "CAA not found for $1. Trying to climb the DNS tree, so will look up the CAA for $NEW_CAA_HOST"
+               get_caa_rr_record $NEW_CAA_HOST
+               return $?
+           else
+               return 1
+           fi
      fi
 
 # to do:


### PR DESCRIPTION
Extended the dns caa rr functionality to handle: 
1) That the caa rr points to the caa rr of another url. 
2) That we climb the dns tree in case no caa rr is found (as instructed in rfc 8659). 

If a scan towards translate.google.com is performed, both 1) and 2) is activated. 
The first caa rr returned will point towards www3.l.google.com (activating 1), and no caa rr is found for www3.l.google.com or l.google.com (thus activating 2) ), but one is found for google.com.