### PR TITLE
Opossum vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * QUIC protocol check
 * bump SSLlabs rating guide to 2009r
+* Check for Opossum vulnerability
 
 ### Features implemented / improvements in 3.2
 

--- a/doc/testssl.1
+++ b/doc/testssl.1
@@ -659,6 +659,9 @@ variable \f[CR]CCS_MAX_WAITSOCK\f[R].
 \f[CR]\-T, \-\-ticketbleed\f[R] Checks for Ticketbleed memory leakage in
 BigIP loadbalancers.
 .PP
+\f[CR]\-\-OP, \-\-opossum\f[R] Checks for HTTP to HTTPS upgrade
+vulnerability named Opossum.
+.PP
 \f[CR]\-\-BB, \-\-robot\f[R] Checks for vulnerability to ROBOT /
 (\f[I]Return Of Bleichenbacher\[cq]s Oracle Threat\f[R]) attack.
 .PP
@@ -1311,6 +1314,8 @@ directly.
 RFC 2246: The TLS Protocol Version 1.0
 .IP \[bu] 2
 RFC 2595: Using TLS with IMAP, POP3 and ACAP
+.IP \[bu] 2
+RFC 2817: Upgrading to TLS Within HTTP/1.1
 .IP \[bu] 2
 RFC 2818: HTTP Over TLS
 .IP \[bu] 2

--- a/doc/testssl.1.html
+++ b/doc/testssl.1.html
@@ -590,6 +590,8 @@
         <code>CCS_MAX_WAITSOCK</code>.</p>
         <p><code>-T, --ticketbleed</code> Checks for Ticketbleed memory
         leakage in BigIP loadbalancers.</p>
+        <p><code>--OP, --opossum</code> Checks for HTTP to HTTPS upgrade
+        vulnerability named Opossum.</p>
         <p><code>--BB, --robot</code> Checks for vulnerability to ROBOT
         / (<em>Return Of Bleichenbacher’s Oracle Threat</em>)
         attack.</p>
@@ -1131,6 +1133,7 @@
         <ul>
         <li>RFC 2246: The TLS Protocol Version 1.0</li>
         <li>RFC 2595: Using TLS with IMAP, POP3 and ACAP</li>
+        <li>RFC 2817: Upgrading to TLS Within HTTP/1.1</li>
         <li>RFC 2818: HTTP Over TLS</li>
         <li>RFC 2830: Lightweight Directory Access Protocol (v3):
         Extension for Transport Layer Security</li>

--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -236,9 +236,11 @@ Also for multiple server certificates are being checked for as well as for the c
 
 `-T, --ticketbleed`             Checks for Ticketbleed memory leakage in BigIP loadbalancers.
 
