### PR TITLE
Add missing counter to ROBOT (3.2)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -20844,7 +20844,7 @@ find_openssl_binary() {
      initialize_engine
 
      openssl_location="$(type -p $OPENSSL)"
-     
+
      [[ -n "$GIT_REL" ]] && \
           cwd="$PWD" || \
           cwd="$RUN_DIR"
@@ -24325,6 +24325,7 @@ parse_cmd_line() {
                     ;;
                -BB|--BB|--robot)
                     do_robot=true
+                    ((VULN_COUNT++))
                     ;;
                -R|--renegotiation)
                     do_renego=true


### PR DESCRIPTION
We missed somehow to add in the big while loop to add the fact that ROBOT is a vulnerability which became apparent with #2967 (3.3dev).

This PR adds that for 3.2 also. See #2968 for 3.3dev.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
