### PR TITLE
Remove redundant commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,13 @@ ARG INSTALL_ROOT
 
 # /etc/os-release provides $VERSION_ID below.
 # We don't need the openh264.repo and the non-oss repos, just costs build time (repo caches).
-# Also we need to remove the util_linux RPM to /really/ make sure busybox-util-linux gets installed.
-# And we need to run zypper update, see all PR #2424.
+
 RUN source /etc/os-release \
-  && rm -f /etc/zypp/repos.d/repo-openh264.repo /etc/zypp/repos.d/repo-non-oss.repo \
+  && zypper removerepo repo-openh264 repo-non-oss repo-update-non-oss \
   && export ZYPPER_OPTIONS=( --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" ) \
   && zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh \
-  && rpm -e util-linux --nodeps \
   && zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
        bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl \
-  && zypper up -y \
   && zypper "${ZYPPER_OPTIONS[@]}" clean --all
 ## Cleanup (reclaim approx 13 MiB):
 # None of this content should be relevant to the container:


### PR DESCRIPTION
.. see https://github.com/testssl/testssl.sh/issues/2420#issuecomment-1762749767

As suggested by @polarathene the not needed repos are more elegantly removed, commands for removing util-linux removal and zypper up were redudant and thus squashed.

First stage was build manually and it looked fine.

This fixes #2439 .


## What is your pull request about?
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
