### PR TITLE
Fix #2502

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14455,7 +14455,7 @@ parse_tls_serverhello() {
                                tls_extensions+=" (id=51), len=$extension_len\n"
                           fi
                           if [[ "$process_full" =~ all ]] || [[ "$process_full" == ephemeralkey ]]; then
-                               if [[ $extension_len -lt 4  ]]; then
+                               if [[ $extension_len -lt 8  ]]; then
                                     debugme tmln_warning "Malformed key share extension."
                                     [[ $DEBUG -ge 1 ]] && tmpfile_handle ${FUNCNAME[0]}.txt
                                     return 1


### PR DESCRIPTION
## Describe your changes

This PR fixes #2502 in the 3.2 branch by checking that the key_share extension is at least 4 bytes long (8 in ASCII-HEX). These 4 bytes encode the group value (2 bytes) and the length of the key (2 bytes).


## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
