### PR TITLE
Backport: Fix Permissions-Policy header listed twice in output

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3520,7 +3520,6 @@ run_security_headers() {
                              "X-XSS-Protection INFO" \
                              "Access-Control-Allow-Origin INFO" \
                              "Access-Control-Allow-Credentials INFO" \
-                             "Permissions-Policy INFO" \
                              "Upgrade INFO" \
                              "X-Served-By INFO" \
                              "Referrer-Policy INFO" \


### PR DESCRIPTION
## Describe your changes

Backport of the 3.3dev fix to the 3.2 branch.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
