### PR TITLE
Bail out if user error bc of umask (3.0 branch)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17555,7 +17555,9 @@ maketempf() {
           fi
           TEMPDIR=$(mktemp -d "$PWD/testssl.XXXXXX") || exit $ERR_FCREATE
      fi
-     TMPFILE=$TEMPDIR/tempfile.txt || exit $ERR_FCREATE
+     ls "$TEMPDIR/" 2>/dev/null || fatal "temporary directory needed not readable" $ERR_FCREATE
+     TMPFILE=$TEMPDIR/tempfile.txt
+     touch $TMPFILE 2>/dev/null || fatal "temporary directory needed not writeable" $ERR_FCREATE
      if [[ "$DEBUG" -eq 0 ]]; then
           ERRFILE="/dev/null"
      else


### PR DESCRIPTION
Implementation for 3.0, 3.2 see #2450

If a user chose a broken umask testssl.sh will start but emits subsequent errors. This patch adds two sanity checks whether it is allowed to create and read files in the temp directory.

Fixes #2449