### PR TITLE
Improved (experimental) Extended Validation (EV) certificate identification

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9637,13 +9637,15 @@ certificate_info() {
      jsonID="cert_certificatePolicies_EV"
      # only the first one, seldom we have two
      policy_oid=$(awk '/ .Policy: / { print $2 }' <<< "$cert_txt" | awk 'NR < 2')
-     if grep -Eq 'Extended Validation|Extended Validated|EV SSL|EV CA' <<< "$issuer" || \
+     if grep -Eq 'Extended Validation|Extended Validated|EV SSL|EV CA|EV TLS' <<< "$issuer" || \
+          [[ 2.23.140.1.1 == "$policy_oid" ]] || \
           [[ 2.16.840.1.114028.10.1.2 == "$policy_oid" ]] || \
           [[ 2.16.840.1.114412.1.3.0.2 == "$policy_oid" ]] || \
           [[ 2.16.840.1.114412.2.1 == "$policy_oid" ]] || \
           [[ 2.16.578.1.26.1.3.3 == "$policy_oid" ]] || \
           [[ 1.3.6.1.4.1.17326.10.14.2.1.2 == "$policy_oid" ]] || \
           [[ 1.3.6.1.4.1.17326.10.8.12.1.2 == "$policy_oid" ]] || \
+          [[ 1.3.6.1.4.1.38064.1.3.1.4 == "$policy_oid" ]] || \
           [[ 1.3.6.1.4.1.13177.10.1.3.10 == "$policy_oid" ]] ; then
           out "yes "
           fileout "${jsonID}${json_postfix}" "OK" "yes"


### PR DESCRIPTION
## Describe your changes

Three changes:

- added grep for "EV TLS" in addition to "EV SSL", as some issuers are using this.  This grep link actually picks-up most EV policies.
- Added policy detection for 2.23.140.1.1.  This is from CA Browser Forum https://cabforum.org/resources/object-registry/ extended-validation(1).
- Added policy detection for 1.3.6.1.4.1.38064.1.3.1.4 , which is SSL.com's EV policy.

## What is your pull request about?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [X] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
