### PR TITLE
Define vars for early data

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -342,6 +342,8 @@ HAS_TLS12=false
 HAS_TLS13=false
 HAS_QUIC=false
 HAS2_QUIC=false                         # for automagically determined second OPENSSL version
+HAS_EARLYDATA=false
+HAS2_EARLYDATA=false
 HAS_X448=false
 HAS_X25519=false
 HAS_SIGALGS=false
@@ -21125,17 +21127,24 @@ find_openssl_binary() {
           $OPENSSL s_client -tls1_3 -sigalgs PSS+SHA256:PSS+SHA384 $NXCONNECT </dev/null 2>&1 | grep -aiq "unknown option" || HAS_SIGALGS=true
      fi
 
+     #reminder: at some point of time we should check $OPENSSL first, then $OPENSSL2
      if [[ -x $OPENSSL2 ]] && OPENSSL_CONF='' $OPENSSL2 s_client -quic 2>&1 | grep -qi 'QUIC requires ALPN'; then
-          HAS2_QUIC="true"
-     elif OPENSSL_CONF='' $OPENSSL s_client -quic 2>&1 | grep -qi 'QUIC requires ALPN'; then
-          HAS_QUIC="true"
+          HAS2_QUIC=true
+     elif $OPENSSL s_client -quic 2>&1 | grep -qi 'QUIC requires ALPN'; then
+          HAS_QUIC=true
+     fi
+
+     # Kind of fine this way as openssl 1.1.1 supports early_data, came with tls 1.3
+     if $OPENSSL s_client --help 2>&1 | grep -q early_data ; then
+          HAS_EARLYDATA=true
+     elif if OPENSSL_CONF='' $OPENSS2 s_client --help 2>&1 | grep -q early_data ; then
+          HAS2_EARLYDATA=true
      fi
 
      $OPENSSL s_client -noservername </dev/null 2>&1 | grep -aiq "unknown option" || HAS_NOSERVERNAME=true
      $OPENSSL s_client -ciphersuites </dev/null 2>&1 | grep -aiq "unknown option" || HAS_CIPHERSUITES=true
      $OPENSSL s_client -comp </dev/null 2>&1 | grep -aiq "unknown option" || HAS_COMP=true
      $OPENSSL s_client -no_comp </dev/null 2>&1 | grep -aiq "unknown option" || HAS_NO_COMP=true
-
      $OPENSSL ciphers @SECLEVEL=0:ALL > /dev/null 2> /dev/null && HAS_SECLEVEL=true
 
      OPENSSL_NR_CIPHERS=$(count_ciphers "$(actually_supported_osslciphers 'ALL:COMPLEMENTOFALL' 'ALL')")

--- a/testssl.sh
+++ b/testssl.sh
@@ -21135,9 +21135,9 @@ find_openssl_binary() {
      fi
 
      # Kind of fine this way as openssl 1.1.1 supports early_data, came with tls 1.3
-     if $OPENSSL s_client --help 2>&1 | grep -q early_data ; then
+     if $OPENSSL s_client -help 2>&1 | grep -q early_data ; then
           HAS_EARLYDATA=true
-     elif if OPENSSL_CONF='' $OPENSS2 s_client --help 2>&1 | grep -q early_data ; then
+     elif OPENSSL_CONF='' $OPENSS2 s_client --help 2>&1 | grep -q early_data ; then
           HAS2_EARLYDATA=true
      fi
 


### PR DESCRIPTION
It seems needed to introduce two variables for upcoming early data tests, see #1186. This is not necessary for OpenSSL as it introduced that together with TLS 1.3. For LibreSSL it is though.

Also, to be in line with other definitions quotes were removed. Also OPENSSL_CONF="" is only needed for newer OpenSSL versions.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
