### PR TITLE
[Client Renego] Small important fixes

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17060,6 +17060,8 @@ run_renego() {
           # We will need $ERRFILE for mitigation detection
           if [[ $ERRFILE =~ dev.null ]]; then
                ERRFILE=$TEMPDIR/errorfile.txt || exit $ERR_FCREATE
+               # cleanup previous run if any (multiple IP)
+               rm -f $ERRFILE
                restore_errfile=1
           else
                restore_errfile=0
@@ -17105,14 +17107,16 @@ run_renego() {
                               (j=0; while [[ $(grep -ac '^SSL-Session:' $TMPFILE) -ne 1 ]] && [[ $j -lt 30 ]]; do sleep $ssl_reneg_wait; ((j++)); done; \
                                    for ((i=0; i < ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
                                        while [[ $(grep -ac '^RENEGOTIATING' $ERRFILE) -ne $((i+3)) ]] && [[ -f $TEMPDIR/allowed_to_loop ]] \
-					       && [[ $(tail -n1 $ERRFILE |grep -acE '^(RENEGOTIATING|depth|verify)') -eq 1 ]] && [[ $k -lt 120 ]]; \
-                                       do sleep $ssl_reneg_wait; ((k++)); done; \
+                                             && [[ $(tail -n1 $ERRFILE |grep -acE '^(RENEGOTIATING|depth|verify|notAfter)') -eq 1 ]] \
+                                             && [[ $k -lt 120 ]]; \
+                                           do sleep $ssl_reneg_wait; ((k++)); if (tail -5 $TMPFILE| grep -qa '^closed'); then sleep 1; break; fi; done; \
                                    done) | \
                                    $OPENSSL s_client $(s_client_options "$proto $legacycmd $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") >$TMPFILE 2>>$ERRFILE &
                               pid=$!
                               ( sleep $((ssl_reneg_attempts*3)) && kill $pid && touch $TEMPDIR/was_killed ) >&2 2>/dev/null &
                               watcher=$!
-                              # Trick to get the return value of the openssl command, output redirection and a timeout. Yes, some target hang/block after some tries.  
+                              # Trick to get the return value of the openssl command, output redirection and a timeout.
+                              # Yes, some target hang/block after some tries.
                               wait $pid
                               tmp_result=$?
                               pkill -HUP -P $watcher
@@ -17120,6 +17124,10 @@ run_renego() {
                               rm -f $TEMPDIR/allowed_to_loop
                               # If we are here, we have done two successful renegotiation (-2) and do the loop
                               loop_reneg=$(($(grep -ac '^RENEGOTIATING' $ERRFILE)-2))
+                              # As above, some servers close the connection and return value is zero
+                              if (tail -5 $TMPFILE| grep -qa '^closed'); then
+                                   tmp_result=1
+                              fi
                               if [[ -f $TEMPDIR/was_killed ]]; then
                                    tmp_result=2
                                    rm -f $TEMPDIR/was_killed


### PR DESCRIPTION
## Describe your changes

After the previous batch of testing logic fixes for client_renego tests, some smaller but important fixes for correctness.
The main one is the zero return value with server connection close case which was previously omitted in the loop.
Manually tested on 57 url with previously suspicious results with success. No regressions on 50 others.
Running at a large automated scale on clusters since last week with no problems.

- In case of multiple IP testing, clear ERRFILE between runs
- Zero return value with server connection close should be taken into account in the looping logic case too. Add it.
- Break the wait loop in case of connection close for faster result.
- Ignore "notAfter" in the wait loop for expired certificates.
- Indentation and tab cleanup.

What is your change about?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable: 
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
