### PR TITLE
Fix bogus "Scan interrupted" scanTime in mass-testing JSON (#1246)

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -26291,7 +26291,12 @@ lets_roll() {
           else
                run_mass_testing
           fi
-          exit $?
+          RET=$?
+          # START_TIME was set by "lets_roll init" above; compute the overall scan
+          # time here so fileout_json_footer() doesn't mistake it for an interrupted
+          # scan (SCAN_TIME==0) and report "Scan interrupted", see #1246
+          calc_scantime
+          exit $RET
      fi
      html_banner
 


### PR DESCRIPTION
Closes #1246.

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files

### #1246 — bogus `"Scan interrupted"` scanTime in mass-testing JSON
In mass-testing mode `main()` runs `run_mass_testing()` / `run_mass_testing_parallel()` and exits without ever calling `lets_roll()` for the scan, so `calc_scantime()` never runs and `SCAN_TIME` stays `0`. `fileout_json_footer()` (called from `cleanup()` on exit) treats `SCAN_TIME==0` as an interrupted scan and writes `"scanTime": "Scan interrupted"` for the whole batch.

`START_TIME` is already set by the earlier `lets_roll init` call, so the fix computes the overall scan time with `calc_scantime()` before exiting the mass-testing path.

Verified with `./testssl.sh --file <list> -p --jsonfile out.json`:
- **Before:** `"scanTime": "Scan interrupted"` (severity `WARN`)
- **After:** `"scanTime": "36"` (severity `INFO`)

## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md)
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem

## AI section
- [x] "I" found a bug using LLM version: `Claude Opus 4.8`
- [x] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `Claude Code`
    - LLMs and versions: `Claude Opus 4.8`
