### PR TITLE
feat(rating): line-wrapping comments for grade_cap_reasons

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22933,15 +22933,20 @@ run_rating() {
      pr_headlineln " Rating (experimental) "
      outln
 
-     [[ -n "$STARTTLS_PROTOCOL" ]] && set_grade_cap "T" "STARTTLS encryption is not mandatory for clients. STARTTLS can only be secured client-side"
 
-     # TL;DR: E-mail transfer via port 25 is broken and the amendments suggested so far are duct tape. So please do not expect testssl.sh to shut up.
+     if [[ -n "$STARTTLS_PROTOCOL" ]]; then
+          read -r -d '' grade_cap_reason <<'EOF'
+TL;DR: E-mail transfer via port 25 is broken and the amendments suggested so far are duct tape. So please do not expect testssl.sh to shut up.
 
-     # Explanation: For other than SMTP you should use TLS as per RFC 8314 . For SMTP however there's this thing named reality: A mail server cannot
-     # just switch to the mail submission port 587 only and continue to receive mail from everyone. Even if you advertise this via SRV record (RFC 6186).
-     # For STARTTLS there's no way to tell for testssl.sh whether it is secure. A MitM can always intercept the connection, unless the client checks
-     # the certificate accordingly (it's getting better but some just don't). TLSA Records/DANE and MTA-STS (RFC-8461) on the server side can help too.
-     # But as said, it's useless unless the client MTA checks all that which no tool can check.
+Explanation: For other than SMTP you should use TLS as per RFC 8314. For SMTP however there's this thing named reality: A mail server cannot
+just switch to the mail submission port 587 only and continue to receive mail from everyone. Even if you advertise this via SRV record (RFC 6186).
+For STARTTLS there's no way to tell for testssl.sh whether it is secure. A MitM can always intercept the connection, unless the client checks
+the certificate accordingly (it's getting better but some just don't). TLSA Records/DANE and MTA-STS (RFC-8461) on the server side can help too.
+But as said, it's useless unless the client MTA checks all that which no tool can check.
+EOF
+          # We can't use newlines in the message, as the grade-sorting function will mess up the reason
+          set_grade_cap "T" "$(tr '\n' ' ' <<<$grade_cap_reason)"
+     fi
 
      pr_bold " Rating specs"; out " (not complete)  "; outln "SSL Labs's 'SSL Server Rating Guide' (version 2009q from 2020-01-30)"
      pr_bold " Specification documentation  "; pr_url "https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide"
@@ -23127,9 +23132,9 @@ run_rating() {
      # Pretty print - again, it's just nicer to read
      for reason in "${sorted_reasons[@]}"; do
           if [[ $reason_nr -eq 0 ]]; then
-               pr_bold " Grade cap reasons            "; outln "$reason"
+               pr_bold " Grade cap reasons            "; out_row_aligned_max_width "$reason\n" '                                ' $TERM_WIDTH
           else
-               outln "                              $reason"
+               out_row_aligned_max_width "                              $reason\n" '                                ' $TERM_WIDTH
           fi
           ((reason_nr++))
           fileout "grade_cap_reason_${reason_nr}" "INFO" "$reason"


### PR DESCRIPTION
## Describe your changes

Fixes #2567 

The grade_cap_reasons are now line-wrapped depending on terminal width

I've additional presumed you wanted the startTLS comment as a the grade-cap reason, and added it. It looks like this (with a narrow terminal):

![image](https://github.com/user-attachments/assets/0e94c1ad-2be1-43ba-8bb7-3b3d3bf272f8)

And for non-startTLS but still broken (on a wide terminal):

![image](https://github.com/user-attachments/assets/d6da4840-d4e2-4e62-aabf-202bf30faf95)


## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [x] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
