### PR TITLE
Fix checks with HAS_UDS and HAS_UDS2

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -19668,7 +19668,7 @@ run_starttls_injection() {
           outln "Need socat for this check"
           return 1
      fi
-     if [[ -z "$HAS_UDS2" ]] && [[ -z "$HAS_UDS" ]]; then
+     if ! "$HAS_UDS2" && ! "$HAS_UDS"; then
           fileout "$jsonID" "WARN" "Need OpenSSL with Unix-domain socket s_client support for this check" "$cve" "$cwe" "$hint"
           outln "Need an OpenSSL with Unix-domain socket s_client support for this check"
           return 1


### PR DESCRIPTION
## Describe your changes

This PR fixes a check where the Boolean variables $HAS_UDS and $HAS_UDS2 are checked for whether they are empty rather than for whether they are true.

I haven't been able to test this PR, as I don't have a STARTTLS server to test against.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