-`--BB, --robot`          Checks for vulnerability to ROBOT / (*Return Of Bleichenbacher's Oracle Threat*) attack.
+`--OP, --opossum`               Checks for HTTP to HTTPS upgrade vulnerability named Opossum.
 
-`--SI, --starttls-injection`          Checks for STARTTLS injection vulnerabilities (SMTP, IMAP, POP3 only). `socat` and OpenSSL >=1.1.0 is needed.
+`--BB, --robot`                 Checks for vulnerability to ROBOT / (*Return Of Bleichenbacher's Oracle Threat*) attack.
+
+`--SI, --starttls-injection`    Checks for STARTTLS injection vulnerabilities (SMTP, IMAP, POP3 only). `socat` and OpenSSL >=1.1.0 is needed.
 
 `-R, --renegotiation`           Tests renegotiation vulnerabilities. Currently there's a check for *Secure Renegotiation* and for *Secure Client-Initiated Renegotiation*. Please be aware that vulnerable servers to the latter can likely be DoSed very easily (HTTP). A check for *Insecure Client-Initiated Renegotiation* is not yet implemented.
 
@@ -490,6 +492,7 @@ Please note that for plain TLS-encrypted ports you must not specify the protocol
 
 * RFC 2246: The TLS Protocol Version 1.0
 * RFC 2595: Using TLS with IMAP, POP3 and ACAP
+* RFC 2817: Upgrading to TLS Within HTTP/1.1
 * RFC 2818: HTTP Over TLS
 * RFC 2830: Lightweight Directory Access Protocol (v3): Extension for Transport Layer Security
 * RFC 3207: SMTP Service Extension for Secure SMTP over Transport Layer Security
@@ -550,7 +553,6 @@ Please note that for plain TLS-encrypted ports you must not specify the protocol
 **etc/\*pem**               are the certificate stores from Apple, Linux, Mozilla Firefox, Windows and Java.
 
 **etc/client-simulation.txt**  contains client simulation data.
-
 
 **etc/cipher-mapping.txt**  provides a mandatory file with mapping from OpenSSL cipher suites names to the ones from IANA / used in the RFCs.
 

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -10,7 +10,7 @@ use Text::Diff;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $uri="heise.de";
+my $uri="testssl.net";
 my $out="";
 my $html="";
 my $debughtml="";

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -48,7 +48,7 @@ $edited_html =~ s/&apos;/'/g;
 
 $diff = diff \$edited_html, \$out;
 
-cmp_ok($edited_html, "eq", $out, "Checking if HTML file matches terminal output") or
+ok($edited_html eq $out, "Checking if HTML file matches terminal output") or
      diag ("\n%s\n", "$diff");
 
 $tests++;

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -10,7 +10,7 @@ use Text::Diff;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $uri="testssl.net";
+my $uri="heise.de";
 my $out="";
 my $html="";
 my $debughtml="";

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -82,7 +82,7 @@ $debughtml =~ s/.*Using bash .*\n//g;
 
 $diff = diff \$debughtml, \$html;
 
-cmp_ok($debughtml, "eq", $html, "Checking if HTML file created with --debug 4 matches HTML file created without --debug") or
+ok($debughtml eq $html, "Checking if HTML file created with --debug 4 matches HTML file created without --debug") or
      diag ("\n%s\n", "$diff");
 $tests++;
 

--- a/t/baseline_data/default_testssl.csvfile
+++ b/t/baseline_data/default_testssl.csvfile
@@ -90,6 +90,7 @@
 "heartbleed","testssl.sh/81.169.166.184","443","OK","not vulnerable, no heartbeat extension","CVE-2014-0160","CWE-119"
 "CCS","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2014-0224","CWE-310"
 "ticketbleed","testssl.sh/81.169.166.184","443","OK","no session ticket extension","CVE-2016-9244","CWE-200"
+"opossum","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2025-49812","CWE-74"
 "ROBOT","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2017-17382 CVE-2017-17427 CVE-2017-17428 CVE-2017-13098 CVE-2017-1000385 CVE-2017-13099 CVE-2016-6883 CVE-2012-5081 CVE-2017-6168","CWE-203"
 "secure_renego","testssl.sh/81.169.166.184","443","OK","supported","","CWE-310"
 "secure_client_renego","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2011-1473","CWE-310"

--- a/t/baseline_data/default_testssl.csvfile
+++ b/t/baseline_data/default_testssl.csvfile
@@ -90,7 +90,7 @@
 "heartbleed","testssl.sh/81.169.166.184","443","OK","not vulnerable, no heartbeat extension","CVE-2014-0160","CWE-119"
 "CCS","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2014-0224","CWE-310"
 "ticketbleed","testssl.sh/81.169.166.184","443","OK","no session ticket extension","CVE-2016-9244","CWE-200"
-"opossum","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2025-49812","CWE-74"
+"opossum","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2025-49812","CWE-287"
 "ROBOT","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2017-17382 CVE-2017-17427 CVE-2017-17428 CVE-2017-13098 CVE-2017-1000385 CVE-2017-13099 CVE-2016-6883 CVE-2012-5081 CVE-2017-6168","CWE-203"
 "secure_renego","testssl.sh/81.169.166.184","443","OK","supported","","CWE-310"
 "secure_client_renego","testssl.sh/81.169.166.184","443","OK","not vulnerable","CVE-2011-1473","CWE-310"

--- a/testssl.sh
+++ b/testssl.sh
@@ -17651,13 +17651,12 @@ run_opossum() {
                     *)   ret=7 ;;
                esac
                if [[ $response =~ Upgrade:\ TLS ]]; then
-                    pr_svrty_critical "VULNERABLE (NOT ok)"
+                    prln_svrty_critical "VULNERABLE (NOT ok)"
                     fileout "$jsonID" "CRITICAL" "VULNERABLE" "$cve" "$cwe" "$hint"
                else
-                    pr_svrty_best "not vulnerable (OK)"
+                    prln_svrty_best "not vulnerable (OK)"
                     fileout "$jsonID" "OK" "not vulnerable $append" "$cve" "$cwe"
                fi
-               echo
           ;;
           *) [[ $DEBUG -ge 1 ]] && echo "not implemented yet"
           ;;

--- a/testssl.sh
+++ b/testssl.sh
@@ -1890,7 +1890,7 @@ http_get_header() {
           tm_out "$response_headers"
           return $ret
      elif type -p wget &>/dev/null; then
-          timeout="--timeout=$HEADER_MAXSLEEP --tries=0"
+          timeout="--timeout=$HEADER_MAXSLEEP --tries=1"
           # wget has no proxy command line. We need to use http_proxy instead. And for the sake of simplicity
           # assume the GET protocol we query is using http -- http_proxy is the $ENV not for the connection TO
           # the proxy, but for the protocol we query THROUGH the proxy
@@ -17654,7 +17654,7 @@ run_opossum() {
                     pr_svrty_critical "VULNERABLE (NOT ok)"
                     fileout "$jsonID" "CRITICAL" "VULNERABLE" "$cve" "$cwe" "$hint"
                else
-                    pr_svrty_best "not vulnerable (OK)"; out "$append"
+                    pr_svrty_best "not vulnerable (OK)"
                     fileout "$jsonID" "OK" "not vulnerable $append" "$cve" "$cwe"
                fi
                echo

--- a/testssl.sh
+++ b/testssl.sh
@@ -24006,7 +24006,7 @@ set_rating_state() {
 
      # All of these should be enabled
      for gbl in do_protocols do_cipherlists do_fs do_server_defaults do_header \
-          do_heartbleed do_ccs_injection do_ticketbleed do_opossum do_robot do_renego \
+          do_heartbleed do_ccs_injection do_ticketbleed do_robot do_renego \
           do_crime do_ssl_poodle do_tls_fallback_scsv do_drown do_beast \
           do_rc4 do_logjam; do
           "${!gbl}" && ((nr_enabled++))

--- a/testssl.sh
+++ b/testssl.sh
@@ -17345,6 +17345,7 @@ run_ccs_injection(){
 
 
 # see https://blog.filippo.io/finding-ticketbleed/ |  https://filippo.io/ticketbleed/
+#
 run_ticketbleed() {
      local tls_hexcode tls_proto=""
      local sessticket_tls="" session_tckt_tls=""
@@ -17639,16 +17640,17 @@ run_opossum() {
      local cwe="CWE-74"
      local -i ret=0
      # we need to talk http here!
-     local uri=${URI/https/http/}
+     local uri=${URI/https/http}
      local service="$SERVICE"
 
      [[ -n "$STARTTLS" ]] && return 0
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for Opossum vulnerability " && outln
      pr_bold " Opossum"; out " ($cve)                  "
 
-     # we're trying to connect also if ASSUME_HTTP is not set. Requirement is though HTTP/HTTPS in target
-     if [[ -z $service ]] && [[ $uri =~ ^http ]]; then
-          service=HTTP
+     # we're trying to connect also if ASSUME_HTTP is not set, there should be either one of following hints though
+     if [[ -z $service ]]; then
+          [[ $uri =~ ^http ]] && service=HTTP                    # https provided as target/URL
+          [[ "$CLIENT_AUTH" == required ]] && service=HTTP       # also try when client auth is requested (we dont use it over cleartext)
      fi
 
      case $service in

--- a/testssl.sh
+++ b/testssl.sh
@@ -1826,7 +1826,7 @@ http_get() {
           # Worst option: slower and hiccups with chunked transfers. Workaround for the
           # latter is using HTTP/1.0. We do not support https here, yet.
           # First the URL will be split
-          IFS=/ read -r proto z node query <<< "$1"
+          IFS=/ read -r proto foo node query <<< "$1"
           proto=${proto%:}
           if [[ "$proto" != http ]]; then
                pr_warning "protocol $proto not supported yet"

--- a/testssl.sh
+++ b/testssl.sh
@@ -9979,7 +9979,7 @@ certificate_info() {
           check_pwnedkeys "$HOSTCERT" "$cert_key_algo" "$cert_keysize"
           case "$?" in
                0) outln "not checked"; fileout "pwnedkeys${json_postfix}" "INFO" "not checked" ;;
-               1) outln "not in database"; fileout "pwnedkeys${json_postfix}" "INFO" "not in database" ;;
+               1) pr_svrty_good "not in database"; fileout "pwnedkeys${json_postfix}" "OK" "not in database" ;;
                2) pr_svrty_critical "NOT ok --"; outln " key appears in database"; fileout "pwnedkeys${json_postfix}" "CRITICAL" "private key is known" ;;
                7) prln_warning "error querying https://v1.pwnedkeys.com"; fileout "pwnedkeys${json_postfix}" "WARN" "connection error" ;;
           esac

--- a/testssl.sh
+++ b/testssl.sh
@@ -1862,8 +1862,9 @@ http_get() {
      fi
 }
 
-# Outputs the headers when downloading any URL (arg1) via HTTP 1.1 GET from port 80.
-# arg2 is optional and could be a http_header
+# Outputs the HTTP headers via HTTP 1.1 HEAD command bia HTTPS and a valid certificate
+#    arg1 is the URL
+#    arg2 is optional and could be a request header. curl/wget don't send empty headers otherwise
 #
 # Only works if curl or wget is available.
 # The proxy environment variable is used automatically.
@@ -1889,10 +1890,10 @@ http_get_header() {
                response_headers="$(curl $xtra_params -x $PROXYIP:$PROXYPORT -H $''"$request_header"'' -A $''"$useragent"'' "$1")"
           fi
           ret=$?
-          tm_out "$response_headers"
+          [[ $ret -eq 0 ]] && tm_out "$response_headers"
           return $ret
      elif type -p wget &>/dev/null; then
-          xtra_params="--timeout=$HEADER_MAXSLEEP --tries=1 --content-on-error --cache=off"
+          xtra_params="--timeout=$HEADER_MAXSLEEP --tries=1 --cache=off"
           # wget has no proxy command line. We need to use http_proxy instead. And for the sake of simplicity
           # assume the GET protocol we query is using http -- http_proxy is the $ENV not for the connection TO
           # the proxy, but for the protocol we query THROUGH the proxy
@@ -1906,7 +1907,7 @@ http_get_header() {
                fi
           fi
           ret=$?
-          tm_out "$response_headers"
+          [[ $ret -eq 0 ]] && tm_out "$response_headers"
           # wget(1): "8: Server issued an error response.". Happens e.g. when 404 is returned. However also if the call wasn't correct (400)
           # So we assume for now that everything is submitted correctly. We parse the error code too later
           [[ $ret -eq 8 ]] && ret=0 && tm_out "$response_headers"

--- a/testssl.sh
+++ b/testssl.sh
@@ -1786,10 +1786,10 @@ filter_input() {
      sed -e 's/#.*$//' -e '/^$/d' <<< "$1" | tr -d '\n' | tr -d '\t' | tr -d '\r'
 }
 
-# Dl's any URL (arg1) via HTTP 1.1 GET from port 80, arg2: file to store http body.
+# Dl any URL (arg1) via HTTP 1.1 GET from port 80 or 443 (curl/wget). arg2: file to store http body.
 # Proxy is not honored yet (see cmd line switches) -- except when using curl or wget.
-# There the environment variable is used automatically
-# Currently it is being used by check_revocation_crl() only.
+# The PROXY environment variable is used when specified
+# Currently this is being used by check_revocation_crl() only.
 #
 http_get() {
      local proto="" foo=""
@@ -1862,13 +1862,13 @@ http_get() {
      fi
 }
 
-# Outputs the HTTP headers via HTTP 1.1 HEAD command bia HTTPS and a valid certificate
+# Outputs the HTTP headers via HTTP 1.1 HEAD command via HTTPS and a valid certificate
 #    arg1 is the URL
 #    arg2 is optional and could be a request header. curl/wget don't send empty headers otherwise
 #
 # Only works if curl or wget is available.
 # The proxy environment variable is used automatically.
-# Currently it is being used by check_pwnedkeys(), only
+# Currently it is being used by check_pwnedkeys() only
 #
 http_head() {
      local proto
@@ -12264,6 +12264,7 @@ code2network() {
 # sockets inspired by https://blog.chris007.de/using-bash-for-network-socket-operation/
 # ARG1: hexbytes separated by commas, with a leading comma
 # ARG2: seconds to sleep
+#
 socksend_clienthello() {
      local data=""
 
@@ -12282,6 +12283,7 @@ socksend_clienthello() {
 
 # ARG1: hexbytes -- preceded by x -- separated by commas, with a leading comma
 # ARG2: seconds to sleep
+#
 socksend() {
      local data line
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -1917,7 +1917,7 @@ http_head() {
      fi
 }
 
-# does a simple http head via printf with no proxy, only used by do_opossum()
+# does a simple http head via printf with no proxy, only used by run_opossum()
 #    arg1: URL
 #    arg2: extra http header
 #
@@ -17683,10 +17683,11 @@ run_ticketbleed() {
 run_opossum() {
      local cve='CVE-2025-49812'
      local jsonID="opossum"
-     local cwe="CWE-74"
+     local cwe="CWE-287"
      local -i ret=0
      local uri=$URI
      local service="$SERVICE"
+     local response=""
 
      [[ -n "$STARTTLS" ]] && return 0
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for Opossum vulnerability " && outln
@@ -17707,10 +17708,10 @@ run_opossum() {
                     1|3) ret=7 ;;       # got stuck
                esac
                if [[ $response =~ Upgrade:\ TLS ]]; then
-                    prln_svrty_critical "VULNERABLE (NOT ok)"
+                    prln_svrty_high "VULNERABLE (NOT ok)"
                     fileout "$jsonID" "CRITICAL" "VULNERABLE" "$cve" "$cwe" "$hint"
                else
-                    prln_svrty_best "not vulnerable (OK)"
+                    prln_svrty_good "not vulnerable (OK)"
                     fileout "$jsonID" "OK" "not vulnerable $append" "$cve" "$cwe"
                fi
           ;;

--- a/testssl.sh
+++ b/testssl.sh
@@ -1870,7 +1870,7 @@ http_get() {
 # The proxy environment variable is used automatically.
 # Currently it is being used by check_pwnedkeys(), only
 #
-http_get_header() {
+http_head() {
      local proto
      local node="" query=""
      local request_header="$2"
@@ -1917,14 +1917,14 @@ http_get_header() {
      fi
 }
 
-# does a simple http head via printf with no proxy, only used by do_opossum
+# does a simple http head via printf with no proxy, only used by do_opossum()
 #    arg1: URL
 #    arg2: extra http header
 #
 # return codes:
 #    0: all fine
-#    1: got stuck within HEADER_MAXSLEEP
-#    3: got stuck within HEADER_MAXSLEEP and PROXY was defined
+#    1: server dind't respond within HEADER_MAXSLEEP
+#    3: server dind't respond within HEADER_MAXSLEEP and PROXY was defined
 #
 http_header_printf() {
      local request_header="$2"
@@ -2021,7 +2021,7 @@ check_pwnedkeys() {
      fi
      fingerprint="$($OPENSSL pkey -pubin -outform DER <<< "$pubkey" 2>/dev/null | $OPENSSL dgst -sha256 -hex 2>/dev/null)"
      fingerprint="${fingerprint#*= }"
-     response="$(http_get_header "https://v1.pwnedkeys.com/$fingerprint")"
+     response="$(http_head "https://v1.pwnedkeys.com/$fingerprint")"
      # Handle curl's/wget's connectivity exit codes
      case $? in
           4|5|7)     return 7 ;;


### PR DESCRIPTION
Fixes #2833

This does a check for the opossum vulnerability, see https://opossum-attack.com/ .

It uses a separate function to send the payload and retrieve the result (`http_header_printf()`). It uses no curl or wget. The latter wouldn't work anyway as according to the manpage as the HTTP header to sent must not contain LFs.

This function was introduced because `http_get_header()` could use wget if curl is not available. On the way to this PR `http_get_header` was improved, so that timeouts were used for curl and wget for better maturity.

Done:
- handling when PROXY is requested (try anyway directly as the payload is not "proxyable")
- print a message when no HTTP service is present
- try hard when auth is required for HTTPS
- manpages
- help


## What is your pull request about?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [x] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
