### PR TITLE
Fix --phone-out + ocsp, also in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG LEAP_VERSION=15.6
 ARG INSTALL_ROOT=/rootfs
 
-FROM opensuse/leap:${LEAP_VERSION} as builder
+FROM opensuse/leap:${LEAP_VERSION} AS builder
 ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -2052,6 +2052,7 @@ check_revocation_ocsp() {
      local host_header=""
      local openssl_bin="$OPENSSL"
      local addtl_warning=""
+     local smartswitch=false
 
      "$PHONE_OUT" || [[ -n "$stapled_response" ]] || return 0
      [[ -n "$GOOD_CA_BUNDLE" ]] || return 0
@@ -2087,6 +2088,7 @@ check_revocation_ocsp() {
                # See #2516 and probably also #2667 and #1275 .
                if [[ -x "$OPENSSL2" ]]; then
                     openssl_bin="$OPENSSL2"
+                    smartswitch=true
                     [[ $DEBUG -ge 3 ]] && echo "Switching to $openssl_bin "
                fi
           else
@@ -2094,19 +2096,26 @@ check_revocation_ocsp() {
           fi
           host_header=${uri##http://}
           host_header=${host_header%%/*}
-          if [[ "$OSSL_NAME" =~ LibreSSL ]]; then
-               host_header="-header Host ${host_header}"
-          elif [[ $OSSL_VER_MAJOR.$OSSL_VER_MINOR == 1.1.0* ]] || [[ $OSSL_VER_MAJOR.$OSSL_VER_MINOR == 1.1.1* ]] || \
-               [[ $OSSL_VER_MAJOR -ge 3 ]]; then
-               host_header="-header Host=${host_header}"
+
+          # This the follwomg is the default (like "-header Host r11.o.lencr.org")
+          host_header="-header Host ${host_header}"
+
+          if "$smartswitch" ; then
+               case $(openssl version -v | awk -F' ' '{ print $2 }') in
+                    # for those versions it's "-header Host=r11.o.lencr.org"
+                    3.*|1.1*) host_header=${host_header/Host /Host=} ;;
+               esac
           else
-               host_header="-header Host ${host_header}"
+               case $OSSL_VER_MAJOR.$OSSL_VER_MINOR in
+                    3.*|1.1*) host_header=${host_header/Host /Host=} ;;
+               esac
           fi
           $openssl_bin ocsp -no_nonce ${host_header} -url "$uri" \
                -issuer $TEMPDIR/hostcert_issuer.pem -verify_other $TEMPDIR/intermediatecerts.pem \
                -CAfile <(cat $ADDTL_CA_FILES "$GOOD_CA_BUNDLE") -cert $HOSTCERT -text &> "$tmpfile"
           success=$?
      fi
+
      if [[ $success -eq 0 ]] && grep -Fq "Response verify OK" "$tmpfile"; then
           response="$(grep -F "$HOSTCERT: " "$tmpfile")"
           response="${response#$HOSTCERT: }"


### PR DESCRIPTION
Previously in 4f1a91f92ee2a4a492929ab5558729fc13f456ad there was a double header sent to the server to check whether the certificate was revoked.

This PR addresses that and fixes #2667 .

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
