### PR TITLE
chore: `Dockerfile` consistency

### DIFF
--- a/.github/workflows/docker-3.2.yml
+++ b/.github/workflows/docker-3.2.yml
@@ -15,10 +15,8 @@ env:
   GIT_BRANCH: "3.2"
 
 jobs:
-
   deploy:
     runs-on: ubuntu-24.04
-
     steps:
       - name: lowercase the repository name
         run: echo "REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN <<HEREDOC
   # Install packages to a custom root-fs location (defined in `ZYPPER_OPTIONS`):
   zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh
   zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
-       bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl
+    bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl
 
   # Optional - Avoid `CACHE_ZYPPER` from being redundantly cached in this RUN layer:
   # (doesn't improve `INSTALL_ROOT` size thanks to `--cache-dir`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,42 +6,53 @@ ARG INSTALL_ROOT=/rootfs
 FROM opensuse/leap:${LEAP_VERSION} AS builder
 ARG CACHE_ZYPPER=/tmp/cache/zypper
 ARG INSTALL_ROOT
-RUN \
-  # /etc/os-release provides ${VERSION_ID} for usage in ZYPPER_OPTIONS:
-  source /etc/os-release \
-  # We don't need the openh264.repo and the non-oss repos, just costs build time (repo caches).
-  && zypper removerepo repo-openh264 repo-non-oss repo-update-non-oss \
-  && export ZYPPER_OPTIONS=( --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" ) \
-  && zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh \
-  && zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
-       bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl \
-  && zypper "${ZYPPER_OPTIONS[@]}" clean --all \
-  ## Cleanup (reclaim approx 13 MiB):
+RUN <<HEREDOC
+  # Remove the `openh264` the `non-oss` repos to save on sync time, they're not needed:
+  zypper removerepo repo-openh264 repo-non-oss repo-update-non-oss
+  # `/etc/os-release` provides the `VERSION_ID` variable for usage in `ZYPPER_OPTIONS`:
+  source /etc/os-release
+  export ZYPPER_OPTIONS=( --releasever "${VERSION_ID}" --installroot "${INSTALL_ROOT}" --cache-dir "${CACHE_ZYPPER}" )
+
+  # Install packages to a custom root-fs location (defined in `ZYPPER_OPTIONS`):
+  zypper "${ZYPPER_OPTIONS[@]}" --gpg-auto-import-keys refresh
+  zypper "${ZYPPER_OPTIONS[@]}" --non-interactive install --download-in-advance --no-recommends \
+       bash procps grep gawk sed coreutils busybox ldns libidn2-0 socat openssl curl
+
+  # Optional - Avoid `CACHE_ZYPPER` from being redundantly cached in this RUN layer:
+  # (doesn't improve `INSTALL_ROOT` size thanks to `--cache-dir`)
+  zypper "${ZYPPER_OPTIONS[@]}" clean --all
+
+  # Cleanup (reclaim approx 13 MiB):
   # None of this content should be relevant to the container:
-  && rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info} \
-           "${INSTALL_ROOT}/usr/share/misc/termcap" \
-           "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
+  rm -r "${INSTALL_ROOT}/usr/share/"{licenses,man,locale,doc,help,info} \
+    "${INSTALL_ROOT}/usr/share/misc/termcap" \
+    "${INSTALL_ROOT}/usr/lib/sysimage/rpm"
+HEREDOC
 
 
 # Create a new image with the contents of ${INSTALL_ROOT}
 FROM scratch AS base-leap
 ARG INSTALL_ROOT
 COPY --link --from=builder ${INSTALL_ROOT} /
-RUN \
+RUN <<HEREDOC
   # Creates symlinks for any other commands that busybox can provide that
   # aren't already provided by coreutils (notably hexdump + tar, see #2403):
   # NOTE: `busybox --install -s` is not supported via the leap package, manually symlink commands.
-  ln -s /usr/bin/busybox /usr/bin/tar \
-  && ln -s /usr/bin/busybox /usr/bin/hexdump \
-  && ln -s /usr/bin/busybox /usr/bin/xxd \
+  ln -s /usr/bin/busybox /usr/bin/tar
+  ln -s /usr/bin/busybox /usr/bin/hexdump
+  ln -s /usr/bin/busybox /usr/bin/xxd
+
   # Add a non-root user `testssl`, this is roughly equivalent to the `useradd` command:
   # useradd --uid 1000 --user-group --create-home --shell /bin/bash testssl
