### PR TITLE
Fix -4/-6 flag being ignored when no specific test is selected

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -24574,9 +24574,6 @@ set_scanning_defaults() {
           VULN_COUNT=14
      fi
      do_rating=true
-
-     do_ipv6_only=false
-     do_ipv4_only=false
 }
 
 # returns number of $do variables set = number of run_funcs() to perform


### PR DESCRIPTION
## Describe your changes
set_scanning_defaults() reset do_ipv4_only/do_ipv6_only to false. When no individual test is requested on the command line, count_do_variables returns 0 and parse_cmd_line() calls set_scanning_defaults() to enable the standard test suite, which silently wiped out the user's -4/-6 selection. As a result determine_ip_addresses() fell through to its "scan everything" branch and scanned both the A and AAAA records, producing one scanResult per IP.

The IP-version flags are connection options, not test-selection state, and are already initialized in initialize_globals(), so remove the stray resets from set_scanning_defaults().

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code`
    - LLMs and versions: `Claude Opus 4.8`

