### PR TITLE
ci(fix): Docker workflow `build-args` input should be a string

### DIFF
--- a/.github/workflows/docker-3.2.yml
+++ b/.github/workflows/docker-3.2.yml
@@ -56,8 +56,7 @@ jobs:
           context: .
           file: Dockerfile.alpine
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le
-          build-args:
-            - GIT_BRANCH
+          build-args: GIT_BRANCH
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
The [`build-args` list type input](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) is actually a white-space delimited string list, my mistake.

## Describe your changes

Fixes: https://github.com/testssl/testssl.sh/pull/2768#issuecomment-2871976661

Will alternatively be fixed by removing the input all together: https://github.com/testssl/testssl.sh/issues/2769 (**PR:** https://github.com/testssl/testssl.sh/pull/2771)

## What is your pull request about?

- [x] Bug fix
- [x] Typo fix
