### PR TITLE
Remove reference to outdated docker image

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,9 +115,6 @@ Please address questions not specifically to the code of testssl.sh to the respe
 #### Mass scanner w parallel scans and elastic searching the results
 * https://github.com/TKCERT/testssl.sh-masscan
 
-#### Another ready-to-go docker image is at:
-* https://quay.io/repository/jumanjiman/testssl
-
 #### Privacy checker using testssl.sh
 * https://privacyscore.org
 


### PR DESCRIPTION
The docker image over at https://quay.io/repository/jumanjiman is not maintained anymore.  The current version is 3 years old and has various security vulnerabilities, see https://quay.io/repository/jumanjiman/testssl/manifest/sha256:dea0446320f550acac1dfd1f2c592d43b526b737a3d9406388d636cb477053d6?tab=vulnerabilities.