### PR TITLE
Avoid subshell overhead

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10929,7 +10929,7 @@ run_fs() {
                     # Versions of TLS prior to 1.3 close the connection if the client does not support the curve
                     # used in the certificate. The easiest solution is to move the curves to the end of the list.
                     # instead of removing them from the ClientHello. This is only needed if there is no RSA certificate.
-                    if (! "$HAS_TLS13" || [[ "$proto" == "-no_tls1_3" ]]) && [[ ! "$ecdhe_cipher_list" == *RSA* ]]; then
+                    if { ! "$HAS_TLS13" || [[ "$proto" == "-no_tls1_3" ]]; } && [[ ! "$ecdhe_cipher_list" == *RSA* ]]; then
                          while true; do
                               curves_to_test=""
                               for (( i=low; i < high; i++ )); do
@@ -10999,7 +10999,7 @@ run_fs() {
                # Versions of TLS prior to 1.3 close the connection if the client does not support the curve
                # used in the certificate. The easiest solution is to move the curves to the end of the list.
                # instead of removing them from the ClientHello. This is only needed if there is no RSA certificate.
-               if ([[ "$proto" == 03 ]] && [[ ! "$ecdhe_cipher_list" == *RSA* ]]); then
+               if [[ "$proto" == 03 ]] && [[ ! "$ecdhe_cipher_list" == *RSA* ]]; then
                     while true; do
                          curves_to_test=""
                          for (( i=0; i < nr_curves; i++ )); do


### PR DESCRIPTION
## Describe your changes

This PR removes the use of parenthesis in two expressions in run_fs() in order to avoid subshell overhead.

## What is your pull request about?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs and the indentation is five spaces
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
