### PR TITLE
Fix date for Ubuntu >= 25.10 (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -469,11 +469,15 @@ HAS_GNUDATE=false
 HAS_FREEBSDDATE=false
 HAS_OPENBSDDATE=false
 if date -d @735275209 >/dev/null 2>&1; then
-     if date -r @735275209  >/dev/null 2>&1; then
+     if date -r @735275209 >/dev/null 2>&1; then
+          # Ubuntu >= 25.10
+          HAS_GNUDATE=true
+     elif date -r 735275209 2>&1 | grep -q "No such file"; then
+          # e.g. Debian 24.04, Debian 11-13
+          HAS_GNUDATE=true
+     elif date -r 735275209 >/dev/null 2>&1; then
           # It can't do any conversion from a plain date output.
           HAS_OPENBSDDATE=true
-     else
-          HAS_GNUDATE=true
      fi
 fi
 # FreeBSD and OS X date(1) accept "-f inputformat", so do newer OpenBSD versions >~ 6.6.


### PR DESCRIPTION
    Ubuntu 25.10 has transitioned from GNU Core-utils to Rust Core-utils. That changes the testing
    results which date version to use for displaying / conversion of dates like in certificates.  Probably 
    more Linux distributions will follow. See also #2909 .

    For maintenance reasons it is advised also the stable version will get this patched. For
    3.3dev, see #2913 .

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
