### PR TITLE
Correct client_renego timing bug.

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17080,7 +17080,13 @@ run_renego() {
                               pr_svrty_medium "VULNERABLE (NOT ok)"; outln ", potential DoS threat"
                               fileout "$jsonID" "MEDIUM" "VULNERABLE, potential DoS threat" "$cve" "$cwe" "$hint"
                          else
-                              (for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep $ssl_reneg_wait; done) | \
+                              # Clear the log to not get the content of previous run before the execution of the new one.
+                              echo -n > $TMPFILE
+                              # If we dont wait for the session to be established on slow server, we will try to re-negotiate
+                              # too early loosing all the attemps before the session establishment as OpenSSL will not buffer them
+                              # (only the first will be till the establishement of the session).
+                              (while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]]; do sleep 1; done; \
+                                   for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep $ssl_reneg_wait; done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &
                               pid=$!
                               ( sleep $(($ssl_reneg_attempts*3)) && kill $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &

--- a/testssl.sh
+++ b/testssl.sh
@@ -17083,7 +17083,7 @@ run_renego() {
                               # Clear the log to not get the content of previous run before the execution of the new one.
                               echo -n > $TMPFILE
                               # If we dont wait for the session to be established on slow server, we will try to re-negotiate
-                              # too early loosing all the attemps before the session establishment as OpenSSL will not buffer them
+                              # too early losing all the attempts before the session establishment as OpenSSL will not buffer them
                               # (only the first will be till the establishement of the session).
                               (while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]]; do sleep 1; done; \
                                    for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep $ssl_reneg_wait; done) | \


### PR DESCRIPTION
OpenSSL will buffer only the first command till the establishment of the session.
In case of slow session establishment, we could:
  * loose some renego trys missing proper mitigation implementation
  * loose some renego trys missing a real vulnerable host if 2/3 of the tries are lost during session establishment (very slow startup).

Wait for the session to be fully established before starting the renego loop.

Fix https://github.com/drwetter/testssl.sh/issues/2469