### PR TITLE
Consistency for function ciphers_by_strength() (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -4399,6 +4399,7 @@ run_allciphers() {
 # test for all ciphers per protocol locally configured (w/o distinguishing whether they are good or bad)
 # for the specified protocol, test for all ciphers locally configured (w/o distinguishing whether they
 # are good or bad) and list them in order to encryption strength.
+#
 ciphers_by_strength() {
      local proto="$1" proto_hex="$2" proto_text="$3"
      local using_sockets="$4" wide="$5" serverpref_known="$6"
@@ -4824,7 +4825,7 @@ run_cipher_per_proto() {
      while read proto proto_hex proto_text; do
           pr_underline "$(printf -- "%b" "$proto_text")"
           ciphers_by_strength "$proto" "$proto_hex" "$proto_text" "$using_sockets" "true" "false"
-     done <<< "$(tm_out " -ssl2 22 SSLv2\n -ssl3 00 SSLv3\n -tls1 01 TLS 1\n -tls1_1 02 TLS 1.1\n -tls1_2 03 TLS 1.2\n -tls1_3 04 TLS 1.3")"
+     done <<< "$(tm_out " -ssl2 22 SSLv2\n -ssl3 00 SSLv3\n -tls1 01 TLSv1\n -tls1_1 02 TLSv1.1\n -tls1_2 03 TLSv1.2\n -tls1_3 04 TLSv1.3")"
      return 0
 #FIXME: no error condition
 }
@@ -4843,6 +4844,7 @@ run_cipher_per_proto() {
 # then either:
 #  1) replace it with one corresponding to $SNI; or
 #  2) remove it, if $SNI is empty
+#
 modify_clienthello() {
      local tls_handshake_ascii="$1"
      local new_key_share="$2" cookie="$3"
@@ -7171,7 +7173,7 @@ run_server_preference() {
      if "$TLS13_ONLY" && ! "$has_tls13_cipher_order"; then
           terminal_msg="no (TLS 1.3 only)"
           limitedsense=" (limited sense as client will pick)"
-          fileout_msg="not a cipher order for TLS 1.3 configured"
+          fileout_msg="not a server cipher order for TLS 1.3 configured"
      elif ! "$TLS13_ONLY" && [[ -z "$cipher2" ]]; then
           pr_warning "unable to determine"
      elif ! "$has_cipher_order" && ! "$has_tls13_cipher_order"; then
@@ -7179,7 +7181,7 @@ run_server_preference() {
           terminal_msg="no (NOT ok)"
           [[ "$fileout_rating" == INFO ]] && terminal_msg="no"
           limitedsense=" (limited sense as client will pick)"
-          fileout_msg="NOT a cipher order configured"
+          fileout_msg="NOT a server cipher order configured"
      elif "$has_cipher_order" && ! "$has_tls13_cipher_order" && [[ "$default_proto" == TLSv1.3 ]]; then
           if [[ $NO_CIPHER_ORDER_LEVEL -eq 5 ]]; then
                pr_svrty_good "yes (OK)"; out " -- only for < TLS 1.3"
@@ -7254,6 +7256,7 @@ run_server_preference() {
 }
 
 # arg1: true if the list that is returned does not need to be ordered by preference.
+#
 check_tls12_pref() {
      local unordered_list_ok="$1"
      local chacha20_ciphers="" non_chacha20_ciphers=""
@@ -7349,6 +7352,7 @@ check_tls12_pref() {
 }
 
 # At the moment only called from run_server_preference()
+#
 cipher_pref_check() {
      local proto="$1" proto_hex="$2" proto_text="$3"
      local using_sockets="$4"


### PR DESCRIPTION
## Describe your changes

This PR is similar as #2905 for 3.3dev . However for the stable branch it's important to note that this is a breaking change as it modifies the output. That happens only tough when `ciphers_by_strength()` is being used --equivalent to the command line `./testssl.sh -E` =  `./testssl.sh --cipher-per-proto`. As this is seldom used and was basically succeeded by `-P, --server-preference` this looks acceptable as it provides consistency which was overdue.

Details:

* keys now always with `v`, like `supportedciphers_TLSv1_2` and also ciphers (e.g. `TLSv1.2   x35     AES256-SHA`)
*  add word "server" to file output so that it reads "NOT a server cipher order configured"

Fixes #2884 for 3.2 .




## What is your pull request about?
- [x] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
