### PR TITLE
Small check for semantic unit tests

### DIFF
--- a/t/03_syntax_check.t
+++ b/t/03_syntax_check.t
@@ -9,7 +9,10 @@ my $tests = 0;
 my $prg="testssl.sh";
 my $os="$^O";
 
-
+if ( $os eq "darwin" ){
+    printf "%s\n", "Skipping checks";
+    exit 0;
+}
 
 #1
 printf "\n%s\n", "Testing for missing vars at left hand side in double square brackets ...";
@@ -19,6 +22,7 @@ my @matches = `grep -n '\\[\\[ [[:alpha:]]' $prg`;
 is(scalar(@matches), 0, "Checking bad '[[ LHS' patterns")
     or diag(@matches);
 $tests++;
+
 
 #2
 printf "\n%s\n", "Testing for backticks ...";

--- a/t/03_syntax_check.t
+++ b/t/03_syntax_check.t
@@ -7,7 +7,9 @@ use Test::More;
 
 my $tests = 0;
 my $prg="testssl.sh";
-# Patterns used to trigger an error:
+my $os="$^O";
+
+
 
 #1
 printf "\n%s\n", "Testing for missing vars at left hand side in double square brackets ...";
@@ -17,7 +19,36 @@ my @matches = `grep -n '\\[\\[ [[:alpha:]]' $prg`;
 is(scalar(@matches), 0, "Checking bad '[[ LHS' patterns")
     or diag(@matches);
 $tests++;
-i
+
+#2
+printf "\n%s\n", "Testing for backticks ...";
+
+my @matches = qx(grep -nP '`[^`]*`' $prg);
+is(scalar(@matches), 0, "Checking bad backtick patterns")
+or diag(@matches);
+$tests++;
+
+#3
+printf "\n%s\n", "Sourcing without checking the file exists #1 ...";
+
+my @matches = qx(grep -nP '^\s*\.\s+\$' $prg);
+is(scalar(@matches), 0, "Checking bad sourcing pattern #1")
+or diag(@matches);
+$tests++;
+
+#4
+printf "\n%s\n", "Sourcing without checking the file exists #2 ...";
+
+my @matches = qx(grep -nP '^\s*source\s+\$' $prg);
+is(scalar(@matches), 0, "Checking bad sourcing pattern #2")
+or diag(@matches);
+$tests++;
+
+
+# We have three eval already, a) re-analyse + exempt them
+#my @matches = qx(grep -nP '\beval\b' $prg);
+
+
 
 # more would go here
 

--- a/t/03_syntax_check.t
+++ b/t/03_syntax_check.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+
+# Basics: are there semantic errors which are easy to spot?
+
+use strict;
+use Test::More;
+
+my $tests = 0;
+my $prg="testssl.sh";
+# Patterns used to trigger an error:
+
+#1
+printf "\n%s\n", "Testing for missing vars at left hand side in double square brackets ...";
+
+# I know this isn't nice but perl doesn't seem for this so great either
+my @matches = `grep -n '\\[\\[ [[:alpha:]]' $prg`;
+is(scalar(@matches), 0, "Checking bad '[[ LHS' patterns")
+    or diag(@matches);
+$tests++;
+i
+
+# more would go here
+
+printf "\n";
+done_testing($tests);
+
+
+#  vim:ts=5:sw=5:expandtab
+

--- a/t/03_syntax_check.t
+++ b/t/03_syntax_check.t
@@ -10,8 +10,9 @@ my $prg="testssl.sh";
 my $os="$^O";
 
 if ( $os eq "darwin" ){
-    printf "%s\n", "Skipping checks";
-    exit 0;
+     printf "%s\n", "Skipping checks on MacOS";
+     printf "\n";
+     done_testing($tests);
 }
 
 #1
@@ -23,6 +24,7 @@ is(scalar(@matches), 0, "Checking bad '[[ LHS' patterns")
     or diag(@matches);
 $tests++;
 
+# The following works only on GNU grep
 
 #2
 printf "\n%s\n", "Testing for backticks ...";
@@ -51,7 +53,6 @@ $tests++;
 
 # We have three eval already, a) re-analyse + exempt them
 #my @matches = qx(grep -nP '\beval\b' $prg);
-
 
 
 # more would go here

--- a/t/03_syntax_check.t
+++ b/t/03_syntax_check.t
@@ -10,9 +10,7 @@ my $prg="testssl.sh";
 my $os="$^O";
 
 if ( $os eq "darwin" ){
-     printf "%s\n", "Skipping checks on MacOS";
-     printf "\n";
-     done_testing($tests);
+     plan skip_all => 'No checks on MacOS';
 }
 
 #1

--- a/testssl.sh
+++ b/testssl.sh
@@ -447,7 +447,7 @@ KEY_EXCH_SCORE=100                      # Keeps track of the score for category 
 CIPH_STR_BEST=0                         # Keeps track of the best bit size for category 3 "Cipher Strength"
 CIPH_STR_WORST=100000                   # Keeps track of the worst bit size for category 3 "Cipher Strength"
                                         # Intentionally set very high, so it can be set to 0, if necessary
-TRUSTED1ST=""                           # Contains the `-trusted_first` flag, if this version of openssl supports it
+TRUSTED1ST=""                           # Contains the "-trusted_first" flag, if this version of openssl supports it
 
 ########### Global variables for parallel mass testing
 #
@@ -18419,7 +18419,7 @@ run_renego() {
                tmp_result=2
                rm -f $TEMPDIR/was_killed
           fi
-          if [[ $tmp_result -eq 1 ]] && [[ loop_reneg -eq 1 ]]; then
+          if [[ $tmp_result -eq 1 ]] && [[ $loop_reneg -eq 1 ]]; then
                tmp_result=3
           fi
           if [[ $SERVICE != HTTP ]]; then
@@ -19630,7 +19630,7 @@ run_drown() {
      if [[ $(has_server_protocol ssl2) -ne 1 ]]; then
           sslv2_sockets
      else
-          [[ aaa == bbb ]]    # provoke return code=1
+          false
      fi
 
      case $? in


### PR DESCRIPTION
Starting with a simple pattern for checking for non-variables at left hand side like [[ LHS == $value ]]. The file is supposed be amended in the future.

This fixes #3074 .

Upon commit it fails first as there are two instances which will be detected (one is deliberate but will be changed too) .


## What is your pull request about?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [ ] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [x] "I" found a bug/improvement using LLM version Claude Sonnet 5 
- [ ] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, JetBrains Junie, VS Code plugin <NAME> etc.]`
    - LLMs and versions: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`

