### PR TITLE
MongoDB identification fix

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2360,7 +2360,7 @@ service_detection() {
           [[ -z "$SERVICE" ]] && head $TMPFILE | grep -Eaqi "jabber|xmpp" && SERVICE=XMPP
           [[ -z "$SERVICE" ]] && head $TMPFILE | grep -Eaqw "Jive News|InterNetNews|NNRP|INN|Kerio Connect|NNTP Service|Kerio MailServer|NNTP server" && SERVICE=NNTP
           # MongoDB port 27017 will respond to a GET request with a mocked HTTP response
-          [[ "$SERVICE" == HTTP ]] && head $TMPFILE | grep -Eaqw "MongoDB" && SERVICE=MongoDB
+          [[ "$SERVICE" == HTTP ]] && head $TMPFILE | grep -Eaqw "you are trying to access MongoDB over HTTP" && SERVICE=MongoDB
           debugme head -50 $TMPFILE | sed -e '/<HTML>/,$d' -e '/<html>/,$d' -e '/<XML/,$d' -e '/<xml/,$d' -e '/<\?XML/,$d' -e '/<\?xml/,$d' -e '/<\!DOCTYPE/,$d' -e '/<\!doctype/,$d'
      fi
 


### PR DESCRIPTION
The actual code grep for "MongoDB" keyword in the head of the HTTP session.
In case of "compressed" HTML, a big page is on one line. On a IT page, we could encounter the "MongoDB" keyword and miss-identify the application protocol.

Fixed by matching on a longuer string taken from a live MogoDB server.

Fix https://github.com/drwetter/testssl.sh/issues/2468