### PR TITLE
Lowercase URL to match 'HTTPS://<server>/'

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21689,6 +21689,7 @@ parse_hn_port() {
      local node_tmp=""
 
      NODE="$1"
+     NODE="${NODE,,}"                   # Lowercase
      NODE="${NODE/https\:\/\//}"        # strip "https"
      NODE="${NODE%%/*}"                 # strip trailing urlpath
 


### PR DESCRIPTION
## Describe your changes

Allow uppercase for scheme, like "HTTP://host/" ... this change lowercases the text in the incoming URI . Since path is stripped, and case doesn't matter in hostnames, it does not impact the rest of the testing.

Please refer to an issue here or describe the change thoroughly in your PR.

## What is your pull request about?
- [x] Improvement

## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
