### PR TITLE
Address CA file parsing problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 * Renegotiation checks improved, also no false positive for Node.js anymore
 * Major update of client simulations with self-collected up-to-date data
 * Update of CA certificate stores
-* Lots of bug fixes
+* Lots of bug and security fixes
 * More travis/CI checks -- still place for improvements
 * Man page reviewed
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -19681,10 +19681,10 @@ debug_globals() {
 # arg2: value (if no = provided)
 parse_opt_equal_sign() {
      if [[ "$1" == *=* ]]; then
-          echo ${1#*=}
+          safe_echo "${1#*=}"
           return 1  # = means we don't need to shift args!
      else
-          echo "$2"
+          safe_echo "$2"
           return 0  # we need to shift
      fi
 }
@@ -20254,8 +20254,11 @@ parse_cmd_line() {
      [[ $CMDLINE_IP == one ]] && ( is_ipv4addr "$URI" || is_ipv6addr "$URI" )  && fatal "\"--ip=one\" plus supplying an IP address doesn't work" $ERR_CMDLINE
      "$do_mx_all_ips" && [[ "$NODNS" == none ]] && fatal "\"--mx\" and \"--nodns=none\" don't work together" $ERR_CMDLINE
 
+     if [[ "${ADDITIONAL_CA_FILES}" =~ \  ]]; then
+          fatal "The CA file \"${ADDITIONAL_CA_FILES}\" must not contain spaces" $ERR_RESOURCE
+     fi
      ADDITIONAL_CA_FILES="${ADDITIONAL_CA_FILES//,/ }"
-     for fname in $ADDITIONAL_CA_FILES; do
+     for fname in ${ADDITIONAL_CA_FILES}; do
           [[ -s "$fname" ]] || fatal "CA file \"$fname\" does not exist" $ERR_RESOURCE
           grep -q "BEGIN CERTIFICATE" "$fname" || fatal "\"$fname\" is not CA file in PEM format" $ERR_RESOURCE
      done


### PR DESCRIPTION
## Describe your changes

.... by forbidding spaces in supplied CA files/directories

Also now we're sanitizing the cmd line parameter better using `safe_echo()`

See also https://github.com/testssl/testssl.sh/issues/2647 .

## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
