### PR TITLE
Fix stored XSS in HTML report via unescaped Location: header (#3090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Enable IPv6 automagically, i.e. if target via IPv6 is reachable just (also) scan it
 * Detect and show DNS HTTPS RR (RFC 9460)
 * Provide an FAQ
+* Security fix: HTML-escape URLs in the HTML report to prevent stored XSS from a server-controlled `Location:` header (#3090)
 
 ### Features implemented / improvements in 3.2
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -71,6 +71,9 @@ Full contribution, see git log.
 * Christian Dresen
    - Dockerfile
 
+* Eric Gu
+  - HTML report XSS fix (escape server-controlled URLs, #3090)
+
 * enxio
    - support for TN3270/telnet STARTTLS
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -760,8 +760,8 @@ tmln_fixme() { tmln_warning "Fixme: $1"; }
 pr_fixme()   { pr_warning "Fixme: $1"; }
 prln_fixme() { prln_warning "Fixme: $1"; }
 
-pr_url()     { tm_out "$1"; html_out "<a href=\"$1\" style=\"color:black;text-decoration:none;\">$1</a>"; }
-pr_boldurl() { tm_bold "$1"; html_out "<a href=\"$1\" style=\"font-weight:bold;color:black;text-decoration:none;\">$1</a>"; }
+pr_url()     { tm_out "$1"; html_out "<a href=\"$(html_reserved "$1")\" style=\"color:black;text-decoration:none;\">$(html_reserved "$1")</a>"; }
+pr_boldurl() { tm_bold "$1"; html_out "<a href=\"$(html_reserved "$1")\" style=\"font-weight:bold;color:black;text-decoration:none;\">$(html_reserved "$1")</a>"; }
 
 ### color switcher (see e.g. https://linuxtidbits.wordpress.com/2008/08/11/output-color-on-bash-scripts/
 ###                          https://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x405.html


### PR DESCRIPTION
pr_url() and pr_boldurl() interpolated their argument directly into <a href="$1">$1</a> without HTML escaping. The most notable caller passes the raw HTTP Location: header from the scanned server, so a malicious HTTPS target could inject arbitrary HTML/JS into an operator's --htmlfile report. Route both the href attribute and the link text through the existing html_reserved() escaper, matching the pattern already used by every other pr_* HTML-output function.

<!--

## Describe your changes
Resolved #3090 

This includes:
- Resolved or fixed issue: <-- ✍️ Add GitHub issue number in format `#0000` 
- A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.
- Please don't remove anything.
- You can tick the boxes later after you save the PR or change the blank between the square brackets by an X or x

-->

## What is your pull request about?
- [ X ] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ X ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [ X ] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [ X ] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [ X ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ X ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ X ] "I" found a bug using LLM version: ` Anthropic Opus 4.8 `
- [ ] My contribution does not include any AI-generated content
- [ X ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Anthropic Claude Code `
    - LLMs and versions: `Anthropic Sonnet 5 `

