### PR TITLE
fix missing semicolon in docs

### DIFF
--- a/etc/README.md
+++ b/etc/README.md
@@ -14,7 +14,7 @@ The certificate trust stores were retrieved from
   --> "Keychain Access" (2 click). In that window --> "Keychains" --> "System Root"
   --> "Category" --> "All Items"
   Select all CA certificates except for "Developer ID Certification Authority", omit expired ones,  "File" --> "Export Items"
-    2. __Internet:__ Clone https://github.com/apple-oss-distributions/security_certificates.git, cd to ``security_certificates/certificates/roots``, ``for f in *.* do echo $f >/dev/stderr; openssl x509 -in $f -inform DER -outform PEM ;done >/tmp/Apple.pem``
+    2. __Internet:__ Clone https://github.com/apple-oss-distributions/security_certificates.git, cd to ``security_certificates/certificates/roots``, ``for f in *.*; do echo $f >/dev/stderr; openssl x509 -in $f -inform DER -outform PEM ;done >/tmp/Apple.pem``
 
 Google Chromium uses basically the trust stores above, see https://www.chromium.org/Home/chromium-security/root-ca-policy.
 


### PR DESCRIPTION
## Describe your changes

Fix missing semicolon in MacOS instructions. Without this, the command obviously isn't working.

## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [x] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
