### PR TITLE
Suggest alternative $OPENSSL2 when $OPENSSL fails

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -17634,8 +17634,8 @@ run_ticketbleed() {
           $OPENSSL s_client $(s_client_options "$STARTTLS $BUGS $tls_proto -connect $NODEIP:$PORT $PROXY") >$TMPFILE 2>$ERRFILE </dev/null
           sclient_connect_successful $? "$TMPFILE"
           if [[ $? -ne 0 ]]; then
-               prln_warning "Cannot test for ticketbleed. Your OpenSSL cannot connect to $NODEIP:$PORT"
-               fileout "$jsonID" "WARN" "Cannot test for ticketbleed. Your OpenSSL cannot connect to $NODEIP:$PORT."
+               prln_warning "Cannot test for ticketbleed. $OPENSSL cannot connect to $NODEIP:$PORT"
+               fileout "$jsonID" "WARN" "Cannot test for ticketbleed as $OPENSSL cannot connect to $NODEIP:$PORT."
                return 1
           fi
           case "$(get_protocol $TMPFILE)" in
@@ -23224,9 +23224,16 @@ determine_optimal_proto() {
                [[ $? -ne 0 ]] && exit $ERR_CLUELESS
                MAX_OSSL_FAIL=10
           else
-               prln_warning " Your OpenSSL cannot connect to $NODEIP:$PORT"
-               fileout "$jsonID" "WARN" "Your OpenSSL cannot connect to $NODEIP:$PORT."
-               ignore_no_or_lame " The results might look ok but they could be nonsense. Really proceed ? (\"yes\" to continue)" "yes"
+               outln
+               prln_warning " Your $OPENSSL cannot connect to $NODEIP:$PORT."
+               if [[ -x $OPENSSL2 ]] ; then
+                    outln " Restarting with --openssl=$OPENSSL2 likely helps"
+                    fileout "$jsonID" "WARN" "$OPENSSL cannot connect to $NODEIP:$PORT. Recommended using --openssl=$OPENSSL2"
+               else
+                    fileout "$jsonID" "WARN" "Your $OPENSSL cannot connect to $NODEIP:$PORT."
+               fi
+               outln
+               ignore_no_or_lame " If you continue the results are likely not corrrect. Really proceed ? (\"yes\" to continue)" "yes"
                [[ $? -ne 0 ]] && exit $ERR_CLUELESS
           fi
      elif "$all_failed"; then

--- a/testssl.sh
+++ b/testssl.sh
@@ -23233,7 +23233,7 @@ determine_optimal_proto() {
                     fileout "$jsonID" "WARN" "Your $OPENSSL cannot connect to $NODEIP:$PORT."
                fi
                outln
-               ignore_no_or_lame " If you continue the results are likely not corrrect. Really proceed ? (\"yes\" to continue)" "yes"
+               ignore_no_or_lame " If you continue the results are likely not correct. Really proceed ? (\"yes\" to continue)" "yes"
                [[ $? -ne 0 ]] && exit $ERR_CLUELESS
           fi
      elif "$all_failed"; then


### PR DESCRIPTION
.. as an UI improvement for the user.

Implemented for Ticketbleed and during startup in determine_optimal_proto() . For the latter it could be considered later to automagically pick $OPENSSL2 .

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
