### PR TITLE
Fix missing issuer CN

### DIFF
--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -26,8 +26,8 @@ my $openssl_json="";
 #       @args="$prg $check2run $uri >/dev/null";
 #       system("@args") == 0
 #           or die ("FAILED: \"@args\" ");
-my $socket_errors='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
-my $openssl_errors='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
+my $socket_errors='(e|E)rror|FIXME|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
+my $openssl_errors='(e|E)rror|FIXME|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 my $json_errors='(id".*:\s"scanProblem"|severity".*:\s"FATAL"|"Scan interrupted")';
 
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -10121,9 +10121,9 @@ certificate_info() {
                expok="OK"
           fi
           out " ($enddate). "
-          # Match on Subject/Issuer plus next 4 lines, there should be the CN
-          cn="$(awk '/Subject:/{stop=NR+4}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
-          issuer_CN="$(awk '/Issuer:/{stop=NR+4}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
+          # Match Subject/Issuer on next 5 lines, where the CN is (4 lines is fine in most cases, 5 should suffice for all certs)
+          cn="$(awk '/Subject:/{stop=NR+5}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
+          issuer_CN="$(awk '/Issuer:/{stop=NR+5}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
           # to catch errors like #2789 during unit test:
           [[ -z "$cn" ]] && cn="FIXME: cn error"
           [[ -z "$issuer_CN" ]] && issuer_CN="FIXME: issuer_CN error"

--- a/testssl.sh
+++ b/testssl.sh
@@ -10121,9 +10121,12 @@ certificate_info() {
                expok="OK"
           fi
           out " ($enddate). "
-          # Match on Subject/Issuer plus next 3 lines
-          cn="$(awk '/Subject:/{stop=NR+3}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
-          issuer_CN="$(awk '/Issuer:/{stop=NR+3}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
+          # Match on Subject/Issuer plus next 4 lines, there should be the CN
+          cn="$(awk '/Subject:/{stop=NR+4}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
+          issuer_CN="$(awk '/Issuer:/{stop=NR+4}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
+          # to catch errors like #2789 during unit test:
+          [[ -z "$cn" ]] && cn="FIXME: cn Error"
+          [[ -z "$issuer_CN" ]] && issuer_CN="FIXME: issuer_CN Error"
           pr_italic "$(strip_leading_space "$cn")"; out " <-- "; prln_italic "$(strip_leading_space "$issuer_CN")"
           fileout "intermediate_cert_notAfter <#${i}>${json_postfix}" "$expok" "$enddate"
           fileout "intermediate_cert_expiration <#${i}>${json_postfix}" "$expok" "$cn_finding"

--- a/testssl.sh
+++ b/testssl.sh
@@ -10125,8 +10125,8 @@ certificate_info() {
           cn="$(awk '/Subject:/{stop=NR+4}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
           issuer_CN="$(awk '/Issuer:/{stop=NR+4}; NR<=stop' <<< "${intermediate_certs_txt[i]}" | awk -F= '/CN/ { print $NF }')"
           # to catch errors like #2789 during unit test:
-          [[ -z "$cn" ]] && cn="FIXME: cn Error"
-          [[ -z "$issuer_CN" ]] && issuer_CN="FIXME: issuer_CN Error"
+          [[ -z "$cn" ]] && cn="FIXME: cn error"
+          [[ -z "$issuer_CN" ]] && issuer_CN="FIXME: issuer_CN error"
           pr_italic "$(strip_leading_space "$cn")"; out " <-- "; prln_italic "$(strip_leading_space "$issuer_CN")"
           fileout "intermediate_cert_notAfter <#${i}>${json_postfix}" "$expok" "$enddate"
           fileout "intermediate_cert_expiration <#${i}>${json_postfix}" "$expok" "$cn_finding"


### PR DESCRIPTION

## Describe your changes

This fixes a problem which was introduced @ 8d8f83ace507db6a699acb4901d1329f31731a04. It caused for some hosts not to parse / display the issuer CN correctly.

Also it adds some code in testssl.sh and in a unit test to detect this earlier. In general an output string FIXME will now cause a unit test to fail. This can + should be used at other places too!

Fixes #2789


Please refer to an issue here or describe the change thoroughly in your PR.

## What is your pull request about?
- [x] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
