### PR TITLE
OpenSSL 4 compatibility

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -9206,9 +9206,9 @@ certificate_info() {
      case "$cert_key_algo" in
           1.3.101.112|E[Dd]25519) cert_key_algo="Ed25519"; cert_keysize=253 ;;
           1.3.101.113|E[Dd]448)   cert_key_algo="Ed448"; cert_keysize=456 ;;
-          2.16.840.1.101.3.4.3.17) cert_key_algo="ML-DSA-44"; cert_keysize=2560 ;;
-          2.16.840.1.101.3.4.3.18) cert_key_algo="ML-DSA-65"; cert_keysize=4032 ;;
-          2.16.840.1.101.3.4.3.19) cert_key_algo="ML-DSA-87"; cert_keysize=4896 ;;
+          2.16.840.1.101.3.4.3.17|ML-DSA-44) cert_key_algo="ML-DSA-44"; cert_keysize=2560 ;;
+          2.16.840.1.101.3.4.3.18|ML-DSA-65) cert_key_algo="ML-DSA-65"; cert_keysize=4032 ;;
+          2.16.840.1.101.3.4.3.19|ML-DSA-87) cert_key_algo="ML-DSA-87"; cert_keysize=4896 ;;
      esac
 
      out "$indent" ; pr_bold " Signature Algorithm          "
@@ -12300,6 +12300,7 @@ get_pub_key_size() {
      if [[ -n $pubkeybits ]]; then
           # remainder e.g. "256 bit)"
           pubkeybits="${pubkeybits//\)/}"
+          pubkeybits="${pubkeybits%% field, *}"
           echo "Server public key is $pubkeybits" >> $TMPFILE
      else
           # This extracts the public key for DSA, DH, and GOST


### PR DESCRIPTION
## Describe your changes

This PR addresses two issues created by changes in certificate printing in OpenSSL 4 (based on testing with OpenSSL 4.0.0-alpha1).

With OpenSSL 4, the public key type for ML-DSA keys is now shown with a string (e.g., ML-DSA-44) rather than an OID. The first change in this PR ensures that the public key size is set correctly in this case.

Second, different information is printed about the size of elliptic curve public keys. All previous versions of OpenSSL (and LibreSSL) just provided the size of the public key:

    Public-Key: (256 bit)

OpenSSL 4.0.0-alpha includes additional information:

    Public-Key: (256 bit field, 128 bit security level)

The second change in this PR removes this additional information.



## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