-  && echo 'testssl:x:1000:1000::/home/testssl:/bin/bash' >> /etc/passwd \
-  && echo 'testssl:x:1000:' >> /etc/group \
-  && echo 'testssl:!::0:::::' >> /etc/shadow \
-  && install --mode 2755 --owner testssl --group testssl --directory /home/testssl \
-  # The home directory will install a copy of `testssl.sh`, symlink the script to be used as a command:
-  && ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
+  echo 'testssl:x:1000:1000::/home/testssl:/bin/bash' >> /etc/passwd
+  echo 'testssl:x:1000:' >> /etc/group
+  echo 'testssl:!::0:::::' >> /etc/shadow
+  install --mode 2755 --owner testssl --group testssl --directory /home/testssl
+
+  # A copy of `testssl.sh` will be added to the home directory,
+  # symlink to that file so it can be treated as a command:
+  ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
+HEREDOC
 
 # Runtime config:
 USER testssl
@@ -49,7 +60,7 @@ ENTRYPOINT ["testssl.sh"]
 CMD ["--help"]
 
 # Final image stage (add `testssl.sh` project files)
-# Choose either one as the final stage (defaults to last stage, `dist-local`)
+# Choose either one as the final stage (defaults to the last stage, `dist-local`)
 
 # 62MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
 FROM base-leap AS dist-git

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,8 +1,20 @@
+# syntax=docker.io/docker/dockerfile:1
+
 FROM alpine:3.21 AS base-alpine
-RUN apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd \
-    && addgroup testssl \
-    && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl \
-    && ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
+RUN <<HEREDOC
+  apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd
+
+  # Add a non-root user `testssl`, this is roughly equivalent to the `adduser` command:
+  # addgroup testssl && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl
+  echo 'testssl:x:1000:1000::/home/testssl:/bin/bash' >> /etc/passwd
+  echo 'testssl:x:1000:' >> /etc/group
+  echo 'testssl:!::0:::::' >> /etc/shadow
+  install --mode 2755 --owner testssl --group testssl --directory /home/testssl
+
+  # A copy of `testssl.sh` will be added to the home directory,
+  # symlink to that file so it can be treated as a command:
+  ln -s /home/testssl/testssl.sh /usr/local/bin/testssl.sh
+HEREDOC
 
 # Runtime config:
 USER testssl
@@ -10,7 +22,7 @@ ENTRYPOINT ["testssl.sh"]
 CMD ["--help"]
 
 # Final image stage (add `testssl.sh` project files)
-# Choose either one as the final stage (defaults to last stage, `dist-git`)
+# Choose either one as the final stage (defaults to the last stage, `dist-local`)
 
 # 35MB Image (Remote repo clone, cannot filter content through `.dockerignore`):
 FROM base-alpine AS dist-git

--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -1,6 +1,6 @@
 ## Usage
 
-Run the image with `testssl.sh` options appended (default is `--help`). The container entrypoint is already set to `testsl.sh` as the command for convenience.
+Run the image with `testssl.sh` options appended (default is `--help`). The container entrypoint is already set to `testsl.sh` for convenience.
 
 ```bash
 docker run --rm -it ghcr.io/testssl/testssl.sh:3.2 --fs github.com
@@ -47,7 +47,7 @@ There are two base images supported:
 - openSUSE Leap ([`Dockerfile`](./Dockerfile)), glibc-based + faster.
 - Alpine ([`Dockerfile`](./Dockerfile.alpine)), musl-based + half the size.
 
-The Alpine variant is made available if you need broarder platform support, or an image about 30MB smaller at the expense of slightly slower performance.
+The Alpine variant is made available if you need broader platform support, or an image about 30MB smaller at the expense of slightly slower performance.
 
 #### Tip - Remote build context + `Dockerfile`
 

--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -19,19 +19,19 @@ docker run --rm -it -v /tmp:/data --workdir /data ghcr.io/testssl/testssl.sh:3.2
 
 > [!NOTE]
 > - The UID/GID ownership of the file will be created by the container user `testssl` (`1000:1000`), with permissions `644`.
-> - Your host directory must permit the `testssl` container user or group to write to that host volume. You could alternatively use [`docker cp`](https://docs.docker.com/reference/cli/docker/container/cp/).
+> - Your host directory must permit the `testssl` container user or group to write to that host volume. You could alternatively use [`docker cp`][docker-docs::cli::cp].
 
 ## Images
 
 ### Available at DockerHub and GHCR
 
 You can pull the image from either of these registries:
-- DockerHub: [`drwetter/testssl.sh`](https://hub.docker.com/r/drwetter/testssl.sh)
-- GHCR: [`ghcr.io/testssl/testssl.sh`](https://github.com/testssl/testssl.sh/pkgs/container/testssl.sh)
+- DockerHub: [`drwetter/testssl.sh`][image-registry::dockerhub]
+- GHCR: [`ghcr.io/testssl/testssl.sh`][image-registry::ghcr]
 
 Supported tags:
 - `3.2` / `latest`
-- `3.0` is the old stable version ([soon to become EOL](https://github.com/testssl/testssl.sh/tree/3.0#status))
+- `3.0` is the old stable version ([soon to become EOL][testssl::v3p0-eol])
 
 ### Building the `testssl.sh` container image
 
@@ -47,7 +47,9 @@ There are two base images supported:
 - openSUSE Leap ([`Dockerfile`](./Dockerfile)), glibc-based + faster.
 - Alpine ([`Dockerfile`](./Dockerfile.alpine)), musl-based + half the size.
 
-The Alpine variant is made available if you need broader platform support, or an image about 30MB smaller at the expense of slightly slower performance.
+The Alpine variant is made available if you need broader platform support, or an image about 30MB smaller at the expense of [slightly slower performance][testssl::base-image-performance].
+
+For contributors, if needing context on the [package selection has been documented][testssl::base-image-packages] for each base image.
 
 #### Tip - Remote build context + `Dockerfile`
 
@@ -58,7 +60,7 @@ docker build --tag localhost/testssl.sh:3.2 https://github.com/testssl/testssl.s
 ```
 
 > [!NOTE]
