### PR TITLE
Banner change

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20500,7 +20500,7 @@ find_openssl_binary() {
           HAS_CURVES=true
           for curve in "${curves_ossl[@]}"; do
                # Same as above, we just don't need a port for invalid.
-               #FIXME: openssl 3 sometimes seems somtimes to hang  when using '-connect invalid.' for up to 10 seconds
+               #FIXME: openssl 3 sometimes seems to hang  when using '-connect invalid.' for up to 10 seconds
                $OPENSSL s_client -curves $curve -connect $NXCONNECT </dev/null 2>&1 | grep -Eiaq "Error with command|unknown option|cannot be set"
                [[ $? -ne 0 ]] && OSSL_SUPPORTED_CURVES+=" $curve "
           done

--- a/testssl.sh
+++ b/testssl.sh
@@ -20310,6 +20310,7 @@ find_openssl_binary() {
      local openssl_location cwd=""
      local ossl_wo_dev_info
      local curve
+     local ossl_line1="" yr=""
      local -a curves_ossl=("sect163k1" "sect163r1" "sect163r2" "sect193r1" "sect193r2" "sect233k1" "sect233r1" "sect239k1" "sect283k1" "sect283r1" "sect409k1" "sect409r1" "sect571k1" "sect571r1" "secp160k1" "secp160r1" "secp160r2" "secp192k1" "prime192v1" "secp224k1" "secp224r1" "secp256k1" "prime256v1" "secp384r1" "secp521r1" "brainpoolP256r1" "brainpoolP384r1" "brainpoolP512r1" "X25519" "X448" "brainpoolP256r1tls13" "brainpoolP384r1tls13" "brainpoolP512r1tls13" "ffdhe2048" "ffdhe3072" "ffdhe4096" "ffdhe6144" "ffdhe8192")
 
      # 0. check environment variable whether it's executable
@@ -21062,7 +21063,7 @@ EOF
      pr_bold "$bb3"
      outln "\n"
 
-     # remove clock and dow if the first word if it is a dow and not a dom (suse)
+     # remove clock and dow if the first word is a dow and not a dom (suse)
      short_built_date=${OSSL_BUILD_DATE/??:??:?? /}
      if [[ ${short_built_date%% *} =~ [A-Za-z]{3} ]]; then
         short_built_date=${short_built_date#* }


### PR DESCRIPTION
## Describe your changes


In order to tell openssl binaries better apart the short banner below the
hash tag signs contain now also the date. That is the short version of the
build date unless it is not supplied which is the case of opensuse. Then
the name contains the date and it's taken from there.

The start and end banner lines have the same length now.

"sieve" was added in a comment and the sequence where sieve appears in
a pattern was trying to match other occurences (i.e. after nntp)

While testing the banners it appeared under Linux that a) the vendor
supplied openssl sometimes hangs during startup when determining the
supported curves using -connect b) a pattern was missing to detect
whether the curve was not supported which falsely labeled all supplied curves
as supported when using /usr/bin/openssl . The pattern for the latter
was added (b). For a) there needs to be a follow up PR to avoid the
long delays.

b) was already done by @dcooper16 / Added my pattern also.


## What is your pull request about?
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ against >=2 hosts and I couldn't spot a problem
- [x] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
