### PR TITLE
Fix port and block problem for Opossum

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -1939,7 +1939,7 @@ http_head_printf() {
      IFS=/ read -r proto foo node query <<< "$1"
      node=${node%:*}
      # $node works here good as it connects via IPv6 first, then IPv4
-     bash -c "exec 33<>/dev/tcp/$node/80" >/dev/null &
+     bash -c "exec 33<>/dev/tcp/$node/80" 2>/dev/null &
      wait_kill $! $HEADER_MAXSLEEP
      if [[ $? -ne 0 ]]; then
           # not killed --> socket open. Now we connect to the virtual host "$node"

--- a/testssl.sh
+++ b/testssl.sh
@@ -1958,7 +1958,7 @@ http_head_printf() {
                ret=1
           fi
      fi
-          exec 33<&-
+     exec 33<&-
      exec 33>&-
      return $ret
 }


### PR DESCRIPTION
This fixes #2847 .

It was falsely assumed that the http head command blocks when port 80 is not available but actucally the exec for the socket is the culprit.

This PR changes that so that the exec is put in the background.

Another change is that $node is still used but the port is stripped of which lead to the problem raised in #2847. We use $node instead of $NODE has we can recycle the `http_head[er]_printf()` later.

`http_header_printf()`was renamed to `http_head_printf()` as there's also an `http_head()` and an `http_get()`


## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
