### PR TITLE
Fix indentation @ Intermediate cert validity (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10144,7 +10144,7 @@ certificate_info() {
                out "$indent"; pr_bold " Intermediate cert validity   "
                first=false
           else
-               out "$indent$spaces"
+               out "$spaces"
           fi
           out "#${i}: "
           if ! [[ "$($OPENSSL x509 -checkend 1 2>>$ERRFILE <<< "$cert")" =~ \ not\  ]]; then


### PR DESCRIPTION
... when there were two server and >1 intermediate CA certificates.


## What is your pull request about?
- [x] Minor Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
