### PR TITLE
fix curves findings in TLS1.2 and prior versions

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10873,22 +10873,18 @@ run_fs() {
                          [[ $i -eq $high ]] && break
                          supported_curve[i]=true
                     done
-                    while true; do
-                         # Versions of TLS prior to 1.3 close the connection if the client does not support the curve
-                         # used in the certificate. The easiest solution is to move the curves to the end of the list.
-                         # instead of removing them from the ClientHello. This is only needed if there is no RSA certificate.
-                         if ((! "$HAS_TLS13" || [[ "$proto" == "-no_tls1_3" ]]) && [[ ! "$ecdhe_cipher_list" == *RSA* ]]) || break; then
+                    # Versions of TLS prior to 1.3 close the connection if the client does not support the curve
+                    # used in the certificate. The easiest solution is to move the curves to the end of the list.
+                    # instead of removing them from the ClientHello. This is only needed if there is no RSA certificate.
+                    if (! "$HAS_TLS13" || [[ "$proto" == "-no_tls1_3" ]]) && [[ ! "$ecdhe_cipher_list" == *RSA* ]]; then
+                         while true; do
                               curves_to_test=""
                               for (( i=low; i < high; i++ )); do
-                                   if ! "${curves_deprecated[i]}"; then
-                                        "${ossl_supported[i]}" && ! "${supported_curve[i]}" && curves_to_test+=":${curves_ossl[i]}"
-                                   fi
+                                   "${ossl_supported[i]}" && ! "${supported_curve[i]}" && curves_to_test+=":${curves_ossl[i]}"
                               done
                               [[ -z "$curves_to_test" ]] && break
                               for (( i=low; i < high; i++ )); do
-                                   if ! "${curves_deprecated[i]}"; then
-                                        "${supported_curve[i]}" && curves_to_test+=":${curves_ossl[i]}"
-                                   fi
+                                   "${supported_curve[i]}" && curves_to_test+=":${curves_ossl[i]}"
                               done
                               $OPENSSL s_client $(s_client_options "$proto -cipher "\'${ecdhe_cipher_list:1}\'" -ciphersuites "\'${tls13_cipher_list:1}\'" -curves "${curves_to_test:1}" $STARTTLS $BUGS -connect $NODEIP:$PORT $PROXY $SNI") &>$TMPFILE </dev/null
                               sclient_connect_successful $? $TMPFILE || break
@@ -10909,8 +10905,8 @@ run_fs() {
                               done
                               [[ $i -eq $high ]] && break
                               supported_curve[i]=true
-                         fi
-                    done
+                         done
+                    fi
                done
           done
      fi
@@ -10950,19 +10946,15 @@ run_fs() {
                # Versions of TLS prior to 1.3 close the connection if the client does not support the curve
                # used in the certificate. The easiest solution is to move the curves to the end of the list.
                # instead of removing them from the ClientHello. This is only needed if there is no RSA certificate.
-               while true; do
-                    if ([[ "$proto" == 03 ]] && [[ ! "$ecdhe_cipher_list" == *RSA* ]]) || break; then
+               if ([[ "$proto" == 03 ]] && [[ ! "$ecdhe_cipher_list" == *RSA* ]]); then
+                    while true; do
                          curves_to_test=""
                          for (( i=0; i < nr_curves; i++ )); do
-                              if ! "${curves_deprecated[i]}" || [[ "$proto" == 03 ]]; then
-                                   ! "${supported_curve[i]}" && curves_to_test+=", ${curves_hex[i]}"
-                              fi
+                              ! "${supported_curve[i]}" && curves_to_test+=", ${curves_hex[i]}"
                          done
                          [[ -z "$curves_to_test" ]] && break
                          for (( i=0; i < nr_curves; i++ )); do
-                              if ! "${curves_deprecated[i]}" || [[ "$proto" == 03 ]]; then
-                                   "${supported_curve[i]}" && curves_to_test+=", ${curves_hex[i]}"
-                              fi
+                              "${supported_curve[i]}" && curves_to_test+=", ${curves_hex[i]}"
                          done
                          len1=$(printf "%02x" "$((2*${#curves_to_test}/7))")
                          len2=$(printf "%02x" "$((2*${#curves_to_test}/7+2))")
@@ -10980,8 +10972,8 @@ run_fs() {
                          done
                          [[ $i -eq $nr_curves ]] && break
                          supported_curve[i]=true
-                    fi
-               done
+                    done
+               fi
           done
      fi
      if "$ecdhe_offered"; then


### PR DESCRIPTION
## Describe your changes

If a server uses a certificate with secp256r1 as its private key testssl.sh only finds the "secp256r1" while the server also offers secp384r1 and secp521r1.  This is caused by TLS versions prior to 1.3 closing the connection with the error "no shared cipher" if the client does not send the curve used in the certificate in the supported_groups extension.
The easiest solution (which is the one implemented here) is to move the curves found to the end of the supported_groups extension instead of removing them, once testssl.sh finds the same curve a second time it moves forward meaning that only an additional handshake is performed. An alternative would be to first find the private key of the certificate and, if a curve is used, add that curve as the last one instead of removing it from the ClientHello.


## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
