### PR TITLE
Ensure HEAD requests on port 80 can actually go through, including timeout checks (only used by the Opossum test at the moment, fixes #2847)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1933,11 +1933,33 @@ http_header_printf() {
      local errfile=$TEMPDIR/$NODE.$NODEIP.http_header_printf-err.log
      local -i ret=0
      local proto="" foo="" node="" query=""
+     local pid
 
      [[ $DEBUG -eq 0 ]] && errfile=/dev/null
 
      IFS=/ read -r proto foo node query <<< "$1"
-     exec 33<>/dev/tcp/$node/80
+
+     # This command may fail immediately if the server responds with "connection refused".
+     # To deal with this while also being able to interrupt the call, we can use 'wait' to check the real exit code if the process no longer exists.
+     # The connection is wrapped in a subshell so we can redirect stderr instead of polluting any test output.
+     bash -c "exec 33<>/dev/tcp/$NODEIP/80" 2>$errfile &
+     pid=$!
+     if ! ps $pid >/dev/null && ! wait $pid; then
+          [[ -n "$PROXY" ]] && return 3
+          return 1
+     fi
+
+     # On the other hand, if the process is still running then we'll need to check for a timeout, since the server doesn't seem to actively reject the connection
+     wait_kill $pid $HEADER_MAXSLEEP
+     if [[ $? -ne 0 ]]; then
+          # Killed, i.e. server didn't respond in time
+          [[ -n "$PROXY" ]] && return 3
+          return 1
+     fi
+
+     # Now we need to set up a new connection, which is very unlikely to fail at this point.
+     # Note that the actual HEAD request will overwrite $errfile, which is fine because it should always be empty if we came this far.
+     exec 33<>/dev/tcp/$NODEIP/80
      printf -- "%b" "HEAD ${proto}//${node}/${query} HTTP/1.1\r\nUser-Agent: ${useragent}\r\nHost: ${node}\r\n${request_header}\r\nAccept: */*\r\n\r\n\r\n" >&33 2>$errfile &
      wait_kill $! $HEADER_MAXSLEEP
      if [[ $? -ne 0 ]]; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -1942,7 +1942,7 @@ http_header_printf() {
      # This command may fail immediately if the server responds with "connection refused".
      # To deal with this while also being able to interrupt the call, we can use 'wait' to check the real exit code if the process no longer exists.
      # The connection is wrapped in a subshell so we can redirect stderr instead of polluting any test output.
-     bash -c "exec 33<>/dev/tcp/$NODEIP/80" 2>$errfile &
+     bash -c "exec 33<>/dev/tcp/$NODE/80" 2>$errfile &
      pid=$!
      if ! ps $pid >/dev/null && ! wait $pid; then
           [[ -n "$PROXY" ]] && return 3
@@ -1959,7 +1959,7 @@ http_header_printf() {
 
      # Now we need to set up a new connection, which is very unlikely to fail at this point.
      # Note that the actual HEAD request will overwrite $errfile, which is fine because it should always be empty if we came this far.
-     exec 33<>/dev/tcp/$NODEIP/80
+     exec 33<>/dev/tcp/$NODE/80
      printf -- "%b" "HEAD ${proto}//${node}/${query} HTTP/1.1\r\nUser-Agent: ${useragent}\r\nHost: ${node}\r\n${request_header}\r\nAccept: */*\r\n\r\n\r\n" >&33 2>$errfile &
      wait_kill $! $HEADER_MAXSLEEP
      if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
## Describe your changes

See #2847 for more details.

## What is your pull request about?
- [X] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files

## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
