### PR TITLE
Fix broken OpenSSL version check for IPv6 proxy in check_proxy() (#3095) [3.2]

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -22352,7 +22352,7 @@ check_proxy() {
                     PROXYIP="$PROXYNODE"
                else
                     # This was tested with vanilla OpenSSL versions
-                    if [[ ${OSSL_VER_MAJOR$}${OSSL_VER_MINOR} -ge 11 ]]; then
+                    if [[ $OSSL_VER_MAJOR -ge 3 ]] || [[ "$OSSL_VER_MAJOR.$OSSL_VER_MINOR" == 1.1.* ]]; then
                          PROXYIP="[$PROXYNODE]"
                     else
                          fatal_cmd_line "OpenSSL version >= 1.1.0 required for IPv6 proxy support" $ERR_OSSLBIN
@@ -22365,7 +22365,7 @@ check_proxy() {
                if [[ -z "$PROXYIP" ]]; then
                     PROXYIP="$(get_aaaa_record "$PROXYNODE" 2>/dev/null | grep -v alias | sed 's/^.*address //')"
                     if [[ -n "$PROXYIP" ]]; then
-                         if [[ ${OSSL_VER_MAJOR$}${OSSL_VER_MINOR} -lt 11 ]]; then
+                         if [[ $OSSL_VER_MAJOR -lt 3 ]] && [[ "$OSSL_VER_MAJOR.$OSSL_VER_MINOR" != 1.1.* ]]; then
                               fatal_cmd_line "OpenSSL version >= 1.1.0 required for IPv6 proxy support" $ERR_OSSLBIN
                          fi
                     fi


### PR DESCRIPTION
Backport of #3096 to the 3.2 branch. Fixes #3095.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files

The same `bad substitution` bug fixed in #3096 (merged to 3.3dev) is present in 3.2 at `testssl.sh:22355` and `testssl.sh:22368`. `check_proxy()` gated IPv6 proxy support on `${OSSL_VER_MAJOR$}${OSSL_VER_MINOR} -ge 11`, where the stray `$` caused a `bad substitution` error. On non-LibreSSL builds this aborted the rest of `check_proxy()` for any IPv6 proxy (literal `[addr]:port`, or a hostname resolving only to AAAA), so `PROXY` was never rebuilt into a valid `-proxy ...` argument and downstream openssl calls failed with an error mentioning neither IPv6 nor the proxy.

Both checks are replaced with the dotted-glob idiom already used elsewhere in this branch for OpenSSL >= 1.1 gates (e.g. `testssl.sh:20860`, `testssl.sh:2140`), which is robust and greppable.

## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.2/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.2/Coding_Convention.md)
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.2/CREDITS.md) (alphabetical order) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.2/CHANGELOG.md)

## AI section
- [x] "I" found a bug using LLM version: `Claude Opus 4.8`
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code`
    - LLMs and versions: `Claude Opus 4.8`
