### PR TITLE
HTTP Clock Skew Invalid Age header crash fix

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2768,6 +2768,14 @@ run_http_date() {
      if [[ ! -s $HEADERFILE ]]; then
           run_http_header "$1" || return 1
      fi
+
+     # make sure that HTTP_AGE is either missing or a valid value (only digits) for the later expression.
+     if [[ -n "$HTTP_AGE" && ! "$HTTP_AGE" =~ ^[0-9]+$ ]]; then
+          pr_bold " HTTP Age Header              "
+          out "Age header has invalid value: $HTTP_AGE (treated as 0)";
+          unset HTTP_AGE
+          outln
+     fi
      pr_bold " HTTP clock skew              "
      if [[ -n "$HTTP_TIME" ]]; then
           if "$HAS_OPENBSDDATE"; then


### PR DESCRIPTION
## Describe your changes

HTTP_clock_skew breaks execution of rest of script if Age header contains non-numerical values. This commit adds a check via regex for this value and removes the variable if it is invalid as if it was not given.

The run_http_date() function tries to run

`difftime=$((HTTP_TIME + HTTP_AGE - NOW_TIME))`

When the Age header is missing bash will automatically substitute with 0, but we found it sometimes occurs that the age header contains an entire date like the Date header. This will lead to an invalid expression and the script will halt.

The fix is checking if the Age header (if it exists) is purely numerical. If it is not a new heading and message is added to the output (but not the file output) and the HTTP_AGE variable is unset. This prevents the error that halts the script and allows the script to continue as if the Age header was not given.

## What is your pull request about?
- [x] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
