### PR TITLE
refactor: Docker (Alpine) improvements

### DIFF
--- a/Dockerfile.git
+++ b/Dockerfile.git
@@ -1,24 +1,23 @@
-# Build using git repo
-
-FROM alpine:3.20
-
-WORKDIR /home/testssl
-
-ARG BUILD_VERSION
-ARG ARCHIVE_URL=https://github.com/testssl/testssl.sh/archive/
-ARG URL=https://github.com/testssl/testssl.sh.git
-
-RUN test -n "${BUILD_VERSION}" \
-    && apk update \
-    && apk add --no-cache bash procps drill git coreutils libidn curl socat openssl xxd \
-    && git clone --depth 1 --branch ${BUILD_VERSION} $URL /home/testssl \
+FROM alpine:3.21 AS base-alpine
+RUN apk update \
+    && apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd \
     && addgroup testssl \
     && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl \
-    && ln -s /home/testssl/testssl.sh /usr/local/bin/ \
-    && mkdir -m 755 -p /home/testssl/etc /home/testssl/bin
+    && ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
 
 USER testssl
-
 ENTRYPOINT ["testssl.sh"]
-
 CMD ["--help"]
+
+# Final image stage (add testssl.sh project files)
+# Choose either one as the final stage (defaults to last stage, `dist-git`)
+
+# 30MB Image (Local repo copy from build context, uses `.dockerignore`):
+FROM base-alpine AS dist-local
+COPY --chown=testssl:testssl . /home/testssl/
+
+# 38MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
+FROM base-alpine AS dist-git
+ARG GIT_URL=https://github.com/testssl/testssl.sh.git
+ARG GIT_BRANCH
+ADD --chown=testssl:testssl ${GIT_URL}#${GIT_BRANCH?branch-required} /home/testssl

--- a/Dockerfile.git
+++ b/Dockerfile.git
@@ -1,6 +1,5 @@
 FROM alpine:3.21 AS base-alpine
-RUN apk update \
-    && apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd \
+RUN apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd \
     && addgroup testssl \
     && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl \
     && ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh


### PR DESCRIPTION
## Describe your changes

Applying changes that I detailed in [this comment](https://github.com/testssl/testssl.sh/issues/2422#issuecomment-2841822406).

Alpine image size reduced from 60MB (_technically 52MB_) to 36MB (`dist-git`) or 28MB (`dist-local`).

**Change overview:**
- Alpine version bump 3.20 => 3.21
- Removed `WORKDIR /home/testssl` to be consistent with the [main `Dockerfile`](https://github.com/testssl/testssl.sh/blob/3a9746ccc5714d9b151d942a61652ad9fa8b6cd3/Dockerfile) which leaves working directory at default `/`.
- `apk update` is not needed, if run with `--no-cache` in a separate `RUN` it has no layer weight. Removing it or adding `--no-cache` reduces weight by 2MB.
- Removed `git` package + `git clone` command, no longer necessary. Reduces weight by 14MB+
- Removed `mkdir -m 755 -p /home/testssl/etc /home/testssl/bin`, these already exist with expected permissions via the clone.
- `ARG` renamed and relocated to end of file at the `dist-git` stage. Technically a breaking change, perhaps the `ARG` names should be kept the same?
- Added a `dist-local` stage that uses `COPY` for a local clone like the main `Dockerfile` does (_reduces weight by 8MB_). While `dist-git` stage uses `ADD` to perform a remote git clone.

Some of these changes were [attempted back in Feb 2023 for `Dockerfile`](https://github.com/testssl/testssl.sh/pull/2305#issue-1565416185) (_when it was still Alpine based_). That PR provides additional information to support these changes
- Such as `apk add --no-cache` implying `apk update`.
- A slight regression by removing `git` package and `.git/` dir which loses the `git log` feature to identify `testssl.sh` version via commit hash.

Related caveat with Alpine image in the past was incompatibility with the OpenSSL bins (glibc) that are copied over into the image, since even with a static glibc build, glibc static is known to have compatibility caveats when it comes to DNS logic (_looking through issue history on DNS / `getaddrinfo`, there was since talk about segfaults that required a newer static compile that resolved it, so maybe not a DNS musl issue at these linked comments_):
- https://github.com/testssl/testssl.sh/pull/2344#issue-1635419135
- https://github.com/testssl/testssl.sh/issues/2516#issuecomment-2724936258


## What is your pull request about?

- [x] Improvement

