### PR TITLE
Add DNSSEC validation check via delv (#3034)

### DIFF
--- a/doc/testssl.1.md
+++ b/doc/testssl.1.md
@@ -202,6 +202,7 @@ Any single check switch supplied as an argument prevents testssl.sh from doing a
     - validity: start + end time, how many days to go (warning for certificate lifetime >=5 years)
     - revocation info (CRL, OCSP, OCSP stapling + must staple). When `--phone-out` supplied it checks against the certificate issuer whether the host certificate has been revoked (plain OCSP, CRL).
     - displaying DNS Certification Authority Authorization resource record
+    - DNSSEC status of the host name, if the BIND `delv` validating lookup utility is installed (otherwise a hint is shown). The check is skipped when `--nodns` is set or when `--ip=proxy` is in use.
     - Certificate Transparency info (if provided by server).
 
 For the trust chain check 5 certificate stores are provided. If the test against one of the trust stores failed, the one is being identified and the reason for the failure is displayed - in addition the ones which succeeded are displayed too.

--- a/testssl.sh
+++ b/testssl.sh
@@ -387,6 +387,7 @@ HAS_IDN2=false
 HAS_AVAHIRESOLVE=false
 HAS_DSCACHEUTIL=false
 HAS_DIG_NOIDNOUT=false
+HAS_DELV=false
 HAS_XXD=false
 
 OSSL_CIPHERS_S=""
@@ -9383,6 +9384,7 @@ certificate_info() {
      local days2warn1=$DAYS2WARN1
      local provides_stapling=false
      local caa_node="" all_caa="" caa_property_name="" caa_property_value=""
+     local dnssec_status=""
      local response=""
      local yearstart
      local gt_398=false gt_398warn=false
@@ -10301,6 +10303,34 @@ certificate_info() {
      else
           pr_svrty_low "not offered"
           fileout "${jsonID}${json_postfix}" "LOW" "--"
+     fi
+     outln
+
+     out "$indent"; pr_bold " DNSSEC"; out " (experimental)        "
+     jsonID="DNSSEC"
+     if [[ -n "$NODNS" ]]; then
+          out "(instructed to minimize/skip DNS queries)"
+          fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed"
+     elif "$DNS_VIA_PROXY"; then
+          out "(instructed to use the proxy for DNS only)"
+          fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed (proxy)"
+     elif ! "$HAS_DELV"; then
+          out "(no \"delv\" binary, install bind9 / bind-utils)"
+          fileout "${jsonID}${json_postfix}" "INFO" "check skipped, delv not installed"
+     else
+          dnssec_status="$(get_dnssec_status "$NODE")"
+          tmp=$?
+          [[ $DEBUG -ge 4 ]] && echo "get_dnssec_status: $tmp"
+          case $tmp in
+               0)   pr_svrty_good "$dnssec_status"
+                    fileout "${jsonID}${json_postfix}" "OK" "$dnssec_status" ;;
+               1)   pr_svrty_low "not signed"
+                    fileout "${jsonID}${json_postfix}" "LOW" "domain not DNSSEC-signed" ;;
+               2)   pr_svrty_high "$dnssec_status"
+                    fileout "${jsonID}${json_postfix}" "HIGH" "DNSSEC $dnssec_status" ;;
+               3)   pr_warning "$dnssec_status"
+                    fileout "${jsonID}${json_postfix}" "WARN" "$dnssec_status" ;;
+          esac
      fi
      outln
 
@@ -21842,6 +21872,7 @@ HAS_DIG: $HAS_DIG
 HAS_HOST: $HAS_HOST
 HAS_DRILL: $HAS_DRILL
 HAS_NSLOOKUP: $HAS_NSLOOKUP
+HAS_DELV: $HAS_DELV
 HAS_IDN: $HAS_IDN
 HAS_IDN2: $HAS_IDN2
 HAS_AVAHIRESOLVE: $HAS_AVAHIRESOLVE
