### PR TITLE
Secure Client-Initiated Renegotiation : fixes/enhancements

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17081,7 +17081,7 @@ run_renego() {
                               pid=$!
                               ( sleep $(($ssl_reneg_attempts*3)) && kill $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &
                               watcher=$!
-                              # Trick to get the return value of the openssl command, output redirection and a timeout. Yes, somme target hang/block after some tries.  
+                              # Trick to get the return value of the openssl command, output redirection and a timeout. Yes, some target hang/block after some tries.  
                               wait $pid && pkill -HUP -P $watcher 
                               tmp_result=$?
                               # If we are here, we have done two successful renegotiation (-2) and do the loop

--- a/testssl.sh
+++ b/testssl.sh
@@ -232,7 +232,7 @@ fi
 DISPLAY_CIPHERNAMES="openssl"           # display OpenSSL ciphername (but both OpenSSL and RFC ciphernames in wide mode)
 declare UA_STD="TLS tester from $SWURL"
 declare -r UA_SNEAKY="Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"
-SSL_RENEG_ATTEMPTS=${SSL_RENEG_ATTEMPTS:-6}       # number of times to check SSL Renegotiation
+SSL_RENEG_ATTEMPTS=${SSL_RENEG_ATTEMPTS:-10}       # number of times to check SSL Renegotiation
 
 ########### Initialization part, further global vars just being declared here
 #
@@ -17067,6 +17067,7 @@ run_renego() {
                          # Mitigations (default values) for:
                          # - node.js allows 3x R and then blocks. So then 4x should be tested.
                          # - F5 BIG-IP ADS allows 5x R and then blocks. So then 6x should be tested.
+                         # - Stormshield allows 9x and then blocks. So then 10x should be tested.
                          # This way we save a couple seconds as we weeded out the ones which are more robust
                          # Amount of times tested before breaking is set in SSL_RENEG_ATTEMPTS.
                          if [[ $SERVICE != HTTP ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -17036,13 +17036,13 @@ run_renego() {
           fileout "$jsonID" "WARN" "client x509-based authentication prevents this from being tested"
           sec_client_renego=1
      else
-	  # We will need $ERRFILE for mitigation detection
-	  if [[ $ERRFILE =~ dev.null ]]; then
-	       ERRFILE=$TEMPDIR/errorfile.txt || exit $ERR_FCREATE
-	       restore_errfile=1
-	  else
-	       restore_errfile=0
-	  fi
+          # We will need $ERRFILE for mitigation detection
+          if [[ $ERRFILE =~ dev.null ]]; then
+               ERRFILE=$TEMPDIR/errorfile.txt || exit $ERR_FCREATE
+               restore_errfile=1
+          else
+               restore_errfile=0
+          fi
           # We need up to two tries here, as some LiteSpeed servers don't answer on "R" and block. Thus first try in the background
           # msg enables us to look deeper into it while debugging
           echo R | $OPENSSL s_client $(s_client_options "$proto $BUGS $legacycmd $STARTTLS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &
@@ -17075,12 +17075,12 @@ run_renego() {
                          else
                               (for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep 1; done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE
-			      tmp_result=$?
-			      # If we are here, we have done two successful renegotiation (-2) and do the loop
-			      loop_reneg=$(($(grep -a '^RENEGOTIATING' $ERRFILE | wc -l)-2))
-			      # If we got less than 2/3 successful attempts during the loop with 1s pause, we are in presence of exponential backoff.
-			      if [[ $loop_reneg -le $(($ssl_reneg_attempts*2/3)) ]]; then
-				   tmp_result=2
+                              tmp_result=$?
+                              # If we are here, we have done two successful renegotiation (-2) and do the loop
+                              loop_reneg=$(($(grep -ac '^RENEGOTIATING' $ERRFILE )-2))
+                              # If we got less than 2/3 successful attempts during the loop with 1s pause, we are in presence of exponential backoff.
+                              if [[ $loop_reneg -le $(($ssl_reneg_attempts*2/3)) ]]; then
+                                   tmp_result=2
                               fi
                               case $tmp_result in
                                    0) pr_svrty_high "VULNERABLE (NOT ok)"; outln ", DoS threat ($ssl_reneg_attempts attempts)"
@@ -17118,7 +17118,7 @@ run_renego() {
      # https://www.openssl.org/news/vulnerabilities.html#y2009. It can only be tested with OpenSSL <=0.9.8k
      # Insecure Client-Initiated Renegotiation is missing ==> sockets. When we complete the handshake ;-)
      if [[ $restore_errfile -eq 1 ]]; then
-	  ERRFILE="/dev/null"
+          ERRFILE="/dev/null"
      fi
      tmpfile_handle ${FUNCNAME[0]}.txt
      return $ret

--- a/testssl.sh
+++ b/testssl.sh
@@ -17069,9 +17069,9 @@ run_renego() {
                               (for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep 1; done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE
 			      tmp_result=$?
-			      # If we are here, we have done two successfull renegotiation (-2) and do the loop
+			      # If we are here, we have done two successful renegotiation (-2) and do the loop
 			      loop_reneg=$(($(grep -a '^RENEGOTIATING' $ERRFILE | wc -l)-2))
-			      # If we got less than 2/3 successfull attemps during the loop with 1s pause, we are in precence of exponential backoff.
+			      # If we got less than 2/3 successful attempts during the loop with 1s pause, we are in presence of exponential backoff.
 			      if [[ $loop_reneg -le $(($ssl_reneg_attempts*2/3)) ]]; then
 				   tmp_result=2
                               fi


### PR DESCRIPTION
Replace https://github.com/drwetter/testssl.sh/pull/2443
and fix https://github.com/drwetter/testssl.sh/issues/2444

This original PR was about false positives on target doing sort of exponential backoff between renegotiation tries.

Here is a proposed simple but efficient way of detecting such mitigation.

Instead of trying to do precise timing measurement, we count the number of successful renegotiation.
As we separate each try by one second without waiting for any result, some try will be lost in case of aggressive exponential slow down between each try even with the command buffering done by openssl.
On the tested targets, the result are pretty good. With the default number of six of tries , only four success. With ten tries, only five are successful.
As a conservative disposition, we only consider the target mitigated if we lost 1/3 or more of tries.

On top of this, tree more fixes/enhancements for the Secure Client-Initiated Renegotiation test:
- there is case of connection hang/block after some renego retry. Implement a loop test timeout without loosing any test feature. This is the most tricky part, but finally work perfectly.
- push the number of retry to 10 for Stormshield based equipment's and others like it is done on sslyse. Some exhibits connections hang/block (for 6<Retry=<10) and need the previous loop timeout.
- decrease the wait from 1s to 0.25s between renego to speedup the loop. The loop timeout stay based on retries*1s.   