### PR TITLE
Fix weird bash globbing (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7094,7 +7094,7 @@ determine_trust() {
           ca_bundles="$CA_BUNDLES_PATH/*.pem"
      fi
      for bundle_fname in $ca_bundles; do
-          certificate_file[i]=$(basename ${bundle_fname//.pem})
+          certificate_file[i]=$(basename ${bundle_fname//.pem 2>/dev/null})
           if [[ ! -r $bundle_fname ]]; then
                prln_warning "\"$bundle_fname\" cannot be found / not readable"
                return 1

--- a/testssl.sh
+++ b/testssl.sh
@@ -7094,7 +7094,7 @@ determine_trust() {
           ca_bundles="$CA_BUNDLES_PATH/*.pem"
      fi
      for bundle_fname in $ca_bundles; do
-          certificate_file[i]=$(basename ${bundle_fname//.pem 2>/dev/null})
+          certificate_file[i]=$(basename ${bundle_fname//.pem} 2>/dev/null)
           if [[ ! -r $bundle_fname ]]; then
                prln_warning "\"$bundle_fname\" cannot be found / not readable"
                return 1


### PR DESCRIPTION
What was problematic was the error message when the certificate stores were missing. This fixes it by redirecting the error message to /dev/null so that if the sub function detects the missing file it returns with an error by the program and not by executing "basename"

As for 3.2 this is for the 3.0 branch.