### PR TITLE
Add a few extension numbers in the server hello

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14861,6 +14861,10 @@ parse_tls_serverhello() {
                     002F) tls_extensions+="TLS server extension \"certificate authorities\" (id=47), len=$extension_len\n" ;;
                     0030) tls_extensions+="TLS server extension \"oid filters\" (id=48), len=$extension_len\n" ;;
                     0031) tls_extensions+="TLS server extension \"post handshake auth\" (id=49), len=$extension_len\n" ;;
+                    0032) tls_extensions+="TLS server extension \"signature algorithms cert\" (id=50), len=$extension_len\n" ;;
+                    0034) tls_extensions+="TLS server extension \"transparency info \" (id=52), len=$extension_len\n" ;;
+                         # 54,55,56 (x36 to x38) is DTLS
+                    003A) tls_extensions+="TLS server extension \"ticket request \" (id=58), len=$extension_len\n" ;;
                     3374) tls_extensions+="TLS server extension \"next protocol\" (id=13172), len=$extension_len\n"
                           if [[ "$process_full" =~ all ]]; then
                                local -i protocol_len


### PR DESCRIPTION

Issue #2686 showed a server which listed an unknown extension number from RFC 8446. THis PR adds this number and a few (later) ones.

It just lists them when detected in `parse_tls_serverhello()`

See also https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml


## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs and the indentation is five spaces
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
