### PR TITLE
Fix parser for server header (3.0)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2901,7 +2901,7 @@ run_server_banner() {
           run_http_header "$1" || return 1
      fi
      pr_bold " Server banner                "
-     grep -ai '^Server' $HEADERFILE >$TMPFILE
+     grep -wEai '^Server[^-]' $HEADERFILE >$TMPFILE
      if [[ $? -eq 0 ]]; then
           serverbanner=$(sed -e 's/^Server: //' -e 's/^server: //' $TMPFILE)
           serverbanner=${serverbanner//$'\r'}


### PR DESCRIPTION
## Describe your changes

Do word matching and exclude minus sign. This fixes https://github.com/testssl/testssl.sh/issues/2787 for 3.0.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
