### PR TITLE
Make sure date -r hits a dir readable

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -478,14 +478,17 @@ HAS_FREEBSDDATE=false
 HAS_OPENBSDDATE=false
 
 if date -d @735275209 >/dev/null 2>&1; then
+     # FreeBSD's / MacOS' date doesn't reach this
      if date -r @735275209 >/dev/null 2>&1; then
           # Ubuntu >= 25.10
           HAS_GNUDATE=true
-     elif LC_ALL=C date -r 735275209 2>&1 | grep -q "No such file"; then
+     # need to make sure we end up in a directory with read permission (see #3009)
+     elif (cd /; LC_ALL=C date -r 735275209 2>&1 | grep -q "No such file"); then
           # e.g. Debian 24.04, Debian 11-13
           HAS_GNUDATE=true
+     # OpenBSD treats this as a reference (as FreeBSD would do it)
      elif date -r 735275209 >/dev/null 2>&1; then
-          # It can't do any conversion from a plain date output.
+          # OpenBSD date can't do any conversion from a plain date output
           HAS_OPENBSDDATE=true
      fi
 fi


### PR DESCRIPTION
When checking early for date flavors, there might be an edge case when a directory with a referred file (for the date command) isn't readable which might cause testssl.sh to not detect the date flavor correctly.

This fixes that (#3009) by cd'ing to / in a subshell which should be cd'able and readable under every platform.



## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
