### PR TITLE
bugfix: aesgcm_used --> enc_aesgcm_used

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -14553,7 +14553,7 @@ gcm-decrypt() {
      elif [[ "$cipher" == TLS_AES_256_GCM_SHA384 ]] && ! "$compute_tag"; then
           if "$HAS_AES256_GCM"; then
                plaintext="$(hex2binary "$ciphertext" | $OPENSSL enc -aes-256-gcm -K "$key" -iv "$nonce" 2>/dev/null | hexdump -v -e '16/1 "%02X"')"
-               aesgcm_used=true
+               enc_aesgcm_used=true
           elif "$HAS2_AES256_GCM"; then
                # empty  OPENSSL_CONF temporarily as it might cause problems, see #2780
                plaintext="$(hex2binary "$ciphertext" | OPENSSL_CONF='' $OPENSSL2 enc -aes-256-gcm -K "$key" -iv "$nonce" 2>/dev/null | hexdump -v -e '16/1 "%02X"')"


### PR DESCRIPTION
<!--

## Describe your changes
Please refer to an issue here or describe the change thoroughly in your PR and check the boxes which are applicable. 

This includes:
- Resolved or fixed issue:
- A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.

-->
Fix Variable Typo #3085

## What is your pull request about?
- [X ] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ ] My contribution does not include any AI-generated content
- [ X ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: Anthropic Claude Opus 4.8

