### PR TITLE
fix: inverted return check in sym-encrypt() at testssl.sh:14741

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14203,7 +14203,7 @@ sym-encrypt() {
           return 7
      fi
      [[ $? -ne 0 ]] && return 7
-     [[ -n "$ciphertext" ]] && return 7
+     [[ -z "$ciphertext" ]] && return 7
 
      tm_out "$(strip_spaces "$ciphertext")"
      return 0


### PR DESCRIPTION
[BUG / possible BUG] Inverted return check in sym-encrypt() at testssl.sh:14741 makes the function return error 7 on every success. The tm_out line at testssl.sh:14743 is unreachable.
https://github.com/testssl/testssl.sh/issues/3079

This includes:

Resolved or fixed issue: https://github.com/testssl/testssl.sh/issues/3079
A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.
-->

What is your pull request about?
 Bug fix
 Improvement
 New feature (adds functionality)
 Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
 Typo / spelling fix
 Documentation update
 Update of other files
If it's a code change please check the boxes which are applicable
[ X] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
 I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
 My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md)
 I have tested this fix or improvement against >=2 hosts and I couldn't spot a problem
 I have tested this new feature against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
 For the new feature I have made corresponding changes to the documentation and / or to help()
 If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)
AI section
My contribution does not include any AI-generated content
My contribution includes AI-generated content, as disclosed below:
[X] AI Tools: LLMs and versions: Anthropic Claude Opus 4.8
