### PR TITLE
Fix escaping.

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -21525,8 +21525,8 @@ find_openssl_binary() {
 
      # In order to avoid delays due to lookups of the hostname "invalid." we just try to avoid using "-connect invalid."
      # when possible. The following does a check fopr that. For WSL we stick for now to the old scheme. Not sure about Cygwin
-     if [[ SYSTEM2 == "WSL" ]]; then
-          NXCONNECT=-connect $NXDNS
+     if [[ $SYSTEM2 == "WSL" ]]; then
+          NXCONNECT="-connect $NXDNS"
      else
           # If this connects and bails out with an error message, we do not need "-connect invalid."
           if $OPENSSL s_client 2>&1 </dev/null | grep -Eiaq 'Connection refused|connect error|Bad file descriptor'; then


### PR DESCRIPTION
## Describe your changes
Two small escaping errors which didn't allow WSL-related changes to apply.

## What is your pull request about?
- [x] Bug fix

## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem

## AI section
- [x] My contribution does not include any AI-generated content

(the missing `$` was spotted by Claude Code Opus 4.8, the missing quotes by me, and both fixes are mine)