### PR TITLE
Fix bug when legacy NPN is tested against a TLS 1.3 host

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11299,7 +11299,7 @@ run_npn() {
           return 0
      fi
 
-     # TLS 1.3 s_client doesn't support -nextprotoneg when connecting with TLS 1.3. So we need to make sure it wont be used
+     # TLS 1.3 s_client doesn't support -nextprotoneg when connecting with TLS 1.3. So we need to make sure it won't be used
      # TLS13_ONLY is tested here again, just to be sure, see npn_pre
      if "$HAS_TLS13" && ! $TLS13_ONLY ]] ; then
            proto="-no_tls1_3"

--- a/testssl.sh
+++ b/testssl.sh
@@ -11258,6 +11258,12 @@ npn_pre(){
           fileout "NPN" "WARN" "not tested $OPENSSL doesn't support NPN/SPDY"
           return 7
      fi
+     if "$TLS13_ONLY"; then
+          # https://github.com/openssl/openssl/issues/3665
+          pr_warning "There's no such thing as NPN on TLS 1.3-only hosts"
+          fileout "NPN" "WARN" "not possible for TLS 1.3-only hosts"
+          return 6
+     fi
      return 0
 }
 
@@ -11281,16 +11287,24 @@ alpn_pre(){
 run_npn() {
      local tmpstr
      local -i ret=0
+     local proto=""
      local jsonID="NPN"
 
      [[ -n "$STARTTLS" ]] && return 0
      "$FAST" && return 0
      pr_bold " NPN/SPDY   "
+
      if ! npn_pre; then
           outln
           return 0
      fi
-     $OPENSSL s_client $(s_client_options "-connect $NODEIP:$PORT $BUGS $SNI -nextprotoneg "$NPN_PROTOs"") </dev/null 2>$ERRFILE >$TMPFILE
+
+     # TLS 1.3 s_client doesn't support -nextprotoneg when connecting with TLS 1.3. So we need to make sure it wont be used
+     # TLS13_ONLY is tested here again, just to be sure, see npn_pre
+     if "$HAS_TLS13" && ! $TLS13_ONLY ]] ; then
+           proto="-no_tls1_3"
+     fi
+     $OPENSSL s_client $(s_client_options "$proto -connect $NODEIP:$PORT $BUGS $SNI -nextprotoneg "$NPN_PROTOs"") </dev/null 2>$ERRFILE >$TMPFILE
      [[ $? -ne 0 ]] && ret=1
      tmpstr="$(grep -a '^Protocols' $TMPFILE | sed 's/Protocols.*: //')"
      if [[ -z "$tmpstr" ]] || [[ "$tmpstr" == " " ]]; then


### PR DESCRIPTION

## Describe your changes


When testing a TLS 1.3 host s_client_options used TLS 1.3 ciphers to test for NPN. As that is not implemented we nee dto make sure any other version is used.

This PR ensures that --after testing whether it's a TLS 1.3-only host where this test doesn't make any sense in the first place.

Fix for #2633

## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
