### PR TITLE
Removed rogue space on QUIC output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -6167,7 +6167,7 @@ sub_quic() {
           wait_kill $! $QUIC_WAIT
           if [[ $? -ne 0 ]]; then
                if [[ -n "$PROXY" ]]; then
-                    proxy_hint_str="(tried directly, is not proxyable):"
+                    proxy_hint_str="(tried directly, is not proxyable): "
                fi
                outln "${proxy_hint_str}not offered or timed out"
                fileout "$jsonID" "INFO" "$proxy_hint_str not offered"

--- a/testssl.sh
+++ b/testssl.sh
@@ -6169,7 +6169,7 @@ sub_quic() {
                if [[ -n "$PROXY" ]]; then
                     proxy_hint_str="(tried directly, is not proxyable):"
                fi
-               outln "$proxy_hint_str not offered or timed out"
+               outln "${proxy_hint_str}not offered or timed out"
                fileout "$jsonID" "INFO" "$proxy_hint_str not offered"
           else
                pr_svrty_best "offered (OK)"


### PR DESCRIPTION
There was an extra space in the output when QUIC wasn't offered or timed out, this has removed it for that specific instance.

Before:

```
 TLS 1.2    offered (OK)
 TLS 1.3    not offered and downgraded to a weaker protocol
 QUIC        not offered or timed out
 NPN/SPDY   not offered
```

After:

```
 TLS 1.2    offered (OK)
 TLS 1.3    not offered and downgraded to a weaker protocol
 QUIC       not offered or timed out
 NPN/SPDY   not offered
```


## Describe your changes

There is an extra space after QUIC in the `--protocols` output.

## What is your pull request about?
- [] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ x] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [ x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
