### PR TITLE
Doing a better guess for Opossum when tcp/80 is not a/v

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17735,8 +17735,10 @@ run_opossum() {
                          prln_local_problem "direct connection to port 80 failed, better try without proxy"
                          fileout "$jsonID" "WARN" "direct connection to port 80 failed, try w/o no proxy" "$cve" "$cwe"
                     else
-                         outln "connection to port 80 failed"
-                         fileout "$jsonID" "INFO" "connection to port 80 failed" "$cve" "$cwe"
+                         out "likely "
+                         pr_svrty_good "not vulnerable (OK)"
+                         outln ", connection to port 80 failed"
+                         fileout "$jsonID" "OK" "connection to port 80 failed" "$cve" "$cwe"
                     fi
                fi
           ;;


### PR DESCRIPTION
This labels the result of a failed test for reaching port 80 when no direct connection is possible as likely not vulnerable.

This seems safe to say, as there's another check whether a proxy is configured, like for corporate environments where a connection is only allowed though the proxy.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
