### PR TITLE
Fix missing line feed in run_breach() failure output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17980,11 +17980,11 @@ run_breach() {
                     # warn_empty / warn_stalled
                     if [[ ${has_compression[@]} =~ warn_empty ]]; then
                          pr_warning "At least 1/4 checks failed (HTTP header request was empty, debug: ${has_compression[@]}"
-                         out ", debug: ${has_compression[@]})"
+                         outln ", debug: ${has_compression[@]})"
                          fileout "$jsonID" "WARN" "Test failed as HTTP response was empty, debug: ${has_compression[@]}" "$cve" "$cwe"
                     else # warn_stalled
                          pr_warning "At least 1/4 checks failed (HTTP header request stalled and was terminated"
-                         out ", debug: ${has_compression[@]})"
+                         outln ", debug: ${has_compression[@]})"
                          fileout "$jsonID" "WARN" "Test failed as HTTP request stalled and was terminated" "$cve" "$cwe"
                     fi
                else


### PR DESCRIPTION
## Describe your changes

This PR fixes [#2751](https://github.com/testssl/testssl.sh/issues/2751).

It substitutes the use of out() in run_breach() for outln() to correctly add a line feed when Breach fails. 

## What is your pull request about?
- [x] Bug fix


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
