### PR TITLE
Revert "Update Dockerfile to leap 15.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-ARG LEAP_VERSION=15.6
+ARG LEAP_VERSION=15.5
 ARG INSTALL_ROOT=/rootfs
 
 FROM opensuse/leap:${LEAP_VERSION} as builder


### PR DESCRIPTION
Reverts drwetter/testssl.sh#2547

15.6. doesn´t build. Needed to be investigated 
