### PR TITLE
Fix #2615

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11079,25 +11079,27 @@ run_fs() {
                     # A few servers get confused if the signature_algorithms extension contains too many entries. So:
                     # * For TLS 1.3, break the list into two and test each half separately.
                     # * For TLS 1.2, generally limit the signature_algorithms extension to algorithms that are consistent with the key type.
+                    # At least one server gets confused if RSA+MD5 is offered first. So, the ordering is reversed so that the strongest
+                    # options appear in $sigalgs_to_test first.
                     for hexc in "${sigalgs_hex[@]}"; do
                          if [[ "$proto" == 04* ]]; then
                               if ! "${tls13_supported_sigalgs[i]}"; then
                                    if [[ "${proto##*-}" == 01 ]]; then
-                                        [[ $i -le 16 ]] && sigalgs_to_test+=", $hexc"
+                                        [[ $i -le 16 ]] && sigalgs_to_test=", $hexc$sigalgs_to_test"
                                    else
-                                        [[ $i -gt 16 ]] && sigalgs_to_test+=", $hexc"
+                                        [[ $i -gt 16 ]] && sigalgs_to_test=", $hexc$sigalgs_to_test"
                                    fi
                               fi
                          elif ! "${tls12_supported_sigalgs[i]}"; then
                               if [[ "$proto" =~ rsa ]]; then
                                    if [[ "${hexc:3:2}" == 01 ]] || [[ "${hexc:0:2}" == 08 ]]; then
-                                        sigalgs_to_test+=", $hexc"
+                                        sigalgs_to_test=", $hexc$sigalgs_to_test"
                                    fi
                               elif [[ "$proto" =~ dss ]]; then
-                                   [[ "${hexc:3:2}" == 02 ]] && sigalgs_to_test+=", $hexc"
+                                   [[ "${hexc:3:2}" == 02 ]] && sigalgs_to_test=", $hexc$sigalgs_to_test"
                               else
                                    if [[ "${hexc:3:2}" == 03 ]] || [[ "${hexc:0:2}" == 08 ]]; then
-                                        sigalgs_to_test+=", $hexc"
+                                        sigalgs_to_test=", $hexc$sigalgs_to_test"
                                    fi
                               fi
                          fi


### PR DESCRIPTION
## Describe your changes

The server mentioned in #2615 has a bug that results in it sending a handshake_failure alert rather than a successful connection if the signature_algorithms extension lists RSA+MD5 before one of the signature algorithms that it supports.

This PR works around this issue by reversing the order in which it lists the signature algorithms in the signature_algorithms extension, thus (generally) listing stronger options first.

This change should not affect the testing, except that it will result in the order of the supported signature algorithms being reversed in the output for servers that respect the client's preferences.

## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
