### PR TITLE
Fix #2599

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1371,13 +1371,17 @@ fileout_insert_warning() {
      [[ "$CMDLINE=" =~ -iL ]] && return 0
      # Note we still have the message on screen + in HTML which is not as optimal as it could be
 
-     if "$do_pretty_json" && "$JSONHEADER"; then
+     # See #2599. The "clientProblem" wrapper should only be added if fileout_insert_warning()
+     # is called before fileout_banner(). The only instance in which this function is called
+     # after fileout_banner() is in the case of a TLS 1.3 only server when $OPENSSL does not
+     # support TLS 1.3.
+     if "$do_pretty_json" && "$JSONHEADER" && ! "$TLS13_ONLY"; then
           echo -e "          \"clientProblem${CLIENT_PROB_NO}\" : [" >>"$JSONFILE"
           CLIENT_PROB_NO=$((CLIENT_PROB_NO + 1))
           FIRST_FINDING=true       # make sure we don't have a comma here
      fi
      fileout "$1" "$2" "$3"
-     if "$do_pretty_json"; then
+     if "$do_pretty_json" && ! "$TLS13_ONLY"; then
           if "$JSONHEADER"; then
                echo -e "\n          ]," >>"$JSONFILE"
           else


### PR DESCRIPTION
## Describe your changes

This PR fixes #2599 by not wrapping `fileout()` messages in a "clientProblem" wrapper if TLS13_ONLY is set. The TLS13_ONLY flag being set is an indicator that `fileout_banner()` has already been called.

## What is your pull request about?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
