### PR TITLE
Report additional modern security headers (INFO)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -3609,7 +3609,14 @@ run_security_headers() {
                              "Referrer-Policy INFO" \
                              "X-UA-Compatible INFO" \
                              "Cache-Control INFO" \
-                             "Pragma INFO"; do
+                             "Pragma INFO" \
+                             "X-Permitted-Cross-Domain-Policies INFO" \
+                             "Origin-Agent-Cluster INFO" \
+                             "Document-Policy INFO" \
+                             "Clear-Site-Data INFO" \
+                             "Reporting-Endpoints INFO" \
+                             "Report-To INFO" \
+                             "NEL INFO"; do
           read header svrty <<< "${header_and_svrty}"
           [[ "$DEBUG" -ge 5 ]] &&  echo "testing \"$header\" (severity \"$svrty\")"
           match_httpheader_key "$header" "$header" "$spaces" "$first"


### PR DESCRIPTION
testssl.sh already highlights `X-Permitted-Cross-Domain-Policies` in `emphasize_stuff_in_headers()` (testssl.sh:3285 / 3335) but never actually reports it in `run_security_headers()` — this PR closes that inconsistency, and while there adds a few other modern security headers testssl currently misses.

Headers added (all **INFO**, presence-only — no correctness logic), appended to the existing `header_and_svrty` array:

- `X-Permitted-Cross-Domain-Policies` (already emphasized but not reported)
- `Origin-Agent-Cluster`
- `Document-Policy`
- `Clear-Site-Data`
- `Reporting-Endpoints`
- `Report-To`
- `NEL`

This follows the same approach as #2619 (COOP/COEP/CORP added as INFO) and slots into the generic loop — the existing `INFO)` case handles output, so there are no other code changes, and no `help()`/man-page change is needed (individual headers aren't documented).

The last three (`Reporting-Endpoints`/`Report-To`/`NEL`) are reporting-oriented rather than hardening controls — happy to drop them if you consider them out of scope; the rest stand on their own.

Tested against hosts that send these headers (e.g. Cloudflare-fronted sites send `Report-To`/`NEL`) and hosts that don't — reported once each, no side effects. 5-space indent, no tabs; `shellcheck --severity=error` clean.