### PR TITLE
Add missing TLS signature schemes

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -8517,7 +8517,7 @@ get_server_certificate() {
                elif [[ "$1" =~ tls1_3_RSA ]]; then
                     tls_sockets "04" "$TLS13_CIPHER" "all+" "00,12,00,00, 00,05,00,05,01,00,00,00,00, 00,0d,00,16,00,14,08,04,08,05,08,06,04,01,05,01,06,01,02,01,08,09,08,0a,08,0b"
                elif [[ "$1" =~ tls1_3_ECDSA ]]; then
-                    tls_sockets "04" "$TLS13_CIPHER" "all+" "00,12,00,00, 00,05,00,05,01,00,00,00,00, 00,0d,00,0a,00,08,04,03,05,03,06,03,02,03"
+                    tls_sockets "04" "$TLS13_CIPHER" "all+" "00,12,00,00, 00,05,00,05,01,00,00,00,00, 00,0d,00,10,00,0e,04,03,05,03,06,03,02,03,08,1a,08,1b,08,1c"
                elif [[ "$1" =~ tls1_3_EdDSA ]]; then
                     tls_sockets "04" "$TLS13_CIPHER" "all+" "00,12,00,00, 00,05,00,05,01,00,00,00,00, 00,0d,00,06,00,04,08,07,08,08"
                elif [[ "$1" =~ tls1_3_MLDSA ]]; then
@@ -9209,11 +9209,15 @@ certificate_transparency() {
           if [[ "$tls_version" == 0304 ]]; then
                ciphers=", 00,c6, 00,c7, 13,01, 13,02, 13,03, 13,04, 13,05, c0,b4, c0,b5"
                if [[ "$cipher" == tls1_3_RSA ]]; then
-                    extra_extns=", 00,0d,00,10,00,0e,08,04,08,05,08,06,04,01,05,01,06,01,02,01"
+                    extra_extns=", 00,0d,00,16,00,14,08,04,08,05,08,06,04,01,05,01,06,01,02,01,08,09,08,0a,08,0b"
                elif [[ "$cipher" == tls1_3_ECDSA ]]; then
-                    extra_extns=", 00,0d,00,0a,00,08,04,03,05,03,06,03,02,03"
+                    extra_extns=", 00,0d,00,10,00,0e,04,03,05,03,06,03,02,03,08,1a,08,1b,08,1c"
                elif [[ "$cipher" == tls1_3_SM2 ]]; then
                     extra_extns=", 00,0d,00,04,00,02,07,08"
+               elif [[ "$cipher" == tls1_3_EdDSA ]]; then
+                    extra_extns=", 00,0d,00,06,00,04,08,07,08,08"
+               elif [[ "$cipher" == tls1_3_MLDSA ]]; then
+                    extra_extns=", 00,0d,00,08,00,06,09,04,09,05,09,06"
                else
                     return 1
                fi
@@ -16458,10 +16462,10 @@ prepare_tls_clienthello() {
           else
                extension_signature_algorithms="
                00, 0d,                    # Type: signature_algorithms , see RFC 8446
-               00, 2a, 00, 28,            # lengths
+               00, 30, 00, 2e,            # lengths
                04,03, 05,03, 06,03, 08,04, 08,05, 08,06, 04,01, 05,01,
                06,01, 08,09, 08,0a, 08,0b, 08,07, 08,08, 02,01, 02,03,
-               07,08, 09,04, 09,05, 09,06"
+               07,08, 09,04, 09,05, 09,06, 08,1a, 08,1b, 08,1c"
           fi
 
           extension_heartbeat="


### PR DESCRIPTION
## Describe your changes

This PR fixes a few places where new signature schemes were not added:

1) It adds ECDSA with the Brainpool curves for TLS 1.3 (0x081a, 0x081b, and 0x081c) to get_server_certificate(), certificate_transparency(), and prepare_tls_clienthello().

2) It adds rsa_pss_pss (0x0809, 0x080a, 0x080b) to certificate_transparency().

3) It adds the signature schemes for EdDSA (0x0807, 0x0808) and ML-DSA (0x0904, 0x0905, 0x0906) to certificate_transparency().

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
