### PR TITLE
ci: Docker - Prefer `dist-local` stage

### DIFF
--- a/.github/workflows/docker-3.2.yml
+++ b/.github/workflows/docker-3.2.yml
@@ -56,8 +56,6 @@ jobs:
           context: .
           file: Dockerfile.alpine
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le
-          build-args:
-            - GIT_BRANCH
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,12 +12,12 @@ CMD ["--help"]
 # Final image stage (add `testssl.sh` project files)
 # Choose either one as the final stage (defaults to last stage, `dist-git`)
 
-# 27MB Image (Local repo copy from build context, uses `.dockerignore`):
-FROM base-alpine AS dist-local
-COPY --chown=testssl:testssl . /home/testssl/
-
 # 35MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
 FROM base-alpine AS dist-git
 ARG GIT_URL=https://github.com/testssl/testssl.sh.git
 ARG GIT_BRANCH
 ADD --chown=testssl:testssl ${GIT_URL}#${GIT_BRANCH?branch-required} /home/testssl
+
+# 27MB Image (Local repo copy from build context, uses `.dockerignore`):
+FROM base-alpine AS dist-local
+COPY --chown=testssl:testssl . /home/testssl/


### PR DESCRIPTION
## Describe your changes

Changes the Alpine `Dockerfile` to also default to `dist-local` stage as the final image output, like the openSUSE Leap `Dockerfile` already does. The `dist-git` stage remains for now as opt-in, but I'm not sure if it has any notable advantage to any potential users, perhaps drop it in the 3.3 release series?

This will affect anyone relying on the `dist-git` default target (_which recently had a breaking change of `BUILD_VERSION` => `GIT_BRANCH` build arg_), they would now need to also be explicit about the `--target` stage when building. However just like mentioned in #2769 there is an alternative without `--target` that works effectively the same with `dist-local`:

```bash
docker build --tag localhost/testssl.sh:3.2 https://github.com/testssl/testssl.sh.git#3.2

# Alpine variant requires `--file`:
docker build \
  --tag localhost/testssl.sh:3.2-alpine \
  --file https://raw.githubusercontent.com/testssl/testssl.sh/3.2/Dockerfile-alpine \
  https://github.com/testssl/testssl.sh.git#3.2
```

Resolves: https://github.com/testssl/testssl.sh/issues/2769
Closes: https://github.com/testssl/testssl.sh/pull/2770

## What is your pull request about?

- [x] Improvement
- [x] Update of other files
