### PR TITLE
ci: `Dockerfile` - Support local and git builds with the openSUSE Leap image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,41 +6,57 @@ ARG INSTALL_ROOT=/rootfs
 FROM opensuse/leap:${LEAP_VERSION} AS builder
 ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT
-
-
-# /etc/os-release provides $VERSION_ID below.
-# We don't need the openh264.repo and the non-oss repos, just costs build time (repo caches).
-
-RUN source /etc/os-release \
+RUN \
+  # /etc/os-release provides ${VERSION_ID} for usage in ZYPPER_OPTIONS:
+  source /etc/os-release \
+  # We don't need the openh264.repo and the non-oss repos, just costs build time (repo caches).
   && zypper removerepo repo-openh264 repo-non-oss repo-update-non-oss \
   && export ZYPPER_OPTIONS=( --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" ) \
   && zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh \
   && zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
        bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl \
-  && zypper "${ZYPPER_OPTIONS[@]}" clean --all
-## Cleanup (reclaim approx 13 MiB):
-# None of this content should be relevant to the container:
-RUN  rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info}
-# Functionality that the container doesn't need:
-RUN  rm    "${INSTALL_ROOT}/usr/share/misc/termcap" \
-  && rm -r "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
+  && zypper "${ZYPPER_OPTIONS[@]}" clean --all \
+  ## Cleanup (reclaim approx 13 MiB):
+  # None of this content should be relevant to the container:
+  && rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info} \
+           "${INSTALL_ROOT}/usr/share/misc/termcap" \
+           "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
 
 
-# Create a new image with the contents of $INSTALL_ROOT
-FROM scratch
+# Create a new image with the contents of ${INSTALL_ROOT}
+FROM scratch AS base-leap
 ARG INSTALL_ROOT
 COPY --link --from=builder ${INSTALL_ROOT} /
-# Link busybox to tar, see #2403. Create user + (home with SGID set):
-RUN  ln -s /usr/bin/busybox /usr/bin/tar \
+RUN \
+  # Creates symlinks for any other commands that busybox can provide that
+  # aren't already provided by coreutils (notably hexdump + tar, see #2403):
+  # NOTE: `busybox --install -s` is not supported via the leap package, manually symlink commands.
+  ln -s /usr/bin/busybox /usr/bin/tar \
   && ln -s /usr/bin/busybox /usr/bin/hexdump \
+  && ln -s /usr/bin/busybox /usr/bin/xxd \
+  # Add a non-root user `testssl`, this is roughly equivalent to the `useradd` command:
+  # useradd --uid 1000 --user-group --create-home --shell /bin/bash testssl
   && echo 'testssl:x:1000:1000::/home/testssl:/bin/bash' >> /etc/passwd \
   && echo 'testssl:x:1000:' >> /etc/group \
   && echo 'testssl:!::0:::::' >> /etc/shadow \
   && install --mode 2755 --owner testssl --group testssl --directory /home/testssl \
-  && ln -s /home/testssl/testssl.sh /usr/local/bin/
+  # The home directory will install a copy of `testssl.sh`, symlink the script to be used as a command:
+  && ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
 
-# Copy over build context (after filtered by .dockerignore): bin/ etc/ testssl.sh
-COPY --chown=testssl:testssl . /home/testssl/
+# Runtime config:
 USER testssl
 ENTRYPOINT ["testssl.sh"]
 CMD ["--help"]
+
+# Final image stage (add `testssl.sh` project files)
+# Choose either one as the final stage (defaults to last stage, `dist-local`)
+
+# 62MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
+FROM base-leap AS dist-git
+ARG GIT_URL=https://github.com/testssl/testssl.sh.git
+ARG GIT_BRANCH
+ADD --chown=testssl:testssl ${GIT_URL}#${GIT_BRANCH?branch-required} /home/testssl
+
+# 54MB Image (Local repo copy from build context, uses `.dockerignore`):
+FROM base-leap AS dist-local
+COPY --chown=testssl:testssl . /home/testssl/

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -4,18 +4,19 @@ RUN apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd
     && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl \
     && ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
 
+# Runtime config:
 USER testssl
 ENTRYPOINT ["testssl.sh"]
 CMD ["--help"]
 
-# Final image stage (add testssl.sh project files)
+# Final image stage (add `testssl.sh` project files)
 # Choose either one as the final stage (defaults to last stage, `dist-git`)
 
-# 30MB Image (Local repo copy from build context, uses `.dockerignore`):
+# 27MB Image (Local repo copy from build context, uses `.dockerignore`):
 FROM base-alpine AS dist-local
 COPY --chown=testssl:testssl . /home/testssl/
 
-# 38MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
+# 35MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
 FROM base-alpine AS dist-git
 ARG GIT_URL=https://github.com/testssl/testssl.sh.git
 ARG GIT_BRANCH


### PR DESCRIPTION
## Describe your changes

This is roughly the equivalent of the [recent Alpine PR](https://github.com/testssl/testssl.sh/pull/2752) to bring the two to parity. Although this one has the more expected default of `dist-local` to be used with a `git clone`.

I've additionally:
- Shifted comments to be more inline with the `RUN` lines. These are omitted when parsed by `RUN`, unlike as shell script when `\` is involved. This is because all those lines for `RUN` will be collapsed to a single line when parsed and give to the shell to run.
- The symlink likewise is more explicit, matching the Alpine image.
- As that image also had `xxd` and BusyBox provides that, I've also add a symlink for that (_assuming the busybox xxd is compatible_).
- The cleanup step is no longer separate `RUN`, just a single `rm -r` command.

## What is your pull request about?

- [x] Improvement
- [x] Update of other files
