### PR TITLE
Client renego refactoring 

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17200,7 +17200,7 @@ run_renego() {
                # Connection could be closed by the server with 0 return value. We do one more iteration to not close
                # s_client STDIN too early as the close could come at any time and race with the tear down of s_client.
                # See https://github.com/drwetter/testssl.sh/issues/2590
-               # In this case the added iteration is harmfull as it will just spin in backgroup
+               # In this case the added iteration is harmless as it will just spin in backgroup
                for ((i=0; i <= ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
                    # 0 means client is renegotiating & doesn't return an error --> vuln!
                    # 1 means client tried to renegotiating but the server side errored then. You still see RENEGOTIATING in the output
@@ -17230,11 +17230,16 @@ run_renego() {
           if (tail -5 $TMPFILE| grep -qa '^closed'); then
                tmp_result=1
           fi
+          # timeout reached ?
           if [[ -f $TEMPDIR/was_killed ]]; then
                tmp_result=2
                rm -f $TEMPDIR/was_killed
           fi
           if [[ $SERVICE != HTTP ]]; then
+               # theoric possible case
+               if [[ $loop_reneg -eq 2 ]];
+                    $tmp_result=0
+               fi
                case $tmp_result in
                     0) pr_svrty_medium "VULNERABLE (NOT ok)"; outln ", potential DoS threat"
                        fileout "$jsonID" "MEDIUM" "VULNERABLE, potential DoS threat" "$cve" "$cwe" "$hint"

--- a/testssl.sh
+++ b/testssl.sh
@@ -17169,6 +17169,10 @@ run_renego() {
           prln_warning "not having provided client certificate and private key file, the client x509-based authentication prevents this from being tested"
           fileout "$jsonID" "WARN" "not having provided client certificate and private key file, the client x509-based authentication prevents this from being tested"
      else
+          # We will extensively use subshell and command pipe
+          # Do not let herited pipeline error control interfere
+          [[ $- == *e* ]] && restore_pipeerror=1 
+          [[ $restore_pipeerror == 1 ]] && set +e
           # We will need $ERRFILE for mitigation detection
           if [[ $ERRFILE =~ dev.null ]]; then
                ERRFILE=$TEMPDIR/errorfile.txt || exit $ERR_FCREATE
@@ -17279,6 +17283,7 @@ run_renego() {
                        ;;
                esac
           fi
+          [[ $restore_pipeerror == 1 ]] && set -e
      fi
 
      #pr_bold " Insecure Client-Initiated Renegotiation  "  # pre-RFC 5746, CVE-2009-3555

--- a/testssl.sh
+++ b/testssl.sh
@@ -17188,7 +17188,7 @@ run_renego() {
           # Amount of times tested before breaking is set in SSL_RENEG_ATTEMPTS.
 
           # Clear the log to not get the content of previous run before the execution of the new one.
-	  # (Used in the loop tests before s_client invocation)
+          # (Used in the loop tests before s_client invocation)
           echo -n > $TMPFILE
           echo -n > $ERRFILE
           # RENEGOTIATING wait loop watchdog file

--- a/testssl.sh
+++ b/testssl.sh
@@ -17173,11 +17173,6 @@ run_renego() {
           prln_warning "not having provided client certificate and private key file, the client x509-based authentication prevents this from being tested"
           fileout "$jsonID" "WARN" "not having provided client certificate and private key file, the client x509-based authentication prevents this from being tested"
      else
-#          # We will extensively use subshell and command pipe
-#          # Do not let herited pipeline error control interfere
-#          [[ $- == *e* ]] && restore_pipeerror=1 
-#          [[ $restore_pipeerror == 1 ]] && set +e
-#	  set +o pipefail
           # We will need $ERRFILE for mitigation detection
           if [[ $ERRFILE =~ dev.null ]]; then
                ERRFILE=$TEMPDIR/errorfile.txt || exit $ERR_FCREATE
@@ -17288,7 +17283,6 @@ run_renego() {
                        ;;
                esac
           fi
-#          [[ $restore_pipeerror == 1 ]] && set -e
      fi
 
      #pr_bold " Insecure Client-Initiated Renegotiation  "  # pre-RFC 5746, CVE-2009-3555

--- a/testssl.sh
+++ b/testssl.sh
@@ -17173,10 +17173,11 @@ run_renego() {
           prln_warning "not having provided client certificate and private key file, the client x509-based authentication prevents this from being tested"
           fileout "$jsonID" "WARN" "not having provided client certificate and private key file, the client x509-based authentication prevents this from being tested"
      else
-          # We will extensively use subshell and command pipe
-          # Do not let herited pipeline error control interfere
-          [[ $- == *e* ]] && restore_pipeerror=1 
-          [[ $restore_pipeerror == 1 ]] && set +e
+#          # We will extensively use subshell and command pipe
+#          # Do not let herited pipeline error control interfere
+#          [[ $- == *e* ]] && restore_pipeerror=1 
+#          [[ $restore_pipeerror == 1 ]] && set +e
+#	  set +o pipefail
           # We will need $ERRFILE for mitigation detection
           if [[ $ERRFILE =~ dev.null ]]; then
                ERRFILE=$TEMPDIR/errorfile.txt || exit $ERR_FCREATE
@@ -17209,7 +17210,7 @@ run_renego() {
                # s_client STDIN too early as the close could come at any time and race with the tear down of s_client.
                # See https://github.com/drwetter/testssl.sh/issues/2590
                # In this case the added iteration is harmless as it will just spin in backgroup
-               for ((i=0; i <= ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R; k=0; \
+               for ((i=0; i <= ssl_reneg_attempts; i++ )); do sleep $ssl_reneg_wait; echo R 2>/dev/null; k=0; \
                    # 0 means client is renegotiating & doesn't return an error --> vuln!
                    # 1 means client tried to renegotiating but the server side errored then. You still see RENEGOTIATING in the output
                    # Exemption from above: server closed the connection but return value was zero
@@ -17287,7 +17288,7 @@ run_renego() {
                        ;;
                esac
           fi
-          [[ $restore_pipeerror == 1 ]] && set -e
+#          [[ $restore_pipeerror == 1 ]] && set -e
      fi
 
      #pr_bold " Insecure Client-Initiated Renegotiation  "  # pre-RFC 5746, CVE-2009-3555

--- a/testssl.sh
+++ b/testssl.sh
@@ -17221,10 +17221,10 @@ run_renego() {
           tmp_result=$?
           pkill -HUP -P $watcher
           wait $watcher
-          # Stop any backgroud wait loop
+          # Stop any background wait loop
           rm -f $TEMPDIR/allowed_to_loop
           # If we are here, we have done the loop. Count the effective renego attempts.
-          # It could be less than the numbers of "for" itterations (minus one) in case of late server close.
+          # It could be less than the numbers of "for" iterations (minus one) in case of late server close.
           loop_reneg=$(grep -ac '^RENEGOTIATING' $ERRFILE)
           # As above, some servers close the connection and return value is zero
           if (tail -5 $TMPFILE| grep -qa '^closed'); then

--- a/testssl.sh
+++ b/testssl.sh
@@ -17237,8 +17237,8 @@ run_renego() {
           fi
           if [[ $SERVICE != HTTP ]]; then
                # theoric possible case
-               if [[ $loop_reneg -eq 2 ]];
-                    $tmp_result=0
+               if [[ $loop_reneg -eq 2 ]]; then
+                    tmp_result=0
                fi
                case $tmp_result in
                     0) pr_svrty_medium "VULNERABLE (NOT ok)"; outln ", potential DoS threat"


### PR DESCRIPTION
## Describe your changes

To correctly fix https://github.com/drwetter/testssl.sh/issues/2590 and potentially other reals corner cases, a complete refactoring of the test is needed.
It remove all the calls to openssl s_client other than the one in the big events driven testing loop.
The result is more robust, faster and cleaner.
It fixes a bad interaction bug with the --openssl-timeout option too.

As a side note, Akamai started to implement a mitigation (before renegotiation could only be enabled or disabled) . It close the connection after a completely unpredictable number of renegotiation (up to more than 30 seen) from the client point of view. So it could lead to potentially "false positive" (well it depend of your point of view...).
I will try later to reduce this noise, but this is not a regression.

## What is your pull request about?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
