### PR TITLE
Uses tolower() utility for hostname conversion

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21689,7 +21689,7 @@ parse_hn_port() {
      local node_tmp=""
 
      NODE="$1"
-     NODE="${NODE,,}"                   # Lowercase
+     NODE="$(tolower "$NODE")"          # Lowercase
      NODE="${NODE/https\:\/\//}"        # strip "https"
      NODE="${NODE%%/*}"                 # strip trailing urlpath
 


### PR DESCRIPTION
## Describe your changes

Attempt at fixing #2759. Modified affected line to use the ``tolower()`` utility for lowercase conversion. Tested against multiple hosts and on different bash versions/OSs, works okay.

## What is your pull request about?
- [X] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
