### PR TITLE
Add --server-preference alias to documentation

### DIFF
--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -143,7 +143,7 @@ Any single check switch supplied as an argument prevents testssl\.sh from doing 
 .P
 \fB\-p, \-\-protocols\fR checks TLS/SSL protocols SSLv2, SSLv3, TLS 1\.0 through TLS 1\.3 and for HTTP: SPDY (NPN) and ALPN, a\.k\.a\. HTTP/2\. For TLS 1\.3 several drafts (from 18 on) and final are supported and being tested for\.
 .P
-\fB\-P, \-\-preference\fR displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher\. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets)\. If there's not, it displays instead which ciphers from the server were picked with each protocol\.
+\fB\-P, \-\-server\-preference, \-\-preference\fR displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher\. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets)\. If there's not, it displays instead which ciphers from the server were picked with each protocol\.
 .P
 \fB\-S, \-\-server_defaults\fR displays information from the server hello(s):
 .IP "\[ci]" 4

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -262,7 +262,7 @@ in <code>/etc/hosts</code>.  The use of the switch is only useful if you either 
 
 <p><code>-p, --protocols</code>  checks TLS/SSL protocols SSLv2, SSLv3, TLS 1.0 through TLS 1.3 and for HTTP: SPDY (NPN) and ALPN, a.k.a. HTTP/2. For TLS 1.3 several drafts (from 18 on) and final are supported and being tested for.</p>
 
-<p><code>-P, --preference</code>  displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets). If there's not, it displays instead which ciphers from the server were picked with each protocol.</p>
+<p><code>-P, --server-preference, --preference</code>  displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets). If there's not, it displays instead which ciphers from the server were picked with each protocol.</p>
 
 <p><code>-S, --server_defaults</code>  displays information from the server hello(s):</p>
 

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -175,7 +175,7 @@ Any single check switch supplied as an argument prevents testssl.sh from doing a
 
 `-p, --protocols`  checks TLS/SSL protocols SSLv2, SSLv3, TLS 1.0 through TLS 1.3 and for HTTP: SPDY (NPN) and ALPN, a.k.a. HTTP/2. For TLS 1.3 several drafts (from 18 on) and final are supported and being tested for.
 
-`-P, --preference`  displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets). If there's not, it displays instead which ciphers from the server were picked with each protocol.
+`-P, --server-preference, --preference`  displays the servers preferences: cipher order, with used openssl client: negotiated protocol and cipher. If there's a cipher order enforced by the server it displays it for each protocol (openssl+sockets). If there's not, it displays instead which ciphers from the server were picked with each protocol.
 
 `-S, --server_defaults`  displays information from the server hello(s):
 


### PR DESCRIPTION
Both `--server-preference` and `--preference` are accepted as options, but only `--server-preference` is listed in `--help` and only `--preference` in the documetation. This also adds the `--server-preference` option to the documentation.