@@ -22349,6 +22380,7 @@ check_resolver_bins() {
      type -p host  &> /dev/null &&  HAS_HOST=true
      type -p drill &> /dev/null &&  HAS_DRILL=true
      type -p nslookup &> /dev/null && HAS_NSLOOKUP=true
+     type -p delv &> /dev/null && HAS_DELV=true
      type -p avahi-resolve &>/dev/null && HAS_AVAHIRESOLVE=true
      type -p idn  &>/dev/null && HAS_IDN=true
      type -p idn2 &>/dev/null && HAS_IDN2=true
@@ -22556,6 +22588,71 @@ get_caa_rr_record() {
 # to do:
 #    4: check whether $1 is a CNAME and take this
      return 0
+}
+
+# Validates whether the supplied domain is DNSSEC-secured by calling delv,
+# the BIND DNSSEC validating lookup utility. delv performs validation locally
+# instead of trusting the AD bit of the configured resolver, which is the
+# right primitive for an authenticity check.
+#
+# arg1: domain to check
+# stdout: a short status string, only set on validated/unsigned answers
+# return: 0 secured (fully validated)
+#         1 unsigned (no DNSSEC)
+#         2 bogus / validation failed
+#         3 transient resolution problem (timeout, network, etc.)
+#         4 delv not present
+#         5 NODNS / DNS_VIA_PROXY: skipped on purpose
+get_dnssec_status() {
+     local domain="$1"
+     local raw_delv=""
+     local line=""
+     local last_failure=""
+     local saved_openssl_conf="$OPENSSL_CONF"
+
+     ! "$HAS_DELV" && return 4
+     [[ -n "$NODNS" ]] && return 5
+     "$DNS_VIA_PROXY" && return 5
+
+     OPENSSL_CONF=""                         # see https://github.com/testssl/testssl.sh/issues/134
+     # delv exits 0 in every case we care about and signals the verdict via
+     # comment lines: status lines start with a single ";" while trace and
+     # error lines start with ";;". Resolver failures land on stderr.
+     raw_delv="$(delv "$domain" 2>&1)"
+     OPENSSL_CONF="$saved_openssl_conf"
+     debugme echo "delv: $raw_delv"
+
+     # Scan the comment lines top-down. Status lines beat trace lines, so the
+     # first ";" line wins. Otherwise we surface the last ";; resolution failed:"
+     # message, which is delv's terminal verdict for problem cases.
+     while IFS= read -r line; do
+          case "$line" in
+               "; fully validated"*)        echo "fully validated";    return 0 ;;
+               "; partially validated"*)    echo "partially validated"; return 0 ;;
+               "; unsigned answer"*)        echo "unsigned";           return 1 ;;
+               ";; resolution failed:"*)
+                    last_failure="${line#;; resolution failed: }"
+                    ;;
+          esac
+     done <<< "$raw_delv"
+
+     if [[ -n "$last_failure" ]]; then
+          # "broken trust chain" / "no valid signature found" / "ncache nxdomain"
+          # are genuine validation failures; everything else (network, timeout,
+          # SERVFAIL from resolver) is a transient resolver problem and should
+          # not be reported as a domain-level DNSSEC failure.
+          case "$last_failure" in
+               *"trust chain"*|*"no valid signature"*|*"insecure"*|\
+               *"bogus"*|*"DNSKEY"*|*"NSEC"*)
+                    echo "$last_failure"
+                    return 2 ;;
+               *)
+                    echo "$last_failure"
+                    return 3 ;;
+          esac
+     fi
+     echo "no verdict from delv"
+     return 3
 }
 
 # arg1: domain to check for. Returned will be the MX record as a string


### PR DESCRIPTION
## What this does

Adds a `DNSSEC` line to the certificate-info section (right after `DNS CAA RR` and before `Certificate Transparency`) that calls `delv` against `$NODE` and reports one of:

- `fully validated` / `partially validated` — pr_svrty_good, JSON severity `OK`
- `not signed` — pr_svrty_low, JSON severity `LOW`, fileout text `domain not DNSSEC-signed`
- a high-severity DNSSEC failure (`broken trust chain`, `no valid signature found`, `bogus*`, `DNSKEY*`, `NSEC*`, `*insecure*`) — pr_svrty_high, severity `HIGH`
- anything else delv complained about (timeouts, SERVFAIL from the configured resolver, generic resolution failure) — pr_warning, severity `WARN`

The two buckets at the bottom matter: I didn't want a flaky upstream resolver to make `testssl.sh` claim a domain has been tampered with. So `get_dnssec_status()` separates "delv really said the chain is bogus" (return 2 → red) from "delv couldn't get an answer" (return 3 → orange warning).

`--nodns=min|none` and `--ip=proxy` short-circuit the check before we shell out, mirroring the existing CAA block one screen above. If `delv` isn't installed, the user sees `(no "delv" binary, install bind9 / bind-utils)` and the rest of the report continues as before.

A new `HAS_DELV` global is initialised next to the other resolver `HAS_*` vars and set in `check_resolver_bins()`; it's also dumped under `--debug` so users can quickly see why the DNSSEC check was skipped.

`doc/testssl.1.md` is updated under the certificate-info bullet list.

## Why delv

`dig +dnssec` only sets the DO bit and trusts whatever AD bit the configured resolver hands back, which is exactly the answer you can't trust if the resolver is the threat. `delv` performs validation locally against the root trust anchor shipped with BIND, which is the right primitive for an authenticity check. That matches the framing in the issue.

## Open question for the maintainer

I deliberately left `Dockerfile` (opensuse leap) and `Dockerfile.alpine` alone. Adding `bind-utils` / `bind-tools` to the images is a sizing decision (a few extra MB on a deliberately small container) and the existing image already ships `ldns` for `drill`. Happy to push a follow-up commit adding them to either or both images, or to leave it for a separate PR. The fallback path means today's Docker users see the "no delv binary" hint and nothing else changes.

## Caveats

- The issue (#3034) is from today and there's no maintainer feedback yet on the exact desired UX. I went with the same look-and-feel as the `DNS CAA RR (experimental)` block since #3034 referenced PR #2866 where that pattern already exists. Happy to iterate on naming, severity choices, or where the line lives.
- `pr_svrty_high` for a known-bogus chain is my best guess at the right weight. If you'd rather have it as `pr_svrty_medium` or as a `pr_warning`, that's a one-line change.
- I considered also extending `get_caa_rr_record()` to fall back to `delv` when `dig`/`drill`/`host`/`nslookup` fail, but that's well outside the scope of this PR (one functional change per PR per `Coding_Convention.md`).

## Tests

Local checks against:

```
$ ./testssl.sh -S example.com   # signed, public resolver chain healthy
   DNSSEC (experimental)        fully validated

$ ./testssl.sh -S example.com --nodns=min
   DNSSEC (experimental)        (instructed to minimize/skip DNS queries)

$ ./testssl.sh -S example.com   # with delv removed from PATH
   DNSSEC (experimental)        (no "delv" binary, install bind9 / bind-utils)

$ ./testssl.sh -S example.com --jsonfile=/tmp/out.json
   ... "id": "DNSSEC <hostCert#1>", "severity": "OK", "finding": "fully validated"
```

`bash -n testssl.sh` and `shellcheck -S error testssl.sh` are clean.

Closes #3034.