### PR TITLE
Fix DN conversion when reading certificate issuer

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22888,7 +22888,7 @@ print_dn() {
      fi
      # Use the LDAP String Representation of Distinguished Names (RFC 2253),
      # The current specification is in RFC 4514.
-     name="$(hex2binary "$cert" | $OPENSSL x509 -issuer -noout -inform DER -nameopt RFC2253 2>/dev/null)"
+     name="$(hex2binary "$cert" | $OPENSSL x509 -issuer -noout -inform DER -nameopt RFC2253,-esc_msb 2>/dev/null)"
      name="${name#issuer=}"
      tm_out "$(strip_leading_space "$name")"
      return 0


### PR DESCRIPTION
This fixes #3003 .

The conversion to proper UTF-8 should have taken place by just using `-nameopt RFC2253`, see manpage openssl-namedisplay-options(1ssl).

As @dcooper16 suggested removing `esc_msb` should help. This may look counterintuitive but works.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
