### PR TITLE
Fix empty result for HTTPS_RR for Mac and friends

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22893,7 +22893,7 @@ get_https_rrecord() {
           # empty if there's no such record
      else
           return 6
-          # No dig, drill, host, or nslookup --> complaint hould have been before already
+          # No dig, drill, host, or nslookup --> complaint should have been before already
      fi
      OPENSSL_CONF="$saved_openssl_conf"      # We're done now with openssl, see https://github.com/drwetter/testssl.sh/issues/134
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -22817,6 +22817,7 @@ get_caa_rrecord() {
 # https://www.rfc-editor.org/rfc/rfc9460.html
 #    arg1: domain to check for
 #    returns: string for record
+#    return value: !=0 if error encountered
 #
 get_https_rrecord() {
      local raw_https=""
@@ -22891,13 +22892,13 @@ get_https_rrecord() {
           raw_https="$(strip_lf "$(nslookup -type=type65 "$1" | awk '/'"^${1}"'.*rdata_65/ { print substr($0,index($0,$4)) }' )")"
           # empty if there's no such record
      else
-          return 1
-          # No dig, drill, host, or nslookup --> complaint was elsewhere already
+          return 6
+          # No dig, drill, host, or nslookup --> complaint hould have been before already
      fi
      OPENSSL_CONF="$saved_openssl_conf"      # We're done now with openssl, see https://github.com/drwetter/testssl.sh/issues/134
 
      if [[ -z "$raw_https" ]]; then
-          return 1
+          return 0
      fi
 
      # Now comes the third, tricky part (old dig for Macs e.g.) --> parsing the hex stream which was returned if it was returned.
@@ -23996,6 +23997,7 @@ dns_https_rr () {
           if [[ $? -ne 0 ]]; then
                prln_warning "$HTTPS_RR"
                fileout "${jsonID}" "WARN" "$HTTPS_RR"
+               return 1
           elif [[ -n "$HTTPS_RR" ]]; then
                pr_svrty_good "yes" ; out ": "
                prln_italic "$(out_row_aligned_max_width "$HTTPS_RR" "$indent                              " $TERM_WIDTH)"
@@ -24005,6 +24007,7 @@ dns_https_rr () {
                fileout "${jsonID}" "INFO" " no resource record found"
           fi
      fi
+     return 0
 }
 
 


### PR DESCRIPTION
... also improve error handling by adding return values in *https_rr functions.

The error for ~Macs occured because for interpretation of raw TYPE65 DNS data it was just 1 returned instead of 0 --for empty records.


## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, JetBrains Junie, VS Code plugin <NAME> etc.]`
    - LLMs and versions: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`

