### PR TITLE
Label missing KEMs as LOW severity (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -11198,11 +11198,14 @@ run_fs() {
                     fi
                fi
           done
+          pr_bold " KEMs offered                 "
           if [[ -n "$kems_offered" ]]; then
-               pr_bold " KEMs offered                 "
                out_row_aligned_max_width_by_entry "$kems_offered" "                              " $TERM_WIDTH pr_kem_param_set_quality
                outln
                fileout "${jsonID}_KEMs" "OK" "$kems_offered"
+          else
+               prln_svrty_low "None"
+               fileout "${jsonID}_KEMs" "LOW" "No KEMs offered"
           fi
           if [[ -n "$curves_offered" ]]; then
                pr_bold " Elliptic curves offered:     "


### PR DESCRIPTION
see #2960.

As 3.2 is used for distributions it seems consistent if we scan for KEMs to backport this feature.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [x] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [x] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
