### PR TITLE
Fix README DeepWiki Link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,7 +101,7 @@ This is the stable version 3.2. Please use it **now**, as 3.0.x will not get any
 
 * .. it is there for reading. Please do so :-) -- at least before asking questions. See man page in groff, html and markdown format in `~/doc/`.
 * [https://testssl.sh/](https://testssl.sh/) will help to get you started.
-* There's also a [https://deepwiki.com/testssl/testssl.sh](AI generated doc), see also below.
+* There's also an [AI generated doc](https://deepwiki.com/testssl/testssl.sh), see also below.
 * Will Hunt provides a longer [description](https://www.4armed.com/blog/doing-your-own-ssl-tls-testing/) for an older version (2.8), including useful background information.
 
 ### Contributing


### PR DESCRIPTION
## Describe your changes

Minor change to fix the DeepWiki link in the project's README. Before, the link was inside the square bracket section, and the label was in the round bracket section. This was causing it to render incorrectly, and point to the wrong link ("https://deepwiki.com/testssl/testssl.sh](AI") on-click anyway in some markdown renderers (including GitHub's).

(Also fixed grammar, updating "a" to be "an" before "AI generated doc")

## What is your pull request about?
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [x] Documentation update
- [ ] Update of other files
