### PR TITLE
Fix CRL conversion issue when already in PEM format

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1979,12 +1979,15 @@ check_revocation_crl() {
           return 1
      fi
      # -crl_download could be more elegant but is supported from 1.0.2 onwards only
-     cp "$tmpfile" "${tmpfile%%.crl}.pem"
-     grep -qe 'BEGIN X509 CRL' "${tmpfile%%.crl}.pem" || $OPENSSL crl -inform DER -in "$tmpfile" -outform PEM -out "${tmpfile%%.crl}.pem" &>$ERRFILE
+     $OPENSSL crl -inform DER -in "$tmpfile" -outform PEM -out "${tmpfile%%.crl}.pem" &>$ERRFILE
      if [[ $? -ne 0 ]]; then
-          pr_warning "conversion of \"$tmpfile\" failed"
-          fileout "$jsonID" "WARN" "conversion of CRL to PEM format failed"
-          return 1
+          if grep -qe 'BEGIN X509 CRL' "$tmpfile"; then
+               mv "$tmpfile" "${tmpfile%%.crl}.pem"
+          else
+               pr_warning "conversion of \"$tmpfile\" failed"
+               fileout "$jsonID" "WARN" "conversion of CRL to PEM format failed"
+               return 1
+          fi
      fi
      if grep -qe '-----BEGIN CERTIFICATE-----' $TEMPDIR/intermediatecerts.pem; then
           $OPENSSL verify -crl_check -CAfile <(cat $ADDTL_CA_FILES "$GOOD_CA_BUNDLE" "${tmpfile%%.crl}.pem") -untrusted $TEMPDIR/intermediatecerts.pem $HOSTCERT &> "${tmpfile%%.crl}.err"

--- a/testssl.sh
+++ b/testssl.sh
@@ -1979,7 +1979,8 @@ check_revocation_crl() {
           return 1
      fi
      # -crl_download could be more elegant but is supported from 1.0.2 onwards only
-     $OPENSSL crl -inform DER -in "$tmpfile" -outform PEM -out "${tmpfile%%.crl}.pem" &>$ERRFILE
+     cp "$tmpfile" "${tmpfile%%.crl}.pem"
+     grep -qe 'BEGIN X509 CRL' "${tmpfile%%.crl}.pem" || $OPENSSL crl -inform DER -in "$tmpfile" -outform PEM -out "${tmpfile%%.crl}.pem" &>$ERRFILE
      if [[ $? -ne 0 ]]; then
           pr_warning "conversion of \"$tmpfile\" failed"
           fileout "$jsonID" "WARN" "conversion of CRL to PEM format failed"


### PR DESCRIPTION
If downloaded CRL file is already in PEM format, openssl command will fail as it is always trying to convert from a DER-encoded CRL.  This commit is for adding a test of the CRL format prior to running the openssl crl conversion. 

Note: as the openssl verify command then assumes that a .pem tmpfile has been generated by the conversion, there would be an issue when the conversion was not needed (i.e. CRL already PEM-encoded) as that .pem would be missing; therefore I also added a copy of the .crl file to a .crl.pem file before the optional conversion.