### PR TITLE
Fixed 'cert_trust_wildcard' identifier when multiple certificates are…

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -10204,7 +10204,7 @@ certificate_info() {
           out "${spaces}"
           pr_svrty_low "wildcard certificate" ; outln " could be problematic, see other hosts at"
           outln "${spaces}https://search.censys.io/search?resource=hosts&virtual_hosts=INCLUDE&q=$cert_fingerprint_sha2"
-          fileout "cert_trust${json_postfix}_wildcard" "LOW" "trust is via wildcard"
+          fileout "cert_trust_wildcard${json_postfix}" "LOW" "trust is via wildcard"
      fi
 
 


### PR DESCRIPTION
## Describe your changes

This is a very small change to address the issue raised in #3051 to make the `cert_trust_wildcard` identifier consistent when multiple server certificates are present.

While this was closed as not planned, I disagree with the idea that it's not a bug, as everything about the current behavior feels inconsistent, especially as the identifier is correct when only a single server certificate is present.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [x] Breaking change (bug fix, feature or improvement that would cause existing functionality to not work as expected)
- [x] Typo fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to CREDITS.md (alphabetical order) and the change to CHANGELOG.md
