### PR TITLE
Fix not working --disable-rating switch

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1125,6 +1125,7 @@ f5_port_decode() {
 # Sets the grade cap to ARG1
 # arg1: A grade to set ("A", "B", "C", "D", "E", "F", "M", or "T")
 # arg2: A reason why (e.g. "Vulnerable to CRIME")
+#
 set_grade_cap() {
      "$do_rating" || return 0
      GRADE_CAP_REASONS+=("Grade capped to $1. $2")
@@ -1141,6 +1142,7 @@ set_grade_cap() {
 
 # Sets a grade warning, as specified by the grade specification
 # arg1: A warning message
+#
 set_grade_warning() {
      "$do_rating" || return 0
      GRADE_WARNINGS+=("$1")
@@ -1150,6 +1152,7 @@ set_grade_warning() {
 # Sets the score for Category 2 (Key Exchange Strength)
 # arg1: Short key algorithm ("EC", "DH", "RSA", ...), or "DHE" for ephemeral key size
 # arg2: key size (number of bits)
+#
 set_key_str_score() {
      local type=$1
      local size=$2
@@ -1187,6 +1190,7 @@ set_key_str_score() {
 # Sets the best and worst bit size key, used to grade Category 3 (Cipher Strength)
 # This function itself doesn't actually set a score; its just in the name to keep it logical (score == rating function)
 # arg1: a bit size
+#
 set_ciph_str_score() {
      local size=$1
 
@@ -23880,6 +23884,7 @@ run_rating() {
 # Rating needs a mix of certificate and vulnerabilities checks, in order to give out proper grades.
 # This function disables rating, if not all required checks are enabled
 # Returns "0" if rating is enabled, and "1" if rating is disabled
+#
 set_rating_state() {
      local gbl
      local -i nr_enabled=0
@@ -23905,9 +23910,9 @@ set_rating_state() {
      return 0
 }
 
-
 # This initializes boolean global do_* variables. They keep track of what to do
 # -- as the name insinuates
+#
 initialize_globals() {
      do_allciphers=false
      do_vulnerabilities=false
@@ -23954,6 +23959,7 @@ initialize_globals() {
 
 
 # Set default scanning options for the boolean global do_* variables.
+#
 set_scanning_defaults() {
      do_allciphers=false
      do_vulnerabilities=true
@@ -24321,9 +24327,9 @@ parse_cmd_line() {
                     do_grease=true
                     ;;
                --disable-rating|--no-rating)
-                    SKIP_TESTS+=("rating")
                     # TODO: a generic thing would be --disable-* / --no-* ,
                     # catch $1 and add it to the array ( #1502 )
+                    SKIP_TESTS+=("rating")
                     ;;
                -9|--full)
                     set_scanning_defaults
@@ -24736,9 +24742,11 @@ parse_cmd_line() {
      set_skip_tests
      [[ "$DEBUG" -ge 5 ]] && debug_globals
 
-     # Unless explicit disabled, check if rating can be enabled
-     # Should be called after set_scanning_defaults
-     ! "$do_rating" && set_rating_state
+     # Unless explicit disabled, check if rating can or should be enabled.
+     # Should be called after set_scanning_defaults() and set_skip_tests()
+     if [[ ! ${SKIP_TESTS[@]} =~ rating ]] ; then
+          set_rating_state
+     fi
 
      CMDLINE_PARSED=true
 }


### PR DESCRIPTION

## Describe your changes

The logic was wrong when calling set_rating_state() in parse_cmd_line() as do_rating was set before to true through set_scanning_defaults().

This PR fixes that by querying ${SKIP_TESTS[@]} instead and then calling set_rating_state() when no --disable-rating was supplied .

Solves: #2825 .

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
