### PR TITLE
Renego timing fix2

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17112,7 +17112,7 @@ run_renego() {
                                    for ((i=0; i < ssl_reneg_attempts; i++ )); do echo R; sleep $ssl_reneg_wait; done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &
                               pid=$!
-                              ( sleep $(($ssl_reneg_attempts*3)) && pkill -HUP -P $pid && wait $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &
+                              ( sleep $(($ssl_reneg_attempts*3)) && kill $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &
                               watcher=$!
                               # Trick to get the return value of the openssl command, output redirection and a timeout. Yes, some target hang/block after some tries.  
                               wait $pid && pkill -HUP -P $watcher

--- a/testssl.sh
+++ b/testssl.sh
@@ -17113,9 +17113,9 @@ run_renego() {
                               # too early losing all the attempts before the session establishment as OpenSSL will not buffer them
                               # (only the first will be till the establishement of the session).
                               (j=0; while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]] && [[ $j -lt 30 ]]; do sleep $ssl_reneg_wait; j=$(($j+1)); done; \
-                                   for ((i=0; i < $ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
+                                   for ((i=0; i < ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
                                        while [[ $(grep -ac '^RENEGOTIATING' $ERRFILE) -ne $(($i+3)) ]] && [[ -f $TEMPDIR/allowed_to_loop ]] \
-                                               && [[ $(tail -n1 $ERRFILE |grep -ac '^RENEGOTIATING') -eq 1 ]] && [[ $k -lt 120 ]]; \
+					       && [[ $(tail -n1 $ERRFILE |grep -acE '^(RENEGOTIATING|depth|verify)') -eq 1 ]] && [[ $k -lt 120 ]]; \
                                        do sleep $ssl_reneg_wait; k=$(($k+1)); done; \
                                    done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &

--- a/testssl.sh
+++ b/testssl.sh
@@ -17112,11 +17112,11 @@ run_renego() {
                               # If we dont wait for the session to be established on slow server, we will try to re-negotiate
                               # too early losing all the attempts before the session establishment as OpenSSL will not buffer them
                               # (only the first will be till the establishement of the session).
-                              (j=0; while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]] && [[ $j -lt 30 ]]; do sleep $ssl_reneg_wait; j=$((j++)); done; \
+                              (j=0; while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]] && [[ $j -lt 30 ]]; do sleep $ssl_reneg_wait; ((j++)); done; \
                                    for ((i=0; i < ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
                                        while [[ $(grep -ac '^RENEGOTIATING' $ERRFILE) -ne $((i+3)) ]] && [[ -f $TEMPDIR/allowed_to_loop ]] \
 					       && [[ $(tail -n1 $ERRFILE |grep -acE '^(RENEGOTIATING|depth|verify)') -eq 1 ]] && [[ $k -lt 120 ]]; \
-                                       do sleep $ssl_reneg_wait; k=$((k++)); done; \
+                                       do sleep $ssl_reneg_wait; ((k++)); done; \
                                    done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &
                               pid=$!

--- a/testssl.sh
+++ b/testssl.sh
@@ -17113,8 +17113,9 @@ run_renego() {
                               # too early losing all the attempts before the session establishment as OpenSSL will not buffer them
                               # (only the first will be till the establishement of the session).
                               (j=0; while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]] && [[ $j -lt 30 ]]; do sleep $ssl_reneg_wait; j=$(($j+1)); done; \
-                                   for ((i=0; i < $ssl_reneg_attempts; i++ )); do echo R; sleep $ssl_reneg_wait; j=0; \
-                                       while [[ $(grep -ac '^RENEGOTIATING' $ERRFILE) -ne $(($i+3)) ]] && [[ -f $TEMPDIR/allowed_to_loop ]] && [[ $k -lt 180 ]]; \
+                                   for ((i=0; i < $ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
+                                       while [[ $(grep -ac '^RENEGOTIATING' $ERRFILE) -ne $(($i+3)) ]] && [[ -f $TEMPDIR/allowed_to_loop ]] \
+                                               && [[ $(tail -n1 $ERRFILE |grep -ac '^RENEGOTIATING') -eq 1 ]] && [[ $k -lt 120 ]]; \
                                        do sleep $ssl_reneg_wait; k=$(($k+1)); done; \
                                    done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &


### PR DESCRIPTION
## Describe your changes

The heuristic for exponential backoff detection and the general case of renegociation request pushes to openssl are too timing context dependent.
You experienced it with the test-case for the initial TLS connection wait fix.

- Use the same strategy and wait for the result of the renegociation request before sending the next one.
- kill the heuristic. We now rely on the timeout previously introduced for hang connections to detect all cases.
- Clean up and local variable declaration.  

This change rely on a fix on the timeout/watchdog file, broken by the zombi fix. Commit fix included.

What is your change about?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable: 
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
