### PR TITLE
Address 2952

### DIFF
--- a/t/00_testssl_help.t
+++ b/t/00_testssl_help.t
@@ -13,7 +13,7 @@ my $out="";
 
 # Try to detect remainders from debugging:
 my $debug_regexp='^(\s)*set (-|\+)x';
-# Blacklists we use to trigger an error:
+# Patterns used to trigger an error:
 my $error_regexp1='(syntax|parse) (e|E)rror';
 my $error_regexp2='testssl.sh: line';
 my $error_regexp3='bash: warning';

--- a/t/01_testssl_banner.t
+++ b/t/01_testssl_banner.t
@@ -8,7 +8,7 @@ use Test::More;
 
 my $tests = 0;
 my $fileout="";
-# Blacklists we use to trigger an error:
+# Patterns used to trigger an error:
 my $error_regexp1='(syntax|parse) (e|E)rror';
 my $error_regexp2='testssl.sh: line';
 my $error_regexp3='bash: warning';

--- a/t/02_clientsim_txt_parsable.t
+++ b/t/02_clientsim_txt_parsable.t
@@ -8,7 +8,7 @@ use Test::More;
 
 my $tests = 0;
 my $fileout="";
-# Blacklists we use to trigger an error:
+# Patterns used to trigger an error:
 my $error_regexp1='(syntax|parse) (e|E)rror';
 my $error_regexp2='client-simulation.txt:';
 

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -2,8 +2,6 @@
 
 # baseline test for testssl, screen and JSON output
 
-# This is referred by the documentation.
-
 # We could also inspect the JSON for any problems for
 #    "id"           : "scanProblem"
 #    "finding"      : "Scan interrupted"
@@ -50,7 +48,6 @@ $tests++;
 #2
 unlike($socket_json, qr/$json_errors/, "via sockets checking JSON output");
 $tests++;
-
 unlink $tmp_json;
 
 #3
@@ -62,7 +59,6 @@ $tests++;
 #4
 unlike($openssl_json, qr/$json_errors/, "via OpenSSL (builtin) checking JSON output");
 $tests++;
-
 unlink $tmp_json;
 
 done_testing($tests);

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -54,43 +54,43 @@ unlike($json_string, qr/$json_errors/, "via sockets checking JSON output");
 $tests++;
 
 #3
-if ( $os eq "linux" ){
-     unlink $json_file;
-     $terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
-     $json_string = json($json_file);
-     unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
-} elsif ( $os eq "darwin" ){
-     printf "%s\n", "Skipping test. The result of the check under MacOS is not understood" ;
-}
+unlink $json_file;
+$terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
+$json_string = json($json_file);
+unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
 $tests++;
 
 #4
 unlike($json_string, qr/$json_errors/, "via OpenSSL (builtin) checking JSON output");
 $tests++;
 
