### PR TITLE
Fix json/csv output when STARTTLS problem is passed back (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -5050,7 +5050,8 @@ run_protocols() {
                     fileout "$jsonID" "OK" "not offered"
                     add_tls_offered ssl2 no
                     ;;
-               4)   out "likely "; pr_svrty_best "not offered (OK), "
+               4)   # STARTTLS problem
+                    out "likely "; pr_svrty_best "not offered (OK), "
                     fileout "$jsonID" "OK" "likely not offered"
                     add_tls_offered ssl2 no
                     pr_warning "received 4xx/5xx after STARTTLS handshake"; outln "$debug_recomm"
@@ -5220,7 +5221,7 @@ run_protocols() {
                pr_warning "TLS downgraded to STARTTLS plaintext"; outln
                fileout "$jsonID" "WARN" "TLS downgraded to STARTTLS plaintext"
                ;;
-          4)   out "likely not offered, "
+          4)   out "likely not offered, "                                  # STARTTLS problem
                fileout "$jsonID" "INFO" "likely not offered"
                add_tls_offered tls1 no
                pr_warning "received 4xx/5xx after STARTTLS handshake"; outln "$debug_recomm"
@@ -5301,8 +5302,8 @@ run_protocols() {
                pr_warning "TLS downgraded to STARTTLS plaintext"; outln
                fileout "$jsonID" "WARN" "TLS downgraded to STARTTLS plaintext"
                ;;
-          4)   out "likely not offered, "
-               fileout "$jsonID" "INFO" "not offered"
+          4)   out "likely not offered, "                        # STARTTLS problem
+               fileout "$jsonID" "INFO" "likely not offered"
                add_tls_offered tls1_1 no
                pr_warning "received 4xx/5xx after STARTTLS handshake"; outln "$debug_recomm"
                fileout "$jsonID" "WARN" "received 4xx/5xx after STARTTLS handshake${debug_recomm}"
@@ -5566,8 +5567,8 @@ run_protocols() {
                pr_warning "TLS downgraded to STARTTLS plaintext"; outln
                fileout "$jsonID" "WARN" "TLS downgraded to STARTTLS plaintext"
                ;;
-          4)   out "likely not offered, "
-               fileout "$jsonID" "INFO" "not offered"
+          4)   out "likely not offered, "              # STARTTLS problem
+               fileout "$jsonID" "INFO" "likely not offered"
                add_tls_offered tls1_3 no
                pr_warning "received 4xx/5xx after STARTTLS handshake"; outln "$debug_recomm"
                fileout "$jsonID" "WARN" "received 4xx/5xx after STARTTLS handshake${debug_recomm}"


### PR DESCRIPTION
In rare cases testssl.sh writes to the terminal an output "likely not offered" but misses the "likely" in the json/csv output.

This fixes #2575 for 3.0 by adding that word and amending the return value 4 with a comment.

## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
