### PR TITLE
Fix bug when --nodns none --ip <IP> is supplied

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22419,6 +22419,7 @@ determine_ip_addresses() {
      else
           :                                  # standard case
      fi
+     IPADDRs2SHOW=$(newline_to_spaces "$ip4 $ip6")
 
      if "$do_ipv4_only"; then
           if [[ -z "$ip4" ]]; then
@@ -22434,6 +22435,7 @@ determine_ip_addresses() {
           fi
           IPADDRs2CHECK=$(newline_to_spaces "$ip6")
      else
+          # Here we populate for general cases $IPADDRs2CHECK
           for addr in $IPADDRs2SHOW; do
                is_ipv6addr $addr && ! "$IPv6_OK" && continue
                [[ -z $IPADDRs2CHECK ]] && IPADDRs2CHECK="${addr}" || IPADDRs2CHECK="${IPADDRs2CHECK} ${addr}"


### PR DESCRIPTION
Due to rebasing `determine_ip_addresses()` in #2852 it was forgotten to add any manually specified IP address to the IP addresses to show and to scan.

This fixes #2854 .


## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
