### PR TITLE
Set POODLE var when exiting run_ssl_poodle()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -15067,10 +15067,12 @@ run_ssl_poodle() {
      pr_bold " POODLE, SSL"; out " ($cve)               "
 
      if "$TLS13_ONLY" || [[ $(has_server_protocol ssl3) -eq 1 ]]; then
-          # one condition should normally suffice but we don't know when run_poddle() was called
+          # one condition should normally suffice but we don't know when run_poodle() was called
           pr_svrty_best "not vulnerable (OK)"
           outln ", no SSLv3 support"
           fileout "$jsonID" "OK" "not vulnerable, no SSLv3" "$cve" "$cwe"
+          # otherwise we'll get a non-zero return code + a warning 'Rerun including POODLE SSL check' @ TLS_FALLBACK_SCSV, see #2708
+          POODLE=1
           return 0
      fi
 


### PR DESCRIPTION
... so that run_tls_fallback_scsv() doesn't exit with a warning.

This fixes https://github.com/testssl/testssl.sh/issues/2708 .


## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
