### PR TITLE
Add missing TLS 1.3 Brainpool groups

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -15255,6 +15255,9 @@ parse_tls_serverhello() {
                                          "0019") echo -n "secp521r1" >> $TMPFILE ;;
                                          "001D") echo -n "X25519" >> $TMPFILE ;;
                                          "001E") echo -n "X448" >> $TMPFILE ;;
+                                         "001F") echo -n "brainpoolP256r1tls13" >> $TMPFILE ;;
+                                         "0020") echo -n "brainpoolP384r1tls13" >> $TMPFILE ;;
+                                         "0021") echo -n "brainpoolP512r1tls13" >> $TMPFILE ;;
                                          "0029") echo -n "curveSM2" >> $TMPFILE ;;
                                          "0100") echo -n "ffdhe2048" >> $TMPFILE ;;
                                          "0101") echo -n "ffdhe3072" >> $TMPFILE ;;


### PR DESCRIPTION
## Describe your changes

This PR adds recognition of the TLS 1.3 Brainpool groups when parsing the supported_groups extension in the server's extensions.

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
