### PR TITLE
Upgrade Dockerfile to leap 15.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-ARG LEAP_VERSION=15.5
+ARG LEAP_VERSION=15.6
 ARG INSTALL_ROOT=/rootfs
 
 FROM opensuse/leap:${LEAP_VERSION} as builder
@@ -18,7 +18,8 @@ RUN source /etc/os-release \
   && zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh \
   && rpm -e util-linux --nodeps \
   && zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
-       bash procps grep gawk sed coreutils busybox-util-linux busybox-vi ldns libidn2-0 socat openssl curl \
+       bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl \
+  && ln -s /usr/bin/busybox /usr/bin/hexdump \
   && zypper up -y \
   && zypper "${ZYPPER_OPTIONS[@]}" clean --all
 ## Cleanup (reclaim approx 13 MiB):


### PR DESCRIPTION
As EOL comes closer for openSUSE Leap 15.5 (https://en.opensuse.org/Lifetime) an update is needed.

``busybox-util-linux`` and ``busybox-vi`` had to be removed as they don't exist anymore. Busybox was added but hexdump was not provided by the vendor. As busybox was compiled "properly" hexdump can be added by just linking to it.

This fixes #2563


## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [x] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
