### PR TITLE
Make code2network() faster by using bash instead of tr

### DIFF
--- a/t/52_ocsp_revoked.t
+++ b/t/52_ocsp_revoked.t
@@ -31,8 +31,8 @@ system("@args") == 0
      or die ("FAILED: \"@args\" ");
 $cat_csv=`cat $csv`;
 
-# Is the certificate revoked?
-like($cat_csv, qr/"cert_ocspRevoked".*"CRITICAL","revoked"/,"The certificate should be revoked");
+# Is the certificate revoked? (formerly: OCSP, now: CRL)
+like($cat_csv, qr/"cert_crlRevoked".*"CRITICAL","revoked"/,"The certificate should be revoked");
 $tests++;
 unlink $csv;
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -12139,16 +12139,20 @@ send_close_notify() {
      fi
 }
 
-# Format string properly for socket
-# ARG1: any commented sequence of two bytes hex, separated by commas. It can contain comments, new lines, tabs and white spaces
-# NW_STR holds the global with the string prepared for printf, like '\x16\x03\x03\'
+# Format string properly for socket in ARG1 as it can be found here
+# ARG1:   sequence of 2 bytes hex, separated by commas. Can contain comments, new lines, tabs + white spaces
+# NW_STR: holds afterwards the global with the string prepared for printf, like '\x16\x03\x03\'
+#
 code2network() {
-     NW_STR=$(sed -e 's/,/\\\x/g' <<< "$1" | sed -e 's/# .*$//g' -e 's/ //g' -e '/^$/d' | tr -d '\n' | tr -d '\t')
+     NW_STR="$(sed -e 's/,/\\\x/g' -e 's/# .*$//g' -e 's/ //g' -e '/^$/d' <<< "$1")"
+     NW_STR="${NW_STR//$'\n'/}"
+     NW_STR="${NW_STR//$'\t'/}"
 }
 
 # sockets inspired by https://blog.chris007.de/using-bash-for-network-socket-operation/
 # ARG1: hexbytes separated by commas, with a leading comma
 # ARG2: seconds to sleep
+#
 socksend_clienthello() {
      local data=""
 
@@ -12167,6 +12171,7 @@ socksend_clienthello() {
 
 # ARG1: hexbytes -- preceded by x -- separated by commas, with a leading comma
 # ARG2: seconds to sleep
+#
 socksend() {
      local data line
 


### PR DESCRIPTION
## Describe your changes

Please refer to an issue here or describe the change thoroughly in your PR.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
