### PR TITLE
 Fix pattern for matching /etc/hosts entries (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21886,24 +21886,27 @@ filter_ip4_address() {
 
 # For security testing sometimes we have local entries. Getent is BS under Linux for localhost: No network, no resolution
 # arg1 is the entry we want to look up in the host file
+#
 get_local_aaaa() {
      local ip6=""
      local etchosts="/etc/hosts /c/Windows/System32/drivers/etc/hosts"
 
      [[ -z "$1" ]] && echo "" && return 1
-     # Also multiple records should work fine
-     ip6=$(grep -wih "$1" $etchosts 2>/dev/null | grep ':' | grep -Ev '^#|\.local' | grep -Ei "[[:space:]]$1" | awk '{ print $1 }')
+     # grep: find hostname with trailing lf or space. -w doesn't work here
+     ip6=$(grep -Eih "[[:space:]]$1([[:space:]]|$)" $etchosts 2>/dev/null | grep ':' | grep -Ev '^#|\.local' | awk '{ print $1 }')
      if is_ipv6addr "$ip6"; then
           echo "$ip6"
      else
           echo ""
      fi
 }
+
 get_local_a() {
      local ip4=""
      local etchosts="/etc/hosts /c/Windows/System32/drivers/etc/hosts"
 
-     ip4=$(grep -wih "$1" $etchosts 2>/dev/null | grep -Ev ':|^#|\.local' | grep -Ei "[[:space:]]$1" | awk '{ print $1 }')
+     # grep: find hostname with trailing lf or space. -w doesn't work here
+     ip4=$(grep -Eih "[[:space:]]$1([[:space:]]|$)" $etchosts 2>/dev/null | grep -Ev ':|^#|\.local' | awk '{ print $1 }')
      if is_ipv4addr "$ip4"; then
           echo "$ip4"
      else


### PR DESCRIPTION
`grep -w` matches also `string1-whatsoever` so that entries like

```
192.168.0.10 anystring anystring-apache
192.168.0.11 anystring-tomcat
```

matched 3 entries over 2 lines.

This PR fixes #2937 for 3.2 by improving the pattern, so that `string1` needs a trailing whitespace or an EOL -- besides a leading whitespace..

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
