### PR TITLE
fix(rating): explicit enable rating if required vuln-checks are enabled

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -23427,6 +23427,7 @@ set_rating_state() {
           return 1
      fi
 
+     do_rating=true
      return 0
 }
 


### PR DESCRIPTION
## Describe your changes

Please refer to an issue here or describe the change thoroughly in your PR.

## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md

-----

Fixes https://github.com/testssl/testssl.sh/issues/2665 - by explicitly enabling rating if all required vulnerability checks are enabled

`do_rating` is false by default, but is set to true with `set_scanning_defaults()` which is run when no parameters are passed (or when `--full` (maybe a few other options as well) is passed)

When `do_rating=true` (i.e. when `set_scanning_defaults()` is called) the `set_rating_state()` function is never ran.  
(see https://github.com/testssl/testssl.sh/blob/3.2/testssl.sh#L24260-L24266)

So... `set_rating_state()` is *only* run when `do_rating=false`; which means we have to set `do_rating=true` inside the function if all required vuln-checks are enabled.  
I did leave the `do_rating=false` return in there, as it provides valuable readability. Let me know if you want that out there; I can easily inverse the logic :-)

So this fix will leave cases where no arguments are passed (or `--full`, ...) with no changes; but correctly fix cases where one would pass all required parameters (as in the referenced issue)