### PR TITLE
Fix check for OpenSSL supported curves

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20505,7 +20505,7 @@ find_openssl_binary() {
           HAS_CURVES=true
           for curve in "${curves_ossl[@]}"; do
                # Same as above, we just don't need a port for invalid.
-               $OPENSSL s_client -curves $curve -connect $NXCONNECT </dev/null 2>&1 | grep -Eiaq "Error with command|unknown option"
+               $OPENSSL s_client -curves $curve -connect $NXCONNECT </dev/null 2>&1 | grep -Eiaq "Error with command|unknown option|Call to SSL_CONF_cmd(.*) failed"
                [[ $? -ne 0 ]] && OSSL_SUPPORTED_CURVES+=" $curve "
           done
      fi


### PR DESCRIPTION
## Describe your changes

OpenSSL 3.X outputs a different error message than previous versions when `$OPENSSL s_client -curves X ...` is called with an unsupported curve. This was resulting in the check within `find_openssl_binary()` adding every curve to `$OPENSSL_SUPPORTED_CURVES`, even ones that were not supported. This PR changes to check in order to detect the new error message.

I have tested the fix against multiple versions of OpenSSL/LibreSSL and verified that `$OPENSSL_SUPPORTED_CURVES` is being set correctly.

## What is your pull request about?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
