### PR TITLE
Fix LibreSSL returns 0 on failure

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7756,7 +7756,7 @@ sclient_connect_successful() {
      local re='Master-Key: ([^\
 ]*)'
 
-     [[ $1 -eq 0 ]] && connect_success=true
+     [[ $1 -eq 0 ]] && [[ ! "$server_hello" =~ SSL\ handshake\ has\ read\ 0\ bytes\ and\ written ]] && connect_success=true
      if ! "$connect_success" && [[ "$server_hello" =~ $re ]]; then
           [[ -n "${BASH_REMATCH[1]}" ]] && connect_success=true
      fi
@@ -21570,7 +21570,7 @@ sclient_auth() {
 ]*)'
      local connect_success=false
 
-     [[ $1 -eq 0 ]] && connect_success=true
+     [[ $1 -eq 0 ]] && [[ ! "$server_hello" =~ SSL\ handshake\ has\ read\ 0\ bytes\ and\ written ]] && connect_success=true
 
      ! "$connect_success" && [[ "$server_hello" =~ $re ]] && \
           [[ -n "${BASH_REMATCH[1]}" ]] && connect_success=true


### PR DESCRIPTION
In some cases LibreSSL's s_client returns a status of 0 even when the connection fails. I have not been able to figure out under what circumstances it happens. However, when it does happen there always seems to be a line in the output of the form "SSL handshake has read 0 bytes and written ... bytes". This PR fixes the problem by not treating a connection as successful if the string "SSL handshake has read 0 bytes and written" is present. This fix seem safe as the connection could not have been successful is no data was received from the server.

So far, I have only encountered this error when testing against the local CUPS server on my computer (Ubuntu 22.04):
```
testssl.sh --openssl=<path to LibreSSL binary> --ssl-native --std 127.0.0.1:631
```