### PR TITLE
Bail out if user error bc of umask

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20518,7 +20518,9 @@ maketempf() {
           fi
           TEMPDIR=$(mktemp -d "$PWD/testssl.XXXXXX") || exit $ERR_FCREATE
      fi
-     TMPFILE=$TEMPDIR/tempfile.txt || exit $ERR_FCREATE
+     ls "$TEMPDIR/" 2>/dev/null || fatal "temporary directory needed not readeable" $ERR_FCREATE
+     TMPFILE=$TEMPDIR/tempfile.txt
+     touch $TEMPFILE 2>/dev/null || fatal "temporary directory needed not writeable" $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then
           ERRFILE="/dev/null"
      else

--- a/testssl.sh
+++ b/testssl.sh
@@ -20520,7 +20520,7 @@ maketempf() {
      fi
      ls "$TEMPDIR/" 2>/dev/null || fatal "temporary directory needed not readable" $ERR_FCREATE
      TMPFILE=$TEMPDIR/tempfile.txt
-     touch $TEMPFILE 2>/dev/null || fatal "temporary directory needed not writeable" $ERR_FCREATE
+     touch $TMPFILE 2>/dev/null || fatal "temporary directory needed not writeable" $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then
           ERRFILE="/dev/null"
      else

--- a/testssl.sh
+++ b/testssl.sh
@@ -20518,7 +20518,7 @@ maketempf() {
           fi
           TEMPDIR=$(mktemp -d "$PWD/testssl.XXXXXX") || exit $ERR_FCREATE
      fi
-     ls "$TEMPDIR/" 2>/dev/null || fatal "temporary directory needed not readeable" $ERR_FCREATE
+     ls "$TEMPDIR/" 2>/dev/null || fatal "temporary directory needed not readable" $ERR_FCREATE
      TMPFILE=$TEMPDIR/tempfile.txt
      touch $TEMPFILE 2>/dev/null || fatal "temporary directory needed not writeable" $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then


### PR DESCRIPTION
If a user chose a broken umask testssl.sh will start but emits subsequent errors.

This patch adds two sanity checks whether it is allowed to create and read files in the temp directory.

Fixes #2449