### PR TITLE
Fix OpenSSL version check

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20622,7 +20622,7 @@ find_openssl_binary() {
      OPENSSL_NR_CIPHERS=$(count_ciphers "$(actually_supported_osslciphers 'ALL:COMPLEMENTOFALL' 'ALL')")
 
      if [[ $OPENSSL_NR_CIPHERS -le 140 ]]; then
-          [[ ${OSSL_VER//./} -ge 210 ]] && HAS_DH_BITS=true
+          [[ "$OSSL_NAME" =~ LibreSSL ]] && [[ ${OSSL_VER//./} -ge 210 ]] && HAS_DH_BITS=true
           if "$SSL_NATIVE"; then
                outln
                pr_warning "LibreSSL/OpenSSL in native ssl mode with poor cipher support is not a good choice for testing INSECURE features!"


### PR DESCRIPTION
## Describe your changes

Before version 3.0.0, OpenSSL versions included letters (e.g., 1.1.1w). Such version numbers confuse `[[ ${OSSL_VER//./} -ge 210 ]]`. Since this check is only needed for LibreSSL, this commit adds a conditional so that the check is only performed for LibreSSL.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
