### PR TITLE
Try harder to find OPENSSL2

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20946,7 +20946,12 @@ find_openssl_binary() {
      initialize_engine
 
      openssl_location="$(type -p $OPENSSL)"
-     
+
+     # kludge for e.g. MacOS and brew
+     if [[ $OPENSSL == $OPENSSL2 ]]; then
+          OPENSSL2=$(type -a openssl | grep -v /usr/bin/openssl | awk '{ print $NF }')
+     fi
+
      [[ -n "$GIT_REL" ]] && \
           cwd="$PWD" || \
           cwd="$RUN_DIR"


### PR DESCRIPTION
This commit adds an improvement so that e.g. under MacOS /opt/homebrew/bin/openssl is automatically taken as $OPENSSL2 so that also QUIC works out of the box for MacOS.

Formally for at least MacOS with silicon CPUs $OPENSSL was equal to $OPENSSL2. LibreSSL in /usr/bin/openssl ($OPENSSL) doesn't have QUIC support (up to version 15.5 of MacOS at least).


## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [ ] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
