### PR TITLE
Fix error when early data empty

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -7176,12 +7176,11 @@ sub_early_data() {
      else
           return 5
      fi
-
-     safe_echo "HEAD / HTTP/1.1\r\nHost: $NODE\r\nConnection: close\r\nEarly-Data: 1\r\n\r\n" > $early_data
+     safe_echo "GET / HTTP/1.1\r\nHost: $NODE\r\nEarly-Data: 1\r\nConnection: close\r\n\r\n" > $early_data
      $openssl_bin s_client $(s_client_options "$STARTTLS $BUGS -tls1_3 -connect $NODEIP:$PORT $PROXY $SNI") -sess_out $sess_data -ign_eof \
             < $early_data >/dev/null 2>$ERRFILE
      if [[ ! -s "$sess_data" ]]; then
-          exit 7
+          return 7
      fi
 
      $openssl_bin s_client $(s_client_options "$STARTTLS $BUGS -tls1_3 -connect $NODEIP:$PORT $PROXY $SNI") -sess_in $sess_data \
@@ -10804,7 +10803,7 @@ run_server_defaults() {
                6) prln_warning "Client Auth: early data check not supported"
                   fileout "$jsonID" "WARN" "check couldn't be performed because of client authentication"
                   ;;
-               7) prln_warning "check failed (no session data"
+               7) prln_warning "check failed (no session data received)"
                   fileout "$jsonID" "WARN" "check failed (no session data)"
                   ((ret++))
                ;;


### PR DESCRIPTION
This PR fixes an error when early data was empty
which caused testssl.sh to exit instead of marking that there was no file returned.

Also it changes HEAD to GET as the latter is probably more often supported.

There needs to be a unit test for 0-RTT / early data!

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [x] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
