### PR TITLE
Improve PR #3041

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10268,39 +10268,44 @@ certificate_info() {
 
      out "$indent"; pr_bold " DNS CAA RR"; out " (experimental)    "
      jsonID="DNS_CAArecord"
-     caa_node="$NODE"
-     caa=""
-     while [[ -z "$caa" ]] &&  [[ -n "$caa_node" ]]; do
-          caa="$(get_caa_rr_record $caa_node)"
-          tmp=${PIPESTATUS[@]}
-          [[ $DEBUG -ge 4 ]] && echo "get_caa_rr_record: $tmp"
-          [[ $caa_node =~ '.'$ ]] || caa_node+="."
-          caa_node=${caa_node#*.}
-     done
-     if [[ -n "$caa" ]]; then
-          pr_svrty_good "available"; out " - please check for match with \"Issuer\" below"
-          if [[ $(count_lines "$caa") -eq 1 ]]; then
-               out ": "
-          else
-               outln; out "$spaces"
-          fi
-          while read caa; do
-               if [[ -n "$caa" ]]; then
-                    all_caa+="$caa, "
-               fi
-          done <<< "$caa"
-          all_caa=${all_caa%, }                 # strip trailing comma
-          pr_italic "$(out_row_aligned_max_width "$all_caa" "$indent                              " $TERM_WIDTH)"
-          fileout "${jsonID}${json_postfix}" "OK" "$all_caa"
-     elif [[ -n "$NODNS" ]]; then
-          out "(instructed to minimize/skip DNS queries)"
-          fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed"
-     elif "$DNS_VIA_PROXY"; then
-          out "(instructed to use the proxy for DNS only)"
-          fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed (proxy)"
+     if is_ipv4addr "$NODE" || is_ipv6addr "$NODE"; then
+          out "not checked (IP address scan -- no domain to query)"
+          fileout "${jsonID}${json_postfix}" "INFO" "not checked (IP address scan)"
      else
-          pr_svrty_low "not offered"
-          fileout "${jsonID}${json_postfix}" "LOW" "--"
+          caa_node="$NODE"
+          [[ $caa_node =~ '.'$ ]] || caa_node+="."     # force FQDN to prevent dig search-domain expansion
+          caa=""
+          while [[ -z "$caa" ]] &&  [[ -n "$caa_node" ]]; do
+               caa="$(get_caa_rr_record $caa_node)"
+               tmp=${PIPESTATUS[@]}
+               [[ $DEBUG -ge 4 ]] && echo "get_caa_rr_record: $tmp"
+               caa_node=${caa_node#*.}
+          done
+          if [[ -n "$caa" ]]; then
+               pr_svrty_good "available"; out " - please check for match with \"Issuer\" below"
+               if [[ $(count_lines "$caa") -eq 1 ]]; then
+                    out ": "
+               else
+                    outln; out "$spaces"
+               fi
+               while read caa; do
+                    if [[ -n "$caa" ]]; then
+                         all_caa+="$caa, "
+                    fi
+               done <<< "$caa"
+               all_caa=${all_caa%, }                 # strip trailing comma
+               pr_italic "$(out_row_aligned_max_width "$all_caa" "$indent                              " $TERM_WIDTH)"
+               fileout "${jsonID}${json_postfix}" "OK" "$all_caa"
+          elif [[ -n "$NODNS" ]]; then
+               out "(instructed to minimize/skip DNS queries)"
+               fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed"
+          elif "$DNS_VIA_PROXY"; then
+               out "(instructed to use the proxy for DNS only)"
+               fileout "${jsonID}${json_postfix}" "INFO" "check skipped as instructed (proxy)"
+          else
+               pr_svrty_low "not offered"
+               fileout "${jsonID}${json_postfix}" "LOW" "--"
+          fi
      fi
      outln
 
@@ -23605,6 +23610,10 @@ display_rdns_etc() {
           else
                outln " A record via:          $CORRECT_SPACES supplied IP \"$CMDLINE_IP\""
           fi
+     fi
+     if is_ipv4addr "$NODE" || is_ipv6addr "$NODE"; then
+          prln_warning " Warning: IP scan -- Trust, CAA and SNI-dependent checks may be unreliable. Rescan with hostname for accurate results."
+          fileout "ip_scan_warning" "WARN" "Scanning by IP address: Trust, CAA and SNI-dependent checks may be unreliable"
      fi
      if [[ "$rDNS" =~ instructed ]]; then
           out "$(printf " %-23s " "rDNS ($nodeip):")"

--- a/testssl.sh
+++ b/testssl.sh
@@ -10273,9 +10273,9 @@ certificate_info() {
           fileout "${jsonID}${json_postfix}" "INFO" "not checked (IP address scan)"
      else
           caa_node="$NODE"
-          [[ $caa_node =~ '.'$ ]] || caa_node+="."     # force FQDN to prevent dig search-domain expansion
           caa=""
           while [[ -z "$caa" ]] &&  [[ -n "$caa_node" ]]; do
+               [[ $caa_node =~ '.'$ ]] || caa_node+="."     # force FQDN to prevent dig search-domain expansion
                caa="$(get_caa_rr_record $caa_node)"
                tmp=${PIPESTATUS[@]}
                [[ $DEBUG -ge 4 ]] && echo "get_caa_rr_record: $tmp"
@@ -23611,10 +23611,6 @@ display_rdns_etc() {
                outln " A record via:          $CORRECT_SPACES supplied IP \"$CMDLINE_IP\""
           fi
      fi
-     if is_ipv4addr "$NODE" || is_ipv6addr "$NODE"; then
-          prln_warning " Warning: IP scan -- Trust, CAA and SNI-dependent checks may be unreliable. Rescan with hostname for accurate results."
-          fileout "ip_scan_warning" "WARN" "Scanning by IP address: Trust, CAA and SNI-dependent checks may be unreliable"
-     fi
      if [[ "$rDNS" =~ instructed ]]; then
           out "$(printf " %-23s " "rDNS ($nodeip):")"
           out "$rDNS"
@@ -24682,6 +24678,7 @@ parse_cmd_line() {
      local outfile_arg=""
      local cipher_mapping
      local -i subret=0
+     local tmp=""
 
      CMDLINE="$(create_cmd_line_string "${CMDLINE_ARRAY[@]}")"
      CMDLINE_PARSED=false
@@ -25359,6 +25356,14 @@ parse_cmd_line() {
      # Should be called after set_scanning_defaults() and set_skip_tests()
      if [[ ! ${SKIP_TESTS[*]} =~ rating ]] ; then
           set_rating_state
+     fi
+
+     tmp=${URI#*//}      # remove https://
+     if [[ ! $tmp =~ [a-zA-Z] ]]; then
+          # No letters indicate it's not a name
+          outln
+          pr_warning " Warning: Target is not a server name: results may be completely wrong, at minimum trust may show false results."
+          fileout "ip_scan_warning" "WARN" "Target is not a server name: results may be completely wrong, at minimum trust may show false results."
      fi
 
      CMDLINE_PARSED=true


### PR DESCRIPTION

    * move message when scanning IP address to the very beginning, inside parse_cmd_line()
    * improve message
    * just check whether there are no chars a-zA-Z

    * move [[ $caa_node =~ '.'$ ]] || caa_node+="." into the while loop


## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