-> This will produce a slightly larger image as [`.dockerignore` is not supported with remote build contexts](https://github.com/docker/buildx/issues/3169).
+> This will produce a slightly larger image as [`.dockerignore` is not supported with remote build contexts][build::dockerignore-remote-context].
 
 ---
 
@@ -70,3 +72,11 @@ docker build \
   --file https://raw.githubusercontent.com/testssl/testssl.sh/3.2/Dockerfile.alpine \
   https://github.com/testssl/testssl.sh.git#3.2
 ```
+
+[docker-docs::cli::cp]: https://docs.docker.com/reference/cli/docker/container/cp/
+[image-registry::dockerhub]: https://hub.docker.com/r/drwetter/testssl.sh
+[image-registry::ghcr]: https://github.com/testssl/testssl.sh/pkgs/container/testssl.sh
+[testssl::v3p0-eol]: https://github.com/testssl/testssl.sh/tree/3.0#status
+[testssl::base-image-performance]: https://github.com/testssl/testssl.sh/issues/2422#issuecomment-2841822406
+[testssl::base-image-packages]: https://github.com/testssl/testssl.sh/issues/2422#issuecomment-2841822406
+[build::dockerignore-remote-context]: https://github.com/docker/buildx/issues/3169


### PR DESCRIPTION
## Describe your changes

- Further consistency between openSUSE + Alpine `Dockerfile` variants, with revised inline docs.
- `Dockerfile` adopts HereDoc syntax for better formatting in `RUN`.
- Associated `Dockerfile.md` docs revised with:
  - Minor revision + some typo fixes.
  - Organization of links to bottom of the document as refs.
  - Two new links referencing an issue comment for context on base image performance and package selection.

---

**NOTE:** I could revert the Alpine change for `addgroup` / `adduser`, but figured maintenance is easier if you don't have to think about [`useradd` vs `adduser` differences](https://github.com/canonical/chisel-releases/issues/549#issuecomment-2833390562).
- An added bonus is it should be quite apparent that the only real differences between the two is very minimal now that it'd be easy to have the main `Dockerfile` with only two lines for Alpine support (_and selected via a `--build-arg` or `--target` stage_), making `Dockerfile.alpine` redundant. Separate `Dockerfile` is absolutely fine though :+1:

Adopting the HereDoc feature was [originally proposed in Feb 2023](https://github.com/testssl/testssl.sh/pull/2305#issue-1565416185) but [rejected](https://github.com/testssl/testssl.sh/issues/2299#issuecomment-1478863039) due to being considered too new. It's been over 2 years since then and anyone building images today should really be using Docker v23 (Feb 2023) at a minimum.

HereDoc removes the `&& \` noise with `RUN`, the value is treated as a multi-line string that `/bin/sh -c` receives (symlinked to `bash` by openSUSE Leap, or to `ash` by Alpine_), thus it's more like a typical inline shell script.

## What is your pull request about?

- [x] Improvement
- [x] Typo fix
- [x] Documentation update
- [x] Update of other files