-#5 -- early data test. We just take the last check
-my $found=0;
-open my $fh, '<', $json_file or die "Can't open '$json_file': $!";
-local $/;                    # undef slurp mode
-my $data = decode_json(<$fh>);
-close $fh;
+if ( $os eq "linux" ){
+     #5 -- early data test. We just take the last check
+     my $found=0;
+     open my $fh, '<', $json_file or die "Can't open '$json_file': $!";
+     local $/;                    # undef slurp mode
+     my $data = decode_json(<$fh>);
+     close $fh;
 
-# Check if the decoded data is an array
-if (ref $data eq 'ARRAY') {
-     # Iterate through the array of JSON objects
-     foreach my $obj (@$data) {
-          # Check if the 'id' is "early_data" and 'severity' is "HIGH"
-          if ($obj->{id} eq 'early_data' && $obj->{severity} eq 'HIGH') {
-               $found=1;
-               last;          # we can leave the loop
+     # Check if the decoded data is an array
+     if (ref $data eq 'ARRAY') {
+          # Iterate through the array of JSON objects
+          foreach my $obj (@$data) {
+               # Check if the 'id' is "early_data" and 'severity' is "HIGH"
+               if ($obj->{id} eq 'early_data' && $obj->{severity} eq 'HIGH') {
+                    $found=1;
+                    last;          # we can leave the loop
+               }
           }
      }
-}
 
-if ($found) {
-    ok(1, "0‑RTT found in JSON from $uri");
-} else {
-    fail("0‑RTT test for $uri failed");
+     if ($found) {
+         ok(1, "0‑RTT found in JSON from $uri");
+     } else {
+         fail("0‑RTT test for $uri failed");
+     }
+} elsif ( $os eq "darwin" ){
+     printf "%s\n", "Skipping test. The result of the check under MacOS is not understood" ;
 }
 $tests++;
 

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -52,15 +52,15 @@ $tests++;
 #2
 unlike($json_string, qr/$json_errors/, "via sockets checking JSON output");
 $tests++;
-unlink $json_file;
 
 #3
 if ( $os eq "linux" ){
+     unlink $json_file;
      $terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
      $json_string = json($json_file);
      unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
 } elsif ( $os eq "darwin" ){
-     printf "%s\n", "skipping test. The result of the check under MacOS is not understood" ;
+     printf "%s\n", "Skipping test. The result of the check under MacOS is not understood" ;
 }
 $tests++;
 

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -89,10 +89,10 @@ if ( $os eq "linux" ){
      } else {
          fail("0‑RTT test for $uri failed");
      }
+     $tests++;
 } elsif ( $os eq "darwin" ){
      printf "%s\n", "Skipping test. The result of the check under MacOS is not understood" ;
 }
-$tests++;
 
 done_testing($tests);
 printf "\n\n";

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# baseline test for testssl, screen and JSON output
+# Baseline test for testssl, screen and JSON output
 
 # We could also inspect the JSON for any problems for
 #    "id"           : "scanProblem"
@@ -13,13 +13,11 @@ use JSON;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $tmp_json="tmp.json";
-my $check2run="-p -s -P --fs -S -h -U -q --ip=one --color 0 --jsonfile $tmp_json";
+my $json_file="";
+my $check2run="-p -s -P --fs -S -h -U -q --ip=one --color 0 --jsonfile";
 my $uri="google.com";
-my $socket_out="";
-my $openssl_out="";
-my $socket_json="";
-my $openssl_json="";
+my $terminal_out="";
+my $json_string="";
 #FIXME: Pattern we use to trigger an error, but likely we can skip that and instead we should?/could use the following??
 #       @args="$prg $check2run $uri >/dev/null";
 #       system("@args") == 0
@@ -34,35 +32,65 @@ STDOUT->autoflush(1);
 die "Unable to open $prg" unless -f $prg;
 
 # Provide proper start conditions
-unlink $tmp_json;
+$json_file="tmp.json";
+unlink $json_file;
 
 # Title
 printf "\n%s\n", "Baseline unit test IPv4 against \"$uri\"";
-$socket_out = `$prg $check2run $uri 2>&1`;
-$socket_json = json($tmp_json);
+
+
+# run the check
+$terminal_out = `$prg $check2run $json_file $uri 2>&1`;
+$json_string = json($json_file);
+
 
 #1
-unlike($socket_out, qr/$socket_errors≈/, "via sockets, checking terminal output");
+unlike($terminal_out, qr/$socket_errors≈/, "via sockets, checking terminal output");
 $tests++;
 
 #2
-unlike($socket_json, qr/$json_errors/, "via sockets checking JSON output");
+unlike($json_string, qr/$json_errors/, "via sockets checking JSON output");
 $tests++;
-unlink $tmp_json;
+unlink $json_file;
 
 #3
-$openssl_out = `$prg --ssl-native $check2run $uri 2>&1`;
-$openssl_json = json($tmp_json);
-unlike($openssl_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
+$terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
+$json_string = json($json_file);
+unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
 $tests++;
 
 #4
-unlike($openssl_json, qr/$json_errors/, "via OpenSSL (builtin) checking JSON output");
+unlike($json_string, qr/$json_errors/, "via OpenSSL (builtin) checking JSON output");
 $tests++;
-unlink $tmp_json;
+
+#5 -- early data test. We just take the last check
+my $found=0;
+open my $fh, '<', $json_file or die "Can't open '$json_file': $!";
+local $/;                    # undef slurp mode
+my $data = decode_json(<$fh>);
+close $fh;
+
+# Check if the decoded data is an array
+if (ref $data eq 'ARRAY') {
+     # Iterate through the array of JSON objects
+     foreach my $obj (@$data) {
+          # Check if the 'id' is "early_data" and 'severity' is "HIGH"
+          if ($obj->{id} eq 'early_data' && $obj->{severity} eq 'HIGH') {
+               $found=1;
+               last;          # we can leave the loop
+          }
+     }
+}
+
+if ($found) {
+    ok(1, "0‑RTT found in JSON from $uri");
+} else {
+    fail("0‑RTT test for $uri failed");
+}
+$tests++;
 
 done_testing($tests);
-printf "\n";
+printf "\n\n";
 
 
 sub json($) {
@@ -71,7 +99,6 @@ sub json($) {
 	unlink $file;
 	return from_json($file);
 }
-
 
 # vim:ts=5:sw=5:expandtab
 

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -54,6 +54,7 @@ $tests++;
 unlink $json_file;
 
 #3
+$uri="testssl.net";
 $terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
 $json_string = json($json_file);
 unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");

--- a/t/10_baseline_ipv4_http.t
+++ b/t/10_baseline_ipv4_http.t
@@ -25,6 +25,7 @@ my $json_string="";
 my $socket_errors='(e|E)rror|FIXME|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_errors='(e|E)rror|FIXME|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 my $json_errors='(id".*:\s"scanProblem"|severity".*:\s"FATAL"|"Scan interrupted")';
+my $os="$^O";
 
 # useful against "failed to flush stdout" messages
 STDOUT->autoflush(1);
@@ -54,10 +55,13 @@ $tests++;
 unlink $json_file;
 
 #3
-$uri="testssl.net";
-$terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
-$json_string = json($json_file);
-unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
+if ( $os eq "linux" ){
+     $terminal_out = `$prg --ssl-native $check2run $json_file $uri 2>&1`;
+     $json_string = json($json_file);
+     unlike($terminal_out, qr/$openssl_errors/, "via (builtin) OpenSSL, checking terminal output");
+} elsif ( $os eq "darwin" ){
+     printf "%s\n", "skipping test. The result of the check under MacOS is not understood" ;
+}
 $tests++;
 
 #4

--- a/t/11_baseline_ipv6_http.t.DISABLED
+++ b/t/11_baseline_ipv6_http.t.DISABLED
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# disabled as IPv6 wasn't supported by Travis CI and isn't by GH action, see https://github.com/testssl/testssl.sh/issues/1177
+# disabled as IPv6 wasn't supported by Travis CI and isn't also supported by GH action, see https://github.com/testssl/testssl.sh/issues/1177
 
 # Just a functional test, whether there are any problems on the client side
 # Probably we could also inspect the JSON for any problems for
@@ -10,8 +10,8 @@
 use strict;
 use Test::More;
 use Data::Dumper;
+# if JSON wlll be needed this and the lines below need to be uncommented
 # use JSON;
-# if we need JSON we need to comment this and the lines below in
 
 my $tests = 0;
 my $prg="./testssl.sh";
@@ -19,7 +19,7 @@ my $check2run ="-p -s -P --fs -S -h -U -q --ip=one --color 0";
 my $uri="";
 my $socket_out="";
 my $openssl_out="";
-# Blacklists we use to trigger an error:
+# Patterns used to trigger an error:
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 

--- a/t/11_baseline_ipv6_http.t.DISABLED
+++ b/t/11_baseline_ipv6_http.t.DISABLED
@@ -10,7 +10,7 @@
 use strict;
 use Test::More;
 use Data::Dumper;
-# if JSON wlll be needed this and the lines below need to be uncommented
+# if JSON it'll be needed to uncommented this and the lines below
 # use JSON;
 
 my $tests = 0;

--- a/t/12_diff_opensslversions.t
+++ b/t/12_diff_opensslversions.t
@@ -21,7 +21,7 @@ my $diff="";
 my $distro_openssl="/usr/bin/openssl";
 my @args="";
 # that can be done better but I am a perl n00b ;-)
-my $os=`perl -e 'print "$^O";'`;
+my $os="$^O";
 
 die "Unable to open $prg" unless -f $prg;
 die "Unable to open $distro_openssl" unless -f $distro_openssl;

--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -22,7 +22,7 @@ my $check2run="-q --ip=one --color 0";
 my $uri="";
 my $socket_out="";
 my $openssl_out="";
-# Blacklists we use to trigger an error:
+# Patterns used to trigger an error:
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 my $openssl_fallback_cmd="";       # empty for Linux

--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -25,6 +25,8 @@ my $openssl_out="";
 # Blacklists we use to trigger an error:
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
+my $openssl_fallback_cmd="";       # empty for Linux
+my $os="$^O";
 
 # my $socket_json="";
 # my $openssl_json="";
@@ -32,6 +34,24 @@ my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client c
 # $check2run="--jsonfile tmp.json $check2run";
 
 die "Unable to open $prg" unless -f $prg;
+
+if ( $os eq "darwin" ){
+     # MacOS silicon doesn't have ~/bin/openssl.Darwin.arm64 binary so we use the
+     # homebrew version which was moved to /opt/homebrew/bin/openssl.NOPE in
+     # .github/workflows/unit_tests_macos.yml . The LibreSSL version from MacOS
+     # sometimes have problems to finish the run, thus we use homebrew's version
+     # as fallback.
+     # If this will be run outside GH actions, i.e. locally, we provide a fallback to
+     # /opt/homebrew/bin/openssl or just leave this thing
+     if ( -x "/opt/homebrew/bin/openssl.NOPE" ) {
+          $openssl_fallback_cmd="--openssl /opt/homebrew/bin/openssl.NOPE";
+     }
+     elsif ( -x "/opt/homebrew/bin/openssl" ) {
+          $openssl_fallback_cmd="--openssl /opt/homebrew/bin/openssl";
+     }
+}
+
+$check2run_smtp="$check2run_smtp $openssl_fallback_cmd" ;
 
 #1
 $uri="smtp-relay.gmail.com:587";

--- a/t/21_baseline_starttls.t
+++ b/t/21_baseline_starttls.t
@@ -33,10 +33,8 @@ my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client c
 
 die "Unable to open $prg" unless -f $prg;
 
-$uri="smtp-relay.gmail.com:587";
-
-
 #1
+$uri="smtp-relay.gmail.com:587";
 # unlink "tmp.json";
 # we will have client simulations later, so we don't need to run everything again:
 printf "\n%s\n", "STARTTLS SMTP unit test via sockets --> $uri ...";
@@ -46,16 +44,7 @@ unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
 #2
-# unlink "tmp.json";
-printf "\n%s\n", "STARTTLS SMTP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `$prg --ssl-native $check2run_smtp -t smtp $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
-
 $uri="pop.gmx.net:110";
-
-#3
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS POP3 unit tests via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t pop3 $uri 2>&1`;
@@ -63,16 +52,8 @@ $socket_out = `$prg $check2run -t pop3 $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-#4
-printf "\n%s\n", "STARTTLS POP3 unit tests via OpenSSL --> $uri ...";
-$openssl_out = `$prg --ssl-native $check2run -t pop3 $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
-
+#3
 $uri="imap.gmx.net:143";
-
-#5
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS IMAP unit tests via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t imap $uri 2>&1`;
@@ -80,16 +61,8 @@ $socket_out = `$prg $check2run -t imap $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-#6
-printf "\n%s\n", "STARTTLS IMAP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `$prg --ssl-native $check2run -t imap $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
-
+#4
 $uri="mail.tigertech.net:4190";
-
-#7
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS MANAGE(SIEVE) unit tests via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t sieve $uri 2>&1`;
@@ -97,9 +70,8 @@ $socket_out = `$prg $check2run -t sieve $uri 2>&1`;
 unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
 
+#5
 $uri="jabber.org:5222";
-
-#8
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS XMPP unit tests via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t xmpp $uri 2>&1`;
@@ -109,12 +81,6 @@ $tests++;
 
 # commented out, bc of travis' limits
 #
-#printf "\n%s\n", "STARTTLS XMPP unit tests via OpenSSL --> $uri ...";
-#$openssl_out = `$prg --ssl-native $check2run -t xmpp $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-#unlike($openssl_out, qr/$openssl_regex_bl/, "");
-#$tests++;
-
 # $uri="jabber.ccc.de:5269";
 # printf "\n%s\n", "Quick STARTTLS XMPP S2S unit tests via sockets --> $uri ...";
 # $openssl_out = `$prg --openssl=/usr/bin/openssl -p $check2run -t xmpp-server $uri 2>&1`;
@@ -122,10 +88,8 @@ $tests++;
 # unlike($openssl_out, qr/$openssl_regex_bl/, "");
 # $tests++;
 
-
+#6
 $uri="ldap.uni-rostock.de:21";
-
-#9
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS FTP unit tests via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t ftp $uri 2>&1`;
@@ -135,34 +99,14 @@ $socket_out =~ s/ error querying OCSP responder .*\n//g;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-# commented out, bc of travis' limits
-#
-# printf "\n%s\n", "STARTTLS FTP unit tests via OpenSSL --> $uri ...";
-# $openssl_out = `$prg --ssl-native $check2run -t ftp $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-# OCSP stapling fails sometimes with: 'offered, error querying OCSP responder (ERROR: No Status found)'
-# $openssl_out =~ s/ error querying OCSP responder .*\n//g;
-# unlike($openssl_out, qr/$openssl_regex_bl/, "");
-# $tests++;
-
-
+#7
 # https://ldapwiki.com/wiki/Public%20LDAP%20Servers
 $uri="db.debian.org:389";
-
-#10
 printf "\n%s\n", "STARTTLS LDAP unit tests via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t ldap $uri 2>&1`;
 # $socket_json = json('tmp.json');
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
-
-#11
-printf "\n%s\n", "STARTTLS LDAP unit tests via OpenSSL --> $uri ...";
-$openssl_out = `$prg --ssl-native $check2run -t ldap $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-unlike($openssl_out, qr/$openssl_regex_bl/, "");
-$tests++;
-
 
 # For NNTP there doesn't seem to be reliable host out there
 #$uri="144.76.182.167:119";
@@ -171,14 +115,7 @@ $tests++;
 #$socket_out = `$prg $check2run -t nntp $uri 2>&1`;
 #unlike($socket_out, qr/$socket_regex_bl/, "");
 #$tests++;
-
-# commented out, bc of travis' limits
-#
-#printf "\n%s\n", "STARTTLS NNTP unit tests via OpenSSL --> $uri ...";
-#$openssl_out = `$prg --ssl-native $check2run -t nntp $uri 2>&1`;
-# $openssl_json = json('tmp.json');
-#unlike($openssl_out, qr/$openssl_regex_bl/, "");
-#$tests++;
+# also: commented out, bc of travis' limits
 
 # IRC: missing
 # LTMP, mysql, postgres

--- a/t/23_client_simulation.t
+++ b/t/23_client_simulation.t
@@ -1,15 +1,16 @@
 #!/usr/bin/env perl
 
 # Just a functional test, whether there are any problems on the client side
-# Probably we could also inspect the JSON for any problems for
+
+# We could also inspect the JSON for any problems for
 #    "id"           : "scanProblem"
 #    "finding"      : "Scan interrupted"
 
 use strict;
 use Test::More;
 use Data::Dumper;
+# if needed: comment this and the lines below in:
 # use JSON;
-# if we need JSON we need to comment this and the lines below in
 
 my $tests = 0;
 my $prg="./testssl.sh";
@@ -17,7 +18,7 @@ my $check2run ="--client-simulation -q --ip=one --color 0";
 my $uri="";
 my $socket_out="";
 my $openssl_out="";
-# Blacklists we use to trigger an error:
+# Pattern we use to trigger an error:
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 
@@ -30,8 +31,8 @@ STDOUT->autoflush(1);
 
 die "Unable to open $prg" unless -f $prg;
 
+#1
 $uri="google.com";
-
 # unlink "tmp.json";
 printf "\n%s\n", "Client simulations unit test via sockets --> $uri ...";
 $socket_out = `$prg $check2run $uri 2>&1`;
@@ -39,6 +40,7 @@ $socket_out = `$prg $check2run $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
+#2 Makes little sense anymore but lets just keep this unit test
 # unlink "tmp.json";
 printf "\n%s\n", "Client simulations unit test via OpenSSL --> $uri ...";
 $openssl_out = `$prg $check2run --ssl-native $uri 2>&1`;
@@ -47,8 +49,8 @@ unlike($openssl_out, qr/$openssl_regex_bl/, "");
 $tests++;
 
 
+#3
 $uri="smtp-relay.gmail.com:587";
-
 # unlink "tmp.json";
 printf "\n%s\n", "STARTTLS: Client simulations unit test via sockets --> $uri ...";
 $socket_out = `$prg $check2run -t smtp $uri 2>&1`;
@@ -56,18 +58,10 @@ $socket_out = `$prg $check2run -t smtp $uri 2>&1`;
 unlike($socket_out, qr/$socket_regex_bl/, "");
 $tests++;
 
-# commented out, bc of travis' limits
-#
 # unlink "tmp.json";
-#printf "\n%s\n", "STARTTLS: Client simulations unit test via OpenSSL --> $uri ...";
-#$openssl_out = `$prg --ssl-native $check2run -t smtp $uri 2>&1`;
-## $openssl_json = json('tmp.json');
-#unlike($openssl_out, qr/$openssl_regex_bl/, "");
-#$tests++;
 
 done_testing($tests);
-unlink "tmp.json";
-
+printf "\n";
 
 
 sub json($) {
@@ -78,5 +72,5 @@ sub json($) {
 }
 
 
-#  vim:ts=5:sw=5:expandtab
+# vim:ts=5:sw=5:expandtab
 

--- a/t/31_isJSON_valid.t
+++ b/t/31_isJSON_valid.t
@@ -53,7 +53,7 @@ $tests++;
 
 
 #3
-uri = "smtp-relay.gmail.com:587";
+$uri = "smtp-relay.gmail.com:587";
 printf "%s\n", " .. plain JSON and STARTTLS --> $uri ...";
 $out = `$prg --jsonfile $json_file $check2run -t smtp $uri`;
 $json = json($json_file);

--- a/t/31_isJSON_valid.t
+++ b/t/31_isJSON_valid.t
@@ -9,23 +9,27 @@ use JSON;
 
 my $tests = 0;
 my $prg="./testssl.sh";
+my $json="tmp.json";
 my $check2run ="--ip=one --ids-friendly -q --color 0";
-my $uri="";
-my $json="";
+my $uri="example.com";        # Cloudflare blocks too often
 my $out="";
 my $cmd_timeout="--openssl-timeout=10";
-# Blacklists we use to trigger an error:
+
+# Patterns used to trigger an error:
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
-# that can be done better but I am a perl n00b ;-)
 my $os="$^O";
+
+# useful against "failed to flush stdout" messages
+STDOUT->autoflush(1);
 
 die "Unable to open $prg" unless -f $prg;
 
-my $uri="cloudflare.com";
+# Provide proper start conditions
+unlink $json;
 
+# Title
 printf "\n%s\n", "Unit testing JSON output ...";
-unlink 'tmp.json';
 
 #1
 printf "%s\n", ".. plain JSON --> $uri ";
@@ -35,7 +39,6 @@ unlink 'tmp.json';
 my @errors=eval { decode_json($json) };
 is(@errors,0,"no errors");
 $tests++;
-
 
 #2
 printf "%s\n", ".. pretty JSON --> $uri ";
@@ -86,15 +89,16 @@ if ( $os eq "linux" ){
      printf "skipped two checks on MacOS\n\n";
 }
 
-printf "\n";
 done_testing($tests);
+printf "\n";
 
 sub json($) {
     my $file = shift;
     $file = `cat $file`;
+    unlink $file;
     return from_json($file);
 }
 
 
-#  vim:ts=5:sw=5:expandtab
+# vim:ts=5:sw=5:expandtab
 

--- a/t/31_isJSON_valid.t
+++ b/t/31_isJSON_valid.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# This is more a PoC. Improvements welcome!
+# Checking whether both JSON outputs are valid
 #
 
 use strict;
@@ -9,7 +9,8 @@ use JSON;
 
 my $tests = 0;
 my $prg="./testssl.sh";
-my $json="tmp.json";
+my $json="";
+my $json_file="";
 my $check2run ="--ip=one --ids-friendly -q --color 0";
 my $uri="example.com";        # Cloudflare blocks too often
 my $out="";
@@ -26,36 +27,37 @@ STDOUT->autoflush(1);
 die "Unable to open $prg" unless -f $prg;
 
 # Provide proper start conditions
-unlink $json;
+$json_file="tmp.json";
+unlink $json_file;
 
 # Title
 printf "\n%s\n", "Unit testing JSON output ...";
 
 #1
 printf "%s\n", ".. plain JSON --> $uri ";
-$out = `$prg $check2run --jsonfile tmp.json $uri`;
-$json = json('tmp.json');
-unlink 'tmp.json';
+$out = `$prg $check2run --jsonfile $json_file $uri`;
+$json = json($json_file);
+unlink $json_file;
 my @errors=eval { decode_json($json) };
 is(@errors,0,"no errors");
 $tests++;
 
 #2
 printf "%s\n", ".. pretty JSON --> $uri ";
-$out = `$prg $check2run --jsonfile-pretty tmp.json $uri`;
-$json = json('tmp.json');
-unlink 'tmp.json';
+$out = `$prg $check2run --jsonfile-pretty $json_file $uri`;
+$json = json($json_file);
+unlink $json_file;
 @errors=eval { decode_json($json) };
 is(@errors,0,"no errors");
 $tests++;
 
 
 #3
-my $uri = "smtp-relay.gmail.com:587";
+uri = "smtp-relay.gmail.com:587";
 printf "%s\n", " .. plain JSON and STARTTLS --> $uri ...";
-$out = `$prg --jsonfile tmp.json $check2run -t smtp $uri`;
-$json = json('tmp.json');
-unlink 'tmp.json';
+$out = `$prg --jsonfile $json_file $check2run -t smtp $uri`;
+$json = json($json_file);
+unlink $json_file;
 @errors=eval { decode_json($json) };
 is(@errors,0,"no errors");
 $tests++;
@@ -68,9 +70,9 @@ if ( $os eq "linux" ){
      # This testssl.sh run deliberately does NOT work as github actions block port 25 egress.
      # but the output should be fine. The idea is to have a unit test for a failed connection.
      printf "%s\n", ".. plain JSON for a failed run: '--mx $uri' ...";
-     $out = `$prg --ssl-native --openssl-timeout=10 $check2run --jsonfile tmp.json --mx $uri`;
-     $json = json('tmp.json');
-     unlink 'tmp.json';
+     $out = `$prg --ssl-native --openssl-timeout=10 $check2run --jsonfile $json_file --mx $uri`;
+     $json = json($json_file);
+     unlink $json_file;
      @errors=eval { decode_json($json) };
      is(@errors,0,"no errors");
      $tests++;
@@ -78,9 +80,9 @@ if ( $os eq "linux" ){
      #5
      # Same as above but with pretty JSON
      printf "%s\n", ".. pretty JSON for a failed run '--mx $uri' ...";
-     $out = `$prg --ssl-native --openssl-timeout=10 $check2run --jsonfile-pretty tmp.json --mx $uri`;
-     $json = json('tmp.json');
-     unlink 'tmp.json';
+     $out = `$prg --ssl-native --openssl-timeout=10 $check2run --jsonfile-pretty $json_file --mx $uri`;
+     $json = json($json_file);
+     unlink $json_file;
      @errors=eval { decode_json($json) };
      is(@errors,0,"no errors");
      $tests++;
@@ -90,7 +92,7 @@ if ( $os eq "linux" ){
 }
 
 done_testing($tests);
-printf "\n";
+printf "\n\n";
 
 sub json($) {
     my $file = shift;

--- a/t/31_isJSON_valid.t
+++ b/t/31_isJSON_valid.t
@@ -18,7 +18,7 @@ my $cmd_timeout="--openssl-timeout=10";
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 # that can be done better but I am a perl n00b ;-)
-my $os="$^O";'
+my $os="$^O";
 
 die "Unable to open $prg" unless -f $prg;
 

--- a/t/31_isJSON_valid.t
+++ b/t/31_isJSON_valid.t
@@ -18,7 +18,7 @@ my $cmd_timeout="--openssl-timeout=10";
 my $socket_regex_bl='(e|E)rror|\.\/testssl\.sh: line |(f|F)atal|(c|C)ommand not found';
 my $openssl_regex_bl='(e|E)rror|(f|F)atal|\.\/testssl\.sh: line |Oops|s_client connect problem|(c|C)ommand not found';
 # that can be done better but I am a perl n00b ;-)
-my $os=`perl -e 'print "$^O";'`;
+my $os="$^O";'
 
 die "Unable to open $prg" unless -f $prg;
 

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -11,8 +11,8 @@ use Text::Diff;
 my $tests = 0;
 my $prg="./testssl.sh";
 my $html="";
-my $htmlfile="tmp.html";
-my $check2run="--ip=one -4 --openssl /usr/bin/openssl --sneaky --ids-friendly --color 0 --htmlfile $htmlfile";
+my $html_file="";
+my $check2run="--ip=one -4 --openssl /usr/bin/openssl --sneaky --ids-friendly --color 0 --htmlfile";
 my $uri="github.com";
 my $out="";
 my $debughtml="";
@@ -21,27 +21,27 @@ my $edited_html="";
 my $diff="";
 my $ip="";
 
-die "Unable to open $prg" unless -f $prg;
-
-printf "\n%s\n", "Doing HTML output checks";
-
 # useful against "failed to flush stdout" messages
 STDOUT->autoflush(1);
 
+die "Unable to open $prg" unless -f $prg;
 
 # Provide proper start conditions
-unlink $htmlfile;
+$html_file="tmp.html";
+unlink $html_file;
 
+# Title
+printf "\n%s\n", "Unit testing HTML output ...";
 
 #1
 printf "%s\n", " .. running $prg against \"$uri\" to create HTML and terminal outputs (may take ~2 minutes)";
 # specify a TERM_WIDTH so that the two calls to testssl.sh don't create HTML files with different values of TERM_WIDTH
-$out = `TERM_WIDTH=120 $prg $check2run $uri`;
-$html = `cat $htmlfile`;
+$out = `TERM_WIDTH=120 $prg $check2run $html_file $uri`;
+$html = `cat $html_file`;
 # $edited_html will contain the HTML with formatting information removed in order to compare against terminal output
 # Start by removing the HTML header.
-$edited_html = `tail -n +11 $htmlfile`;
-unlink $htmlfile;
+$edited_html = `tail -n +11 $html_file`;
+unlink $html_file;
 
 # Remove the HTML footer
 $edited_html =~ s/\n\<\/pre\>\n\<\/body\>\n\<\/html\>//;
@@ -74,9 +74,9 @@ if ( $^O eq "darwin" ){
 #2
 printf "%s\n", " .. running again $prg against \"$uri\", now with --debug 4 to create HTML output (may take another ~2 minutes)";
 # Redirect stderr to /dev/null in order to avoid some unexplained "date: invalid date" error messages
-$out = `TERM_WIDTH=120 $prg $check2run --debug 4 $uri 2>/dev/null`;
-$debughtml = `cat $htmlfile`;
-unlink $htmlfile;
+$out = `TERM_WIDTH=120 $prg $check2run $html_file --debug 4 $uri 2>/dev/null`;
+$debughtml = `cat $html_file`;
+unlink $html_file;
 
 # Remove date information from the Start and Done banners in the two HTML files, since they were created at different times
 $html =~ s/Start 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]/Start XXXX-XX-XX XX:XX:XX/;
@@ -116,10 +116,9 @@ ok($debughtml eq $html, "Checking if HTML file created with --debug 4 matches HT
      diag ("\n%s\n", "$diff");
 $tests++;
 
-
-printf "\n\n";
 done_testing($tests);
+printf "\n\n";
 
 
-#  vim:ts=5:sw=5:expandtab
+# vim:ts=5:sw=5:expandtab
 

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -11,16 +11,15 @@ use Text::Diff;
 my $tests = 0;
 my $prg="./testssl.sh";
 my $html="";
+my $htmlfile="tmp.html";
 my $check2run="--ip=one -4 --openssl /usr/bin/openssl --sneaky --ids-friendly --color 0 --htmlfile $htmlfile";
 my $uri="github.com";
 my $out="";
 my $debughtml="";
 my $edited_html="";
-my $htmlfile="tmp.html";
 # Pick /usr/bin/openssl as we want to avoid the debug messages like "Your ./bin/openssl.Linux.x86_64 doesn't support X25519"
 my $diff="";
 my $ip="";
-
 
 die "Unable to open $prg" unless -f $prg;
 

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -20,10 +20,19 @@ my $htmlfile="tmp.html";
 # Pick /usr/bin/openssl as we want to avoid the debug messages like "Your ./bin/openssl.Linux.x86_64 doesn't support X25519"
 my $diff="";
 my $ip="";
+
+
 die "Unable to open $prg" unless -f $prg;
 
 printf "\n%s\n", "Doing HTML output checks";
+
+# useful against "failed to flush stdout" messages
+STDOUT->autoflush(1);
+
+
+# Provide proper start conditions
 unlink $htmlfile;
+
 
 #1
 printf "%s\n", " .. running $prg against \"$uri\" to create HTML and terminal outputs (may take ~2 minutes)";

--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -10,14 +10,14 @@ use Text::Diff;
 
 my $tests = 0;
 my $prg="./testssl.sh";
+my $html="";
+my $check2run="--ip=one -4 --openssl /usr/bin/openssl --sneaky --ids-friendly --color 0 --htmlfile $htmlfile";
 my $uri="github.com";
 my $out="";
-my $html="";
 my $debughtml="";
 my $edited_html="";
 my $htmlfile="tmp.html";
 # Pick /usr/bin/openssl as we want to avoid the debug messages like "Your ./bin/openssl.Linux.x86_64 doesn't support X25519"
-my $check2run="--ip=one -4 --openssl /usr/bin/openssl --sneaky --ids-friendly --color 0 --htmlfile $htmlfile";
 my $diff="";
 my $ip="";
 die "Unable to open $prg" unless -f $prg;

--- a/t/33_isJSON_severitylevel_valid.t
+++ b/t/33_isJSON_severitylevel_valid.t
@@ -24,6 +24,9 @@ printf "\n%s\n", "Doing severity level checks";
 die "Unable to open $prg" unless -f $prg;
 unlink 'tmp.json';
 
+# useful against "failed to flush stdout" messages
+STDOUT->autoflush(1);
+
 #1
 pass(" .. running testssl.sh against $uri to create a JSON report with severity level >= LOW (may take 2~3 minutes)"); $tests++;
 $out = `$prg $check2run --jsonfile tmp.json $uri`;

--- a/t/33_isJSON_severitylevel_valid.t
+++ b/t/33_isJSON_severitylevel_valid.t
@@ -5,33 +5,39 @@ use Test::More;
 use Data::Dumper;
 use JSON;
 
-my (
-    $out,
-    $json,
-    $json_pretty,
-    $found,
-    $tests
-);
+my $tests = 0;
 
-$tests = 0;
+
 
 my $prg="./testssl.sh";
+my $json="";
+my $json_file="";
 my $check2run = '-S --beast --sweet32 --breach --beast --lucky13 --rc4 --severity LOW --color 0';
 my $uri = 'badssl.com';
+my $out="";
+my $json_pretty="";
+my $found=1;
 
-printf "\n%s\n", "Doing severity level checks";
 
-die "Unable to open $prg" unless -f $prg;
-unlink 'tmp.json';
+
 
 # useful against "failed to flush stdout" messages
 STDOUT->autoflush(1);
 
+die "Unable to open $prg" unless -f $prg;
+
+# Provide proper start conditions
+$json_file="tmp.json";
+unlink $json_file;
+
+# Title
+printf "\n%s\n", "Doing severity level checks";
+
 #1
 pass(" .. running testssl.sh against $uri to create a JSON report with severity level >= LOW (may take 2~3 minutes)"); $tests++;
-$out = `$prg $check2run --jsonfile tmp.json $uri`;
-$json = json('tmp.json');
-unlink 'tmp.json';
+$out = `$prg $check2run --jsonfile $json_file $uri`;
+$json = json($json_file);
+unlink $json_file;
 $found = 0;
 cmp_ok(@$json,'>',0,"At least 1 finding is expected"); $tests++;
 foreach my $f ( @$json ) {
@@ -44,9 +50,9 @@ is($found,0,"We should not have any finding with INFO level"); $tests++;
 
 #2
 pass(" .. running testssl.sh against $uri to create a JSON-PRETTY report with severity level >= LOW (may take 2~3 minutes)"); $tests++;
-$out = `$prg $check2run --jsonfile-pretty tmp.json $uri`;
-$json_pretty = json('tmp.json');
-unlink 'tmp.json';
+$out = `$prg $check2run --jsonfile-pretty $json_file $uri`;
+$json_pretty = json($json_file);
+unlink $json_file;
 $found = 0;
 my $vulnerabilities = $json_pretty->{scanResult}->[0]->{vulnerabilities};
 foreach my $f ( @$vulnerabilities ) {
@@ -57,8 +63,8 @@ foreach my $f ( @$vulnerabilities ) {
 }
 is($found,0,"We should not have any finding with INFO level"); $tests++;
 
-printf "\n";
 done_testing($tests);
+printf "\n\n";
 
 sub json($) {
     my $file = shift;
@@ -68,5 +74,5 @@ sub json($) {
 }
 
 
-#  vim:ts=5:sw=5:expandtab
+# vim:ts=5:sw=5:expandtab
 

--- a/t/51_badssl.com.t
+++ b/t/51_badssl.com.t
@@ -20,6 +20,9 @@ my (
 
 die "Unable to open $prg" unless -f $prg;
 
+# useful against "failed to flush stdout" messages
+STDOUT->autoflush(1);
+
 # Provide proper start conditions
 unlink 'tmp.json';
 

--- a/t/61_diff_testsslsh.t
+++ b/t/61_diff_testsslsh.t
@@ -3,7 +3,7 @@
 # Baseline diff test against testssl.sh (csv output)
 #
 # We don't use a full run yet and only the certificate section.
-# There we would need to blacklist more, like:
+# There we would need to block-list more, like:
 # cert_serialNumber, cert_fingerprintSHA1, cert_fingerprintSHA256, cert
 # cert_expirationStatus, cert_notBefore, cert_notAfter, cert_caIssuers, intermediate_cert
 #

--- a/testssl.sh
+++ b/testssl.sh
@@ -1971,8 +1971,9 @@ http_head_printf() {
                safe_echo "HEAD ${path} HTTP/1.1\r\nUser-Agent: ${useragent}\r\nHost: ${node}\r\nAccept: */*\r\n${extra_header}\r\n\r\n" >&33 2>$errfile
                ret=0
                touch $tmpfile
-               # This doesn't block
-               while IFS= read -r line <&33; do
+               # This doesn't block. A timeout seems necessary for MacOS 18 and e.g. Akamai
+               # but maybe it's due because the server side keeps the connection open
+               while IFS= read -t 4 -r line <&33; do
                     safe_echo "$line" >>$tmpfile
                done
                cat $tmpfile


### PR DESCRIPTION
This PR fixes #2952 in `t/21_baseline_starttls.t`:

* it removes ` --ssl-native` completely from STARTTLS checks
* For mac: uses homebrews openssl for socket tests, if available

Also it cleans up the OS variable check from two other checks, example.com instead of cloudflare is used (cf blocks), more flush hacks added

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
