### PR TITLE
Fix date parsing bc of locale problem (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -468,11 +468,12 @@ declare TLS13_OSSL_CIPHERS="TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CH
 HAS_GNUDATE=false
 HAS_FREEBSDDATE=false
 HAS_OPENBSDDATE=false
+
 if date -d @735275209 >/dev/null 2>&1; then
      if date -r @735275209 >/dev/null 2>&1; then
           # Ubuntu >= 25.10
           HAS_GNUDATE=true
-     elif date -r 735275209 2>&1 | grep -q "No such file"; then
+     elif LC_ALL=C date -r 735275209 2>&1 | grep -q "No such file"; then
           # e.g. Debian 24.04, Debian 11-13
           HAS_GNUDATE=true
      elif date -r 735275209 >/dev/null 2>&1; then
@@ -483,6 +484,7 @@ fi
 # FreeBSD and OS X date(1) accept "-f inputformat", so do newer OpenBSD versions >~ 6.6.
 date -j -f '%s' 1234567 >/dev/null 2>&1 && \
      HAS_FREEBSDDATE=true
+
 
 echo A | sed -E 's/A//' >/dev/null 2>&1 && \
      declare -r HAS_SED_E=true || \


### PR DESCRIPTION
The new block making sure that rust coreutils work properly (PR #2913) introduced a new check in order to determine which date functions to use.

The function however parsed only for English error messages ("No such file"). This PR fixes #2929 that for 3.2  by setting LC_ALL to C.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
