### PR TITLE
Fix CAA query when nodns set

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9111,32 +9111,35 @@ certificate_info() {
      jsonID="DNS_CAArecord"
      caa_node="$NODE"
      caa=""
-     while ( [[ -z "$caa" ]] &&  [[ ! -z "$caa_node" ]] ); do
-          caa="$(get_caa_rr_record $caa_node)"
-          [[ $caa_node =~ '.'$ ]] || caa_node+="."
-          caa_node=${caa_node#*.}
-     done
-     if [[ -n "$caa" ]]; then
-          pr_svrty_good "available"; out " - please check for match with \"Issuer\" above"
-          if [[ $(count_lines "$caa") -eq 1 ]]; then
-               out ": "
-          else
-               outln; out "$spaces"
-          fi
-          while read caa; do
-               if [[ -n "$caa" ]]; then
-                    all_caa+="$caa, "
-               fi
-          done <<< "$caa"
-          all_caa=${all_caa%, }                 # strip trailing comma
-          pr_italic "$(out_row_aligned_max_width "$all_caa" "$indent                              " $TERM_WIDTH)"
-          fileout "${jsonID}${json_postfix}" "OK" "$all_caa"
-     elif [[ -n "$NODNS" ]]; then
+
+    if [[ -n "$NODNS" ]]; then
           out "(instructed to minimize DNS queries)"
           fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed"
      else
-          pr_svrty_low "not offered"
-          fileout "${jsonID}${json_postfix}" "LOW" "--"
+          while ( [[ -z "$caa" ]] &&  [[ ! -z "$caa_node" ]] ); do
+               caa="$(get_caa_rr_record $caa_node)"
+               [[ $caa_node =~ '.'$ ]] || caa_node+="."
+               caa_node=${caa_node#*.}
+          done
+          if [[ -n "$caa" ]]; then
+               pr_svrty_good "available"; out " - please check for match with \"Issuer\" above"
+               if [[ $(count_lines "$caa") -eq 1 ]]; then
+                    out ": "
+               else
+                    outln; out "$spaces"
+               fi
+               while read caa; do
+                    if [[ -n "$caa" ]]; then
+                         all_caa+="$caa, "
+                    fi
+               done <<< "$caa"
+               all_caa=${all_caa%, }                 # strip trailing comma
+               pr_italic "$(out_row_aligned_max_width "$all_caa" "$indent                              " $TERM_WIDTH)"
+               fileout "${jsonID}${json_postfix}" "OK" "$all_caa"
+               else
+               pr_svrty_low "not offered"
+               fileout "${jsonID}${json_postfix}" "LOW" "--"
+          fi
      fi
      outln
 


### PR DESCRIPTION
## Describe your changes

Please refer to an issue here or describe the change thoroughly in your PR.

If minimal DNS/no DNS queries were requested it should not do CAA RR queries. It's a minor braking change but add consistency.


# What is your change about?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files

## If it's a code change please check the boxes which are applicable: 
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [x] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
