### PR TITLE
Fix stored XSS in HTML report via unescaped Location: header (#3090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Change Log
 
+### Security fixes in 3.2.x
+
+* Security fix: HTML-escape URLs in the HTML report to prevent stored XSS from a server-controlled `Location:` header (#3090)
+
 ### Features implemented / improvements in 3.2
 
 * Rating (SSL Labs), as of 3.2.2 version 2009r

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -68,6 +68,9 @@ Full contribution, see git log.
 * Christian Dresen
    - Dockerfile
 
+* Eric Gu
+  - HTML report XSS fix (escape server-controlled URLs, #3090)
+
 * enxio
    - support for TN3270/telnet STARTTLS
 

--- a/testssl.sh
+++ b/testssl.sh
@@ -739,8 +739,8 @@ tmln_fixme() { tmln_warning "Fixme: $1"; }
 pr_fixme()   { pr_warning "Fixme: $1"; }
 prln_fixme() { prln_warning "Fixme: $1"; }
 
-pr_url()     { tm_out "$1"; html_out "<a href=\"$1\" style=\"color:black;text-decoration:none;\">$1</a>"; }
-pr_boldurl() { tm_bold "$1"; html_out "<a href=\"$1\" style=\"font-weight:bold;color:black;text-decoration:none;\">$1</a>"; }
+pr_url()     { tm_out "$1"; html_out "<a href=\"$(html_reserved "$1")\" style=\"color:black;text-decoration:none;\">$(html_reserved "$1")</a>"; }
+pr_boldurl() { tm_bold "$1"; html_out "<a href=\"$(html_reserved "$1")\" style=\"font-weight:bold;color:black;text-decoration:none;\">$(html_reserved "$1")</a>"; }
 
 ### color switcher (see e.g. https://linuxtidbits.wordpress.com/2008/08/11/output-color-on-bash-scripts/
 ###                          https://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x405.html


### PR DESCRIPTION
Backport of the 3.3dev fix to the 3.2 branch.

pr_url() and pr_boldurl() interpolated their argument directly into <a href="$1">$1</a> without HTML escaping. The most notable caller passes the raw HTTP Location: header from the scanned server, so a malicious HTTPS target could inject arbitrary HTML/JS into an operator's --htmlfile report. Route both the href attribute and the link text through the existing html_reserved() escaper, matching the pattern already used by every other pr_* HTML-output function.

See #3090 

<!--

## Describe your changes
Please refer to an issue here or describe the change thoroughly in your PR and check the boxes which are applicable. 

This includes:
- Resolved or fixed issue: <-- ✍️ Add GitHub issue number in format `#0000` 
- A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.
- Please don't remove anything.
- You can tick the boxes later after you save the PR or chnage the blank between the square brackets by an X or x

-->

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [x] "I" found a bug using LLM version: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, JetBrains Junie, VS Code plugin <NAME> etc.]`
    - LLMs and versions: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`

