### PR TITLE
Support RFC 9150 cipher suites

### DIFF
--- a/etc/cipher-mapping.txt
+++ b/etc/cipher-mapping.txt
@@ -342,6 +342,8 @@
  0x02,0x00,0x80 - EXP-RC4-MD5                    SSL_CK_RC4_128_EXPORT40_WITH_MD5                   SSLv2      Kx=RSA(512)    Au=RSA     Enc=RC4(40)                    Mac=MD5      export    
       0x00,0x28 - EXP-KRB5-RC4-SHA               TLS_KRB5_EXPORT_WITH_RC4_40_SHA                    SSLv3      Kx=KRB5        Au=KRB5    Enc=RC4(40)                    Mac=SHA1     export    
       0x00,0x2B - EXP-KRB5-RC4-MD5               TLS_KRB5_EXPORT_WITH_RC4_40_MD5                    SSLv3      Kx=KRB5        Au=KRB5    Enc=RC4(40)                    Mac=MD5      export    
+      0xC0,0xB4 - TLS_SHA256_SHA256              TLS_SHA256_SHA256                                  TLSv1.3    Kx=any         Au=any     Enc=None                       Mac=SHA256             
+      0xC0,0xB5 - TLS_SHA384_SHA384              TLS_SHA384_SHA384                                  TLSv1.3    Kx=any         Au=any     Enc=None                       Mac=SHA384             
       0xC0,0x10 - ECDHE-RSA-NULL-SHA             TLS_ECDHE_RSA_WITH_NULL_SHA                        SSLv3      Kx=ECDH        Au=RSA     Enc=None                       Mac=SHA1               
       0xC0,0x06 - ECDHE-ECDSA-NULL-SHA           TLS_ECDHE_ECDSA_WITH_NULL_SHA                      SSLv3      Kx=ECDH        Au=ECDSA   Enc=None                       Mac=SHA1               
       0xC0,0x15 - AECDH-NULL-SHA                 TLS_ECDH_anon_WITH_NULL_SHA                        SSLv3      Kx=ECDH        Au=None    Enc=None                       Mac=SHA1               

--- a/etc/tls_data.txt
+++ b/etc/tls_data.txt
@@ -3,9 +3,9 @@
 # see #807 and #806 (especially
 # https://github.com/drwetter/testssl.sh/issues/806#issuecomment-318686374)
 
-# All 5 ciphers defined for TLS 1.3
+# 7 ciphers defined for TLS 1.3 in RFCs 8446 and 9150
 readonly TLS13_CIPHER="
-13,01, 13,02, 13,03, 13,04, 13,05"
+13,01, 13,02, 13,03, 13,04, 13,05, c0,b4, c0,b5"
 
 # 123 standard cipher + 4x GOST for TLS 1.2 and SPDY/NPN HTTP2/ALPN
 declare TLS12_CIPHER="

--- a/openssl-iana.mapping.html
+++ b/openssl-iana.mapping.html
@@ -425,6 +425,10 @@ xB9  TLS_RSA_PSK_WITH_NULL_SHA384
 <tr><td> [0xc0ae]</td><td>   ECDHE-ECDSA-AES128-CCM8      </td><td> ECDH     </td><td>   AESCCM  </td><td>  128          </td><td> TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8  </td></tr>
 <tr><td> [0xc0af]</td><td>   ECDHE-ECDSA-AES256-CCM8      </td><td> ECDH     </td><td>   AESCCM  </td><td>  256          </td><td> TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8  </td></tr>
 
+<!-- RFC 9150 -->
+<tr><td> [0xc0b4]</td><td>   TLS_SHA256_SHA256       </td><td> ECDH     </td><td>   Null  </td><td>  0          </td><td> TLS_SHA256_SHA256</td></tr>
+<tr><td> [0xc0b5]</td><td>   TLS_SHA384_SHA384       </td><td> ECDH     </td><td>   Null  </td><td>  0          </td><td> TLS_SHA384_SHA384</td></tr>
+
 <!-- OLD CHACHA POLY CIPHERS, per agreement with Peter Mosmans we use the names like SSLlabs -->
 <tr><td> [0xcc13]</td><td>   ECDHE-RSA-CHACHA20-POLY1305-OLD  </td><td> ECDH     </td><td>   ChaCha20-Poly1305</td><td>    </td><td> TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256_OLD</td></tr>
 <tr><td> [0xcc14]</td><td>   ECDHE-ECDSA-CHACHA20-POLY1305-OLD</td><td> ECDH     </td><td>   ChaCha20-Poly1305</td><td>    </td><td> TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256_OLD</td></tr>

--- a/utils/update_client_sim_data.pl
+++ b/utils/update_client_sim_data.pl
@@ -72,6 +72,10 @@ foreach my $client ( @$ssllabs ) {
 				push @ciphersuites, "TLS_AES_128_CCM_SHA256"; }
 			elsif ( $suite == "4869" ) {
 				push @ciphersuites, "TLS_AES_128_CCM_8_SHA256"; }
+			elsif ( $suite == "49332" ) {
+				push @ciphersuites, "TLS_SHA256_SHA256"; }
+			elsif ( $suite == "49333" ) {
+				push @ciphersuites, "TLS_SHA384_SHA384"; }
 			elsif ( exists $ciphers{$suite} ) {
 				push @ciphers, $ciphers{$suite}; }
 			elsif ( $suite == "255" ) {


### PR DESCRIPTION
## Describe your changes

[OpenSSL 3.4.0](https://github.com/openssl/openssl/blob/openssl-3.4.0/NEWS.md) was released on October 22, 2024, and it includes support for the TLS 1.3 integrity-only cipher suites defined in RFC 9150. This PR adds support those two cipher suites: TLS_SHA256_SHA256 and TLS_SHA384_SHA384.

## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [X] I have tested this __new feature__ against 1 host which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
