### PR TITLE
Consistency for function ciphers_by_strength()

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4486,6 +4486,7 @@ run_allciphers() {
 # test for all ciphers per protocol locally configured (w/o distinguishing whether they are good or bad)
 # for the specified protocol, test for all ciphers locally configured (w/o distinguishing whether they
 # are good or bad) and list them in order to encryption strength.
+#
 ciphers_by_strength() {
      local proto="$1" proto_hex="$2" proto_text="$3"
      local using_sockets="$4" wide="$5" serverpref_known="$6"
@@ -4911,7 +4912,7 @@ run_cipher_per_proto() {
      while read proto proto_hex proto_text; do
           pr_underline "$(printf -- "%b" "$proto_text")"
           ciphers_by_strength "$proto" "$proto_hex" "$proto_text" "$using_sockets" "true" "false"
-     done <<< "$(tm_out " -ssl2 22 SSLv2\n -ssl3 00 SSLv3\n -tls1 01 TLS 1\n -tls1_1 02 TLS 1.1\n -tls1_2 03 TLS 1.2\n -tls1_3 04 TLS 1.3")"
+     done <<< "$(tm_out " -ssl2 22 SSLv2\n -ssl3 00 SSLv3\n -tls1 01 TLSv1\n -tls1_1 02 TLSv1.1\n -tls1_2 03 TLSv1.2\n -tls1_3 04 TLSv1.3")"
      return 0
 #FIXME: no error condition
 }
@@ -4930,6 +4931,7 @@ run_cipher_per_proto() {
 # then either:
 #  1) replace it with one corresponding to $SNI; or
 #  2) remove it, if $SNI is empty
+#
 modify_clienthello() {
      local tls_handshake_ascii="$1"
      local new_key_share="$2" cookie="$3"
@@ -7321,7 +7323,7 @@ run_server_preference() {
      if "$TLS13_ONLY" && ! "$has_tls13_cipher_order"; then
           terminal_msg="no (TLS 1.3 only)"
           limitedsense=" (limited sense as client will pick)"
-          fileout_msg="not a cipher order for TLS 1.3 configured"
+          fileout_msg="not a server cipher order for TLS 1.3 configured"
      elif ! "$TLS13_ONLY" && [[ -z "$cipher2" ]]; then
           pr_warning "unable to determine"
      elif ! "$has_cipher_order" && ! "$has_tls13_cipher_order"; then
@@ -7329,7 +7331,7 @@ run_server_preference() {
           terminal_msg="no (NOT ok)"
           [[ "$fileout_rating" == INFO ]] && terminal_msg="no"
           limitedsense=" (limited sense as client will pick)"
-          fileout_msg="NOT a cipher order configured"
+          fileout_msg="NOT a server cipher order configured"
      elif "$has_cipher_order" && ! "$has_tls13_cipher_order" && [[ "$default_proto" == TLSv1.3 ]]; then
           if [[ $NO_CIPHER_ORDER_LEVEL -eq 5 ]]; then
                pr_svrty_good "yes (OK)"; out " -- only for < TLS 1.3"
@@ -7404,6 +7406,7 @@ run_server_preference() {
 }
 
 # arg1: true if the list that is returned does not need to be ordered by preference.
+#
 check_tls12_pref() {
      local unordered_list_ok="$1"
      local chacha20_ciphers="" non_chacha20_ciphers=""
@@ -7499,6 +7502,7 @@ check_tls12_pref() {
 }
 
 # At the moment only called from run_server_preference()
+#
 cipher_pref_check() {
      local proto="$1" proto_hex="$2" proto_text="$3"
      local using_sockets="$4"


### PR DESCRIPTION
* keys now always with _v_, like `supportedciphers_TLSv1_2` and also ciphers (e.g. `TLSv1.2   x35     AES256-SHA`)
* add word "server" to file output so that it reads "NOT a server cipher order configured"

Fixes #2884

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
