### PR TITLE
Fix subshell killing to avoid zombies

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17083,11 +17083,12 @@ run_renego() {
                               (for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep $ssl_reneg_wait; done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &
                               pid=$!
-                              ( sleep $(($ssl_reneg_attempts*3)) && kill $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &
+                              ( sleep $(($ssl_reneg_attempts*3)) && pkill -HUP -P $pid && wait $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &
                               watcher=$!
                               # Trick to get the return value of the openssl command, output redirection and a timeout. Yes, some target hang/block after some tries.  
-                              wait $pid && pkill -HUP -P $watcher 
+                              wait $pid && pkill -HUP -P $watcher
                               tmp_result=$?
+                              wait $watcher
                               # If we are here, we have done two successful renegotiation (-2) and do the loop
                               loop_reneg=$(($(grep -ac '^RENEGOTIATING' $ERRFILE )-2))
                               if [[ -f $TEMPDIR/was_killed ]]; then


### PR DESCRIPTION
Learned from the rest of the code ...

Bug introduced in https://github.com/drwetter/testssl.sh/pull/2459

Now survive many our of automated target testing without zombies.