### PR TITLE
Fix Dockerfile.md formatting

### DIFF
--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -36,7 +36,7 @@ You can pull the image from dockerhub and run:
 docker run --rm -t drwetter/testssl.sh --fs example.com
 ```
 
-Supported tags are: ``3.2`` and ``latest`, which are the same, i.e. the rolling release. ``3.0`` is the latest stable version from git which might have a few improvements (see git log) over the released version 3.0.X.
+Supported tags are: ``3.2`` and ``latest``, which are the same, i.e. the rolling release. ``3.0`` is the latest stable version from git which might have a few improvements (see git log) over the released version 3.0.X.
 
 ``docker run --rm -t drwetter/testssl.sh:stable example.com``.
 


### PR DESCRIPTION
## Describe your changes

Trivial fix for wrong quotes in markdown:

> ![Screen Shot 2024-02-02 at 19 41 04](https://github.com/drwetter/testssl.sh/assets/1784648/f965d43a-45ee-46b6-8820-0aacf25a8a45)

What is your chnage about?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Typo fix
- [x] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable: 
- [ ] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
