### PR TITLE
OpenSSL 4 compatibility for stapled OCSP responses

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10002,7 +10002,7 @@ certificate_info() {
 
      out "$indent"; pr_bold " OCSP stapling                "
      jsonID="OCSP_stapling"
-     if grep -a "OCSP response" <<< "$ocsp_response" | grep -q "no response sent" ; then
+     if grep -a "OCSP response" <<< "$ocsp_response" | grep -Eq "no response[s]? sent" ; then
           if [[ -n "$ocsp_uri" ]]; then
                pr_svrty_low "not offered"
                fileout "${jsonID}${json_postfix}" "LOW" "not offered"
@@ -10418,10 +10418,10 @@ run_server_defaults() {
                          # response so that certificate_info() can determine
                          # whether it includes a certificate transparency extension.
                          ocsp_response_binary[certs_found]="$STAPLED_OCSP_RESPONSE"
-                         if grep -a "OCSP response:" $TMPFILE | grep -q "no response sent"; then
+                         if grep -aE "OCSP response[s]?:" $TMPFILE | grep -Eq "no response[s]? sent"; then
                               ocsp_response[certs_found]="$(grep -a "OCSP response" $TMPFILE)"
                          else
-                              ocsp_response[certs_found]="$(awk -v n=2 '/OCSP response:/ {start=1; inc=2} /======================================/ { if (start) {inc--} } inc' $TMPFILE)"
+                              ocsp_response[certs_found]="$(awk -v n=2 '/OCSP response[s]?:/ {start=1; inc=2} /======================================/ { if (start) {inc--} } inc' $TMPFILE)"
                          fi
                          ocsp_response_status[certs_found]=$(grep -a "OCSP Response Status" $TMPFILE)
                          previous_hostcert[certs_found]=$newhostcert


### PR DESCRIPTION
## Describe your changes

It seems that OpenSSL 4.0.0 allows for the possibility that a server's response to the status request extension may include more than one OCSP response (presumably one for each certificate in the certification path).

As a result, the line indicating that the server does not provide status information was changed from "OCSP response: no response sent" to "OCSP responses: no responses sent". If a response was included, "OCSP responses:" is followed by an indication of the number of responses included.

This PR addresses the change from "response" to "responses".

I do not know of any servers that provide more than one OCSP response, so I have not tried to make any changes to handle more than one response.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
