### PR TITLE
Make sure util_Linux gets replaced as intended

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG INSTALL_ROOT
 # /etc/os-release provides $VERSION_ID below.
 # We don't need the openh264.repo and the non-oss repos, just costs build time (repo caches).
 # Also we need to remove the util_linux RPM to /really/ make sure busybox-util-linux gets installed.
-# And we need to update, see PR #2424
+# And we need to run zypper update, see all PR #2424.
 RUN source /etc/os-release \
   && rm -f /etc/zypp/repos.d/repo-openh264.repo /etc/zypp/repos.d/repo-non-oss.repo \
   && export ZYPPER_OPTIONS=( --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" ) \


### PR DESCRIPTION
There were some discussions in #2420 whether the zypper install commend worked as intended. While there's liitle doubt that those packages weren't installed this PR makes really sure that this is and will be always the case.

Also it does an update via ``zypper up`` as the image provided from dockerhub seemed to be somewhat behind.