### PR TITLE
Rollup improvements (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1785,7 +1785,7 @@ filter_input() {
 
 # Dl any URL (arg1) via HTTP 1.1 GET from port 80 or 443 (curl/wget). arg2: file to store http body.
 # Proxy is not honored yet (see cmd line switches) -- except when using curl or wget.
-# The PROXY environment variable is used when specifiied
+# The PROXY environment variable is used when specified
 # Currently this is being used by check_revocation_crl() only.
 #
 http_get() {
@@ -19947,7 +19947,7 @@ run_starttls_injection() {
      $SOCAT FD:5 UNIX-LISTEN:$uds 2>/dev/null &
      socat_pid=$!
 
-     if "$HAS_DS"; then
+     if "$HAS_UDS"; then
           openssl_bin="$OPENSSL"
      elif "$HAS2_UDS"; then
           openssl_bin="$OPENSSL2"


### PR DESCRIPTION
## Describe your changes

    Backport readability and more improvements from 3.3dev

    The opossum patch improved http_get() , http_get_header/http_head()
    in terms of readability. This was backported to improve maintainability.

    Also in pwned keys if not pwned appear now in green/OK and not just
    info level.

    HAS_UDS2 was renamed to HAS2_UDS.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [x] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
