### PR TITLE
Fix additional parameter in shouldwedo_ipv6()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22383,7 +22383,7 @@ shouldwedo_ipv6() {
           # was killed, so this got stuck
           IPv6_OK=false
           "$do_ipv6_only" && connectivity_problem 1 1 "" "IPv6 connect got stuck when IPv6-only scan requested"
-          do_ipv6_only=false                # this ensures we have round brackets and we don't try IPv6 anymore
+          do_ipv6_only=false                 # Ensures round brackets enclosing IPv6 addresses and we don't try IPv6 anymore
      else
           # we're trying in the foreground again, only to get the return code
           bash -c "exec 5<>/dev/tcp/$1/$PORT" &>/dev/null
@@ -22392,9 +22392,9 @@ shouldwedo_ipv6() {
           else
                IPv6_OK=false
                if "$do_ipv6_only"; then
-                    connectivity_problem 2 2 $MAX_SOCKET_FAIL "" "repeated IPv6 connect problems when IPv6-only scan requested"
+                    connectivity_problem 2 2 "" "repeated IPv6 connect problems when IPv6-only scan requested"
                else
-                    do_ipv6_only=false       #FIXME: wrong variable. It ensures we have round brackets enclosing IPv6 addresses + we don't try it anymore
+                    do_ipv6_only=false       # Ensures round brackets for IPv6 addresses + we don't try IPv6 anymore. Better other var
                fi
           fi
      fi


### PR DESCRIPTION
.... for connectivity_problem() which may block testssl.sh


## Describe your changes

Please refer to an issue here or describe the change thoroughly in your PR.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
