### PR TITLE
Add support for EC private key in mTLS check

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -25214,7 +25214,7 @@ parse_cmd_line() {
      if [[ ! -z "$MTLS" ]]; then
           if [[ -f $MTLS ]]; then
                grep -q 'BEGIN CERTIFICATE' "$MTLS" || fatal_cmd_line "\"$MTLS\" is not a client certificate file in PEM format" $ERR_RESOURCE
-               grep -q 'BEGIN PRIVATE KEY\|BEGIN RSA PRIVATE KEY' "$MTLS" || fatal_cmd_line "\"$MTLS\" the not encrypted private key is missing in the specified PEM file" $ERR_RESOURCE
+               grep -q 'BEGIN PRIVATE KEY\|BEGIN RSA PRIVATE KEY\|BEGIN EC PRIVATE KEY' "$MTLS" || fatal_cmd_line "\"$MTLS\" the not encrypted private key is missing in the specified PEM file" $ERR_RESOURCE
                MTLS=$MTLS
           else
                [[ -s "$MTLS" ]] || fatal_cmd_line "the specified client certificate file \"$MTLS\" does not exist" $ERR_RESOURCE

--- a/testssl.sh
+++ b/testssl.sh
@@ -25214,7 +25214,7 @@ parse_cmd_line() {
      if [[ ! -z "$MTLS" ]]; then
           if [[ -f $MTLS ]]; then
                grep -q 'BEGIN CERTIFICATE' "$MTLS" || fatal_cmd_line "\"$MTLS\" is not a client certificate file in PEM format" $ERR_RESOURCE
-               grep -q 'BEGIN PRIVATE KEY\|BEGIN RSA PRIVATE KEY\|BEGIN EC PRIVATE KEY' "$MTLS" || fatal_cmd_line "\"$MTLS\" the not encrypted private key is missing in the specified PEM file" $ERR_RESOURCE
+               grep -Eaq 'BEGIN PRIVATE KEY|BEGIN RSA PRIVATE KEY|BEGIN EC PRIVATE KEY' "$MTLS" || fatal_cmd_line "\"$MTLS\" the not encrypted private key is missing in the specified PEM file" $ERR_RESOURCE
                MTLS=$MTLS
           else
                [[ -s "$MTLS" ]] || fatal_cmd_line "the specified client certificate file \"$MTLS\" does not exist" $ERR_RESOURCE


### PR DESCRIPTION
## Describe your changes

When testing mTLS with a client PEM including key and certificate, the `testssl` mtls check does not check for EC private keys.

## What is your pull request about?
- [X] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [X] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [X] I've read CONTRIBUTING.md and Coding_Convention.md 
- [X] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
