### PR TITLE
Trailing space after value in header is fine

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2588,7 +2588,7 @@ match_ipv4_httpheader() {
 
      # Exclude some headers as they are mistakenly identified as ipv4 address. Issues #158, #323.
      # Also facebook used to have a CSP rule for 127.0.0.1
-     headers="$(grep -Evai "$excluded_header" $HEADERFILE)"
+     headers="$(grep -Evai "$excluded_header" $HEADERFILE 2>/dev/null)"
      if [[ "$headers" =~ $ipv4address ]]; then
           pr_bold " IPv4 address in header       "
           while read line; do
@@ -2736,6 +2736,8 @@ run_hsts() {
           # strict parsing now as suggested in #2381
           hsts_age_sec="${HEADERVALUE#*=}"
           hsts_age_sec=${hsts_age_sec%%;*}
+          # see #2466
+          hsts_age_sec=$(strip_trailing_space "$hsts_age_sec")
           if [[ $hsts_age_sec =~ \" ]]; then
                # remove first an last " in $hsts_age_sec (borrowed from strip_trailing_space/strip_leading_space):
                hsts_age_sec=$(printf "%s" "${hsts_age_sec#"${hsts_age_sec%%[!\"]*}"}")


### PR DESCRIPTION
This fixes #2466.

## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
