### PR TITLE
Fix displayed message when IPv6 needs to be tested too (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -23134,7 +23134,12 @@ run_mx_all_ips() {
                determine_ip_addresses || continue
                if [[ $(count_words "$IPADDRs") -gt 1 ]]; then    # we have more than one ipv4 address to check
                     MULTIPLE_CHECKS=true
-                    pr_bold "Testing all IPv4 addresses (port $PORT): "; outln "$IPADDRs"
+                    if [[ "$HAS_IPv6" ]]; then
+                    pr_bold "Testing all IP addresses (port $PORT): "
+               else
+                    pr_bold "Testing all IPv4 addresses (port $PORT): "
+               fi
+               outln "$IPADDRs"
                     for ip in $IPADDRs; do
                          NODEIP="$ip"
                          lets_roll "${STARTTLS_PROTOCOL}"
@@ -25055,7 +25060,12 @@ lets_roll() {
           determine_ip_addresses
           if [[ $(count_words "$IPADDRs") -gt 1 ]]; then    # we have more than one ipv4 address to check
                MULTIPLE_CHECKS=true
-               pr_bold "Testing all IPv4 addresses (port $PORT): "; outln "$IPADDRs"
+               if [[ "$HAS_IPv6" ]]; then
+                    pr_bold "Testing all IP addresses (port $PORT): "
+               else
+                    pr_bold "Testing all IPv4 addresses (port $PORT): "
+               fi
+               outln "$IPADDRs"
                for ip in $IPADDRs; do
                     draw_line "-" $((TERM_WIDTH * 2 / 3))
                     outln


### PR DESCRIPTION
message: "Testing all IPv4 addresses"

related to https://github.com/testssl/testssl.sh/issues/2843

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
