### PR TITLE
feat: --grade-only flag to only test checks required for rating

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21260,6 +21260,7 @@ single check as <options>  ("$PROG_NAME URI" does everything except -E and -g):
      -J, --logjam                  tests for LOGJAM vulnerability
      -D, --drown                   tests for DROWN vulnerability
      -4, --rc4, --appelbaum        which RC4 ciphers are being offered?
+     --grade-only                  test only the checks required for rating
 
 tuning / connect options (most also can be preset via environment variables):
      -9, --full                    includes tests for implementation bugs and cipher per protocol (could disappear)
@@ -21293,7 +21294,7 @@ output options (can also be preset via environment variables):
      --color <0|1|2|3>             0: no escape or other codes,  1: b/w escape codes,  2: color (default), 3: extra color (color all ciphers)
      --colorblind                  swap green and blue in the output
      --debug <0-6>                 1: screen output normal but keeps debug output in /tmp/.  2-6: see "grep -A 5 '^DEBUG=' testssl.sh"
-     --disable-rating              Explicitly disables the rating output
+     --disable-rating              explicitly disables the rating output
 
 file output options (can also be preset via environment variables)
      --log, --logging              logs stdout to '\${NODE}-p\${port}\${YYYYMMDD-HHMM}.log' in current working directory (cwd)
@@ -24733,6 +24734,27 @@ parse_cmd_line() {
                     REQHEADER="$(parse_opt_equal_sign "$1" "$2")"
                     [[ $? -eq 0 ]] && shift
                     REQHEADERS+=("$REQHEADER")
+                    ;;
+               --grade[-_]only)
+                    # See set_rating_state() for required variables
+                    do_protocols=true
+                    do_cipherlists=true
+                    do_fs=true
+                    do_server_defaults=true
+                    do_header=true
+                    do_heartbleed=true
+                    do_ccs_injection=true
+                    do_ticketbleed=true
+                    do_robot=true
+                    do_renego=true
+                    do_crime=true
+                    do_ssl_poodle=true
+                    do_tls_fallback_scsv=true
+                    do_drown=true
+                    do_beast=true
+                    do_rc4=true
+                    do_logjam=true
+                    do_allciphers=true
                     ;;
                (--) shift
                     break


### PR DESCRIPTION
## Describe your changes

Fixes https://github.com/testssl/testssl.sh/issues/2875

Added a very simple `--grade-only` flag, that will enable only the checks required for rating to be successful.

NOTE: this is a very simple implementation that sets the required variables to true (even if they potentially were disabled with other flags). HOWEVER it is also possible to add additional tests with any of the single-check flags (like `./testssl.sh --grade-only --winshock`)

Not sure if this is too simple for your liking? Let me know if so, then I will update. I threw this together rather quickly :-)

...oh, and I lowercased the `--disable-rating` help text; all the surrounding text is lowercase 


## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
