### PR TITLE
Provide better debugging means for GH runners

### DIFF
--- a/.github/workflows/unit_tests_macos.yml
+++ b/.github/workflows/unit_tests_macos.yml
@@ -45,6 +45,8 @@ jobs:
           printf "%s\n" "----------"
           bash --version
           printf "%s\n" "----------"
+          echo $PATH
+          printf "%s\n" "----------"
 
       - name: Install perl modules
         run: |
@@ -52,6 +54,7 @@ jobs:
           cpanm --notest Data::Dumper
           cpanm --notest JSON
           cpanm --notest Text::Diff
+          cpanm --notest IPC::Run3
 
       - name: run it
         run: |

--- a/.github/workflows/unit_tests_ubuntu.yml
+++ b/.github/workflows/unit_tests_ubuntu.yml
@@ -51,6 +51,8 @@ jobs:
           printf "%s\n" "----------"
           bash --version
           printf "%s\n" "----------"
+          echo $PATH
+          printf "%s\n" "----------"
 
       - name: Install perl modules
         run: |
@@ -58,6 +60,7 @@ jobs:
           cpanm --notest Data::Dumper
           cpanm --notest JSON
           cpanm --notest Text::Diff
+          cpanm --notest IPC::Run3
 
       - name: run it
         run: |

--- a/t/03_debug.t.DISABLED
+++ b/t/03_debug.t.DISABLED
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+
+# Example for debugging what the runners do, here MacOS only
+# (we used that before), To get output on the screen it's
+# needed to encapsulate the functions you want to debug with
+# set -x/+x and comment the last function @ 00_testssl_help.t
+
+use strict;
+use Test::More;
+use IPC::Run3;
+
+my $os="$^O";
+my $prg="./testssl.sh";
+my $check2run ="-p";
+my $uri="testssl.sh";
+my $stdout = '';
+my $stderr = '';
+
+# if ( $os eq "darwin" ){
+     printf "%s\n", "testing MacOS ";
+     run3(["/bin/bash", $prg, $check2run, $uri], \undef, \$stdout, \$stderr);
+     print STDERR $stderr;
+     print STDOUT $stdout;
+# } elsif ( $os eq "linux" ){
+#     printf "skipped check on Linux\n\n";
+#}
+
+
+# Use the following when you want to run everything below ~/t
+# done_testing();
+
+
+# This stops, no further checks within ~/t will run:
+BAIL_OUT("Fundamental check done, aborting");
+
+
+
+# vim:ts=5:sw=5:expandtab
+

--- a/t/12_diff_opensslversions.t
+++ b/t/12_diff_opensslversions.t
@@ -98,6 +98,11 @@ $cat_csvfile2 =~ s/.nonce-.* //g;
 $cat_csvfile  =~ s/","google.com\/.*","443/","google.com","443/g;
 $cat_csvfile2 =~ s/","google.com\/.*","443/","google.com","443/g;
 
+# Address differences in QUIC: Ubuntu 24.04's openssl still doesn't support QUIC, MacOS 26 does
+# (Status 06/2026, should be checked later)
+$cat_csvfile  =~  s/"QUIC".*\n//g;
+$cat_csvfile2  =~ s/"QUIC".*\n//g;
+
 
 if ( $os eq "darwin" ){
      # Now address the differences for LibreSSL, see t/61_diff_testsslsh.t

--- a/t/Readme.md
+++ b/t/Readme.md
@@ -8,3 +8,7 @@
 Please help to write CI tests! Documentation can be found [here](https://perldoc.perl.org/Test/More.html).
 You can consult the existing code here. Feel free to use `10_baseline_ipv4_http.t` or `12_diff_opensslversions.t` as a
 template. The latter is newer and code is cleaner.
+
+
+* `03_debug.t.DISABLED` is a handy tool when the runner is not in line with checks outside github. It provides debugging means
+* IPv6 was (status 2025) not allowed, thus the file `11_baseline_ipv6_http.t.DISABLED` which can be renamed if that will change.


### PR DESCRIPTION
This is just to assist debugging of the runners, so that we can grab in such a case the screen and stderr .

* there's a script `t/03_debug.t.DISABLED` which needs to be renamed then
* it utilises IPC::Run3
- also showing the PATH is added for both runners
- `t/Readme` amended accordingly

## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [ ] Typo fix
- [x] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
