### PR TITLE
feat: --rating-only flag to only test checks required for rating

### DIFF
--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -156,6 +156,7 @@ The same can be achieved by setting the environment variable `WARNINGS`.
 
 `--add-ca <CAfile>` enables you to add your own CA(s) in PEM format for trust chain checks. `CAfile` can be a directory containing files with a \.pem extension, a single file or multiple files as a comma separated list of root CAs. Internally they will be added during runtime to all CA stores. This is (only) useful for internal hosts whose certificates are issued by internal CAs. Alternatively ADDTL_CA_FILES is the environment variable for this.
 
+`--rating-only` makes testssl.sh do the bare minimum to allow rating to succeed. See RATING for more
 
 ### SINGLE CHECK OPTIONS
 
@@ -448,7 +449,7 @@ set_grade_warning "Documentation is always right"
 
 #### Implementing a new check which contains grade caps
 
-When implementing a new check (be it vulnerability or not) that sets grade caps, the `set_rating_state()` has to be updated (i.e. the `$do_mycheck` variable-name has to be added to the loop, and `$nr_enabled` if-statement has to be incremented)
+When implementing a new check (be it vulnerability or not) that sets grade caps, the `set_rating_state()` has to be updated (i.e. the `$do_mycheck` variable-name has to be added to the loop, and `$nr_enabled` if-statement has to be incremented), and the `--rating-only` switch statement needs to have `$do_mycheck=true` added
 
 The `set_rating_state()` automatically disables rating, if all the required checks are *not* enabled.
 This is to prevent giving out a misleading or wrong grade.

--- a/testssl.sh
+++ b/testssl.sh
@@ -21598,6 +21598,7 @@ tuning / connect options (most also can be preset via environment variables):
      --mtls <CLIENT CERT file>     path to <CLIENT CERT> file in PEM format containing unencrypted certificate key (beta)
      --basicauth <user:pass>       provide HTTP basic auth information
      --reqheader <header>          add custom http request headers
+     --rating-only                 test only the checks required for rating
 
 output options (can also be preset via environment variables):
      --quiet                       don't output the banner. By doing this you acknowledge usage terms normally appearing in the banner
@@ -21610,7 +21611,7 @@ output options (can also be preset via environment variables):
      --color <0|1|2|3>             0: no escape or other codes,  1: b/w escape codes,  2: color (default), 3: extra color (color all ciphers)
      --colorblind                  swap green and blue in the output
      --debug <0-6>                 1: screen output normal but keeps debug output in /tmp/.  2-6: see "grep -A 5 '^DEBUG=' testssl.sh"
-     --disable-rating              Explicitly disables the rating output
+     --disable-rating              explicitly disables the rating output
 
 file output options (can also be preset via environment variables)
      --log, --logging              logs stdout to '\${NODE}-p\${port}\${YYYYMMDD-HHMM}.log' in current working directory (cwd)
@@ -25146,6 +25147,31 @@ parse_cmd_line() {
                     REQHEADER="$(parse_opt_equal_sign "$1" "$2")"
                     [[ $? -eq 0 ]] && shift
                     REQHEADERS+=("$REQHEADER")
+                    ;;
+               --rating[-_]only)
+                    # Do only the bare minimum for rating to be successfully done
+                    # See set_rating_state() for required variables
+                    do_protocols=true
+                    do_cipherlists=true
+                    do_fs=true
+                    do_server_defaults=true
+                    do_header=true
+                    do_heartbleed=true
+                    do_ccs_injection=true
+                    do_ticketbleed=true
+                    do_robot=true
+                    do_renego=true
+                    do_crime=true
+                    do_ssl_poodle=true
+                    do_tls_fallback_scsv=true
+                    do_drown=true
+                    do_beast=true
+                    do_rc4=true
+                    do_logjam=true
+                    do_allciphers=true
+
+                    # Force vuln. checks to be shown under the same header
+                    VULN_THRESHLD=-1
                     ;;
                (--) shift
                     break


### PR DESCRIPTION
## Describe your changes

Fixes https://github.com/testssl/testssl.sh/issues/2875

UPDATES since https://github.com/testssl/testssl.sh/pull/2942:
* Switched to `--rating-only` for consistency with the rest of the testssl.sh
* Moved the flag in the help-text
* Set VULN_THRESHLD to -1 to force the vuln. checks to appear under the same header (zero was not enough?)
* Added some docs, albeit basic :--)

Added a very simple `--rating-only` flag, that will enable only the checks required for rating to be successful.

NOTE: this is a very simple implementation that sets the required variables to true (even if they potentially were disabled with other flags). HOWEVER it is also possible to add additional tests with any of the single-check flags (like `./testssl.sh --rating-only --winshock`)

Not sure if this is too simple for your liking? Let me know if so, then I will update. I threw this together rather quickly :-)

...oh, and I lowercased the `--disable-rating` help text; all the surrounding text is lowercase

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [x] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
