### PR TITLE
Feature: Detection STARTTLS throtteling via code 421/SMTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@
 * BREACH check: list all compression methods and add brotli
 * Test for old winshock vulnerability
 * Test for STARTTLS injection vulnerabilities (SMTP, POP3, IMAP)
-* STARTTLS: XMPP server support, plus new set of OpenSSL-bad binaries
+* STARTTLS: XMPP server support, plus a new set of OpenSSL-bad binaries
+* STARTTLS sieve support, plus again a new set of OpenSSL-bad binaries
 * Several code improvements to STARTTLS, also better detection when no STARTTLS is offered
+* Detect throtteling via STARTTLS smtp
 * Renegotiation checks more reliable against different servers
 * STARTTLS on active directory service support
 * Security fixes: DNS and other input from servers
@@ -41,13 +43,13 @@
 * Added --user-agent argument to support using a custom User Agent
 * Added --overwrite argument to support overwriting output files without warning
 * Headerflag X-XSS-Protection is now labeled as INFO
+* Search for more HTTP security headers on the server
 * Strict parser for HSTS
 * DNS via proxy improvements
 * Client simulation runs in wide mode which is even better readable
 * Added --reqheader to support custom headers in HTTP requests
-* Search for more HTTP security headers on the server
 * Test for support for RFC 8879 certificate compression
-* Deprecating --fast and --ssl-native (warning but still av)
+* Deprecating --fast and --ssl-native (warning only but still av)
 * Compatible to GNU grep 3.8
 * Don't use external pwd command anymore
 * Doesn't hang anymore when there's no local resolver


### PR DESCRIPTION
## Describe your changes

For this another variable needed to be passed to `starttls_full_read()` via `starttls_smtp_dialog`, where the variable is defined.

Handling of the connection problem will occur at the calling level, `fd_socket()`, so that in the future this can be extended if another STARTTLS problem signals that we're too fast.

Fixes #2098.


## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [x] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
