### PR TITLE
Fix --mx host:port parsing and incorrect no-MX message (#2986)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -23652,21 +23652,27 @@ draw_line() {
 
 run_mx_all_ips() {
      local fname_date="$1"
+     local domain="$2"
      local mxs mx
-     local mxport
+     local mxport=${3:-25}
      local -i ret=0
      local word=""
 
      STARTTLS_PROTOCOL="smtp"
+     # A port may be appended to the domain, e.g. "--mx example.com:587" (#2986).
+     # Strip it off before the MX DNS lookup and use it as the port to test.
+     if [[ "$domain" =~ :[0-9]+$ ]]; then
+          mxport="${domain##*:}"
+          domain="${domain%:*}"
+     fi
      # test first higher priority servers
-     mxs=$(get_mx_record "$2" | sort -n | sed -e 's/^.* //' -e 's/\.$//' | tr '\n' ' ')
+     mxs=$(get_mx_record "$domain" | sort -n | sed -e 's/^.* //' -e 's/\.$//' | tr '\n' ' ')
      if [[ $CMDLINE_IP == one ]]; then
           word="as instructed one"                               # with highest priority
           mxs=${mxs%% *}
      else
           word="the only"
      fi
-     mxport=${3:-25}
      if [[ -n "$LOGFILE" ]] || [[ -n "$PARENT_LOGFILE" ]]; then
           prepare_logging "${fname_date}"
      else
@@ -23707,7 +23713,7 @@ run_mx_all_ips() {
           outln
           pr_bold "Done testing all MX records (on port $mxport): "; outln "$mxs"
      else
-          prln_bold " $1 has no MX records(s)"
+          prln_bold " $domain has no MX record(s)"
      fi
      return $ret
 }


### PR DESCRIPTION
Fixes #2986.

`--mx <host>:<port>` confused the parser: `--mx` sets `PORT=25` unconditionally, and the trailing `:port` on the domain was never stripped before the MX DNS lookup — so `host -t MX example.com:25` returned nothing, and the failure branch then printed `$1` (the run date) instead of the host, e.g. `20260606-1200 has no MX records(s)`.

This:
- strips a trailing `:<port>` off the domain before the `get_mx_record` lookup (bash parameter expansion, no extra fork) and uses it as the port under test;
- corrects the no-MX message to print the actual `$domain` and `MX record(s)` (typo).

Tested against multiple hosts with and without an appended `:port` (e.g. `--mx google.com:25` now resolves the MX and proceeds on port 25); plain `--mx example.com` behaviour is unchanged. `shellcheck -x -P utils --severity=error` clean and `bash -n` clean on the change; five-space/no-tabs convention followed.