### PR TITLE
Fix error when no *.pem CA bundles exist

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7612,6 +7612,8 @@ determine_trust() {
      esac
      debugme tmln_out
 
+     # Enable nullglob to prevent *.pem globs from breaking when there are no CA bundle files.
+     shopt -s nullglob
      # if you run testssl.sh from a different path /you can set either TESTSSL_INSTALL_DIR or CA_BUNDLES_PATH to find the CA BUNDLES
      if [[ -z "$CA_BUNDLES_PATH" ]]; then
           ca_bundles="$TESTSSL_INSTALL_DIR/etc/*.pem"
@@ -7649,6 +7651,8 @@ determine_trust() {
           fi
           ((i++))
      done
+     # Disable nullglob to avoid affecting the rest of the script.
+     shopt -u nullglob
      num_ca_bundles=$((i - 1))
      debugme tm_out " "
      if "$all_ok"; then


### PR DESCRIPTION
TL;DR: if you copy this project into a git repo, clones will see the error `Chain of trust               basename: extra operand ‘./etc/SSLSocketClient.java’`[.](https://xkcd.com/1700/) The same happens if you don't have any .pem CA bundles. Temporarily enabling nullglob fixes this.

This pull request is based on the latest version (f3c7eb43336889711b15bfff6b7be833f745cb04). I've tried to keep the fix from affecting the rest of the code as much as possible. I ran it a couple of times in different scenarios and found no issues.

## The error

I downloaded the testssl.sh repo and copied it to my project as a form of vendoring. After a commit and push, my project works on my machine, but on other machines it has this strange error in the middle:

```
$ testssl.sh --server-defaults boppreh.com

[...]
 Trust (hostname)             Ok via SAN and CN (SNI mandatory)
 Chain of trust               basename: extra operand ‘./etc/SSLSocketClient.java’
Try 'basename --help' for more information.
"./etc/*.pem" cannot be found / not readable
 EV cert (experimental)       no
[...]
```

Later on I learned that you can trigger this error by removing all .pem files in `./etc`.

## The bug(s)

Here's the step-by-step:

1. testssl.sh's [.gitignore](https://github.com/drwetter/testssl.sh/blob/3.2/.gitignore#L26) explicitly ignores `*.pem` files, even though the project contains a number of .pem CA bundles in [`etc`](https://github.com/drwetter/testssl.sh/tree/3.2/etc). Not a bug per-se, but unintuitive.
2. Git saw the `./testssl.sh-3.2/.gitignore` file, and promptly ignored all .pem files in `./testssl.sh-3.2`, including `etc`. So my local copy has CA bundles, but none of it was committed.
3. [At some point in testssl.sh](https://github.com/drwetter/testssl.sh/blob/f3c7eb43336889711b15bfff6b7be833f745cb04/testssl.sh#L7617-L7619) it lists all CA bundles using a `$DIR/*.pem` glob:

```bash
     if [[ -z "$CA_BUNDLES_PATH" ]]; then
          ca_bundles="$TESTSSL_INSTALL_DIR/etc/*.pem"
     else
          ca_bundles="$CA_BUNDLES_PATH/*.pem"
     fi
```

Because bash is uncivilized, this glob expands to itself when there are no matches (unless nullglob is set, more on that later). `ca_bundles` now contains something like `$DIR/*.pem`, when a list of files was expected.

4. It then iterates over $ca_bundles, and calls `basename` on each "file" while removing the .pem extension, equivalent to `basename $DIR/*`:

````bash
     for bundle_fname in $ca_bundles; do
          certificate_file[i]=$(basename ${bundle_fname//.pem})
````

5. The shell expands that pattern, now shortened to `$DIR/*` and matching a bunch of unrelated files. So `basename` receives too many operands and errors out, citing a random file (`basename: extra operand ‘./etc/SSLSocketClient.java’`). Also, why does basename use smart quotes in its error message? That alone wasted like half an hour of my time, looking for unicode characters sneaked in source code or env vars. But I digress.
6. More things naturally break down the line (`"./etc/*.pem" cannot be found / not readable`) because of the bad file path.

## The fix

The fix is very straightforward: [`shopt -s nullglob`](https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html). When a pattern has no matches, it expands to nothing instead of to itself.

What complicates matters is that it affects all following operations in the current shell. I tried wrapping the `ca_bundles` declaration in a subshell for this, but then the `for` loop splits it on spaces, which is bad if any of the CA bundle paths have spaces in them. Then I tried wrapping the whole `for` loop in a subshell, but it sets variables that are read later, so that doesn't work either.

In the end I opted for enabling nullglob just before those lines, and disabling it afterwards. This minimizes impact to other parts of the code, at the cost of looking like a band-aid.