### PR TITLE
Fix STARTTLS cap withouth validating if it's mandatory. 

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22881,7 +22881,7 @@ run_rating() {
      pr_headlineln " Rating (experimental) "
      outln
 
-     [[ -n "$STARTTLS_PROTOCOL" ]] && set_grade_cap "T" "Encryption via STARTTLS is not mandatory (opportunistic)."
+     [[ -n "$STARTTLS_PROTOCOL" ]] && pr_warning "Encryption via STARTTLS should be mandatory (not opportunistic). testssl doesn't check it.\n"
 
      pr_bold " Rating specs"; out " (not complete)  "; outln "SSL Labs's 'SSL Server Rating Guide' (version 2009q from 2020-01-30)"
      pr_bold " Specification documentation  "; pr_url "https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide"


### PR DESCRIPTION
## Describe your changes

testssl doesn't check if STARTTLS is mandatory and issues a message to warn users.
But instead of raising a warning message, it caps grade to T, which sets the score to 0. This is incorrect and unfair to users with security concerns.

## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files

## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [X] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
