### PR TITLE
Modify grading for incomplete chain. 

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7814,7 +7814,11 @@ determine_trust() {
                     out "$code"
                fi
                fileout "${jsonID}${json_postfix}" "CRITICAL" "failed $code. $addtl_warning"
-               set_grade_cap "T" "Issues with the chain of trust $code"
+               if [[ "$code" =~ "chain incomplete" ]]; then 
+                  set_grade_cap "B" "Issues with chain of trust $code"
+               else
+                  set_grade_cap "T" "Issues with chain of trust $code"
+               fi
           else
                # alt least one ok and other(s) not ==> display the culprit store(s)
                if "$some_ok"; then
@@ -7834,7 +7838,12 @@ determine_trust() {
                               if ! [[ ${certificate_file[i]} =~ Java ]]; then
                                    # Exemption for Java AND rating, as this store doesn't seem to be as complete.
                                    # We won't penalize this but we still need to raise a red flag. See #1648
-                                   set_grade_cap "T" "Issues with chain of trust $code"
+                                   # set_grade_cap "T" "Issues with chain of trust $code"
+                                   if [[ "$code" =~ "chain incomplete" ]]; then 
+                                      set_grade_cap "B" "Issues with chain of trust $code"
+                                   else
+                                      set_grade_cap "T" "Issues with chain of trust $code"
+                                   fi 
                               fi
                          fi
                     done


### PR DESCRIPTION
Modified grading for incomplete chain


## Describe your changes

SSLLabs doesn't give an T if the chain is incomplete but rather an B. Would be nice if we have the same grading here.

## What is your pull request about?
- [x ] Improvement


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
