### PR TITLE
Fix typo

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -24118,7 +24118,7 @@ determine_service() {
                               if "$HAS_XMPP"; then
                                    # small hack -- instead of changing calls all over the place
                                    STARTTLS="$STARTTLS -xmpphost $NODE"
-                              llelse
+                              else
                                    # If the XMPP name cannot be provided using -xmpphost,
                                    # then it needs to be provided to the -connect option
                                    NODEIP="$NODE"


### PR DESCRIPTION
It appears that #3084 accidentally introduced a typo in determine_service(). This PR undoes the change.

<!--

## Describe your changes
Please refer to an issue here or describe the change thoroughly in your PR and check the boxes which are applicable. 

This includes:
- Resolved or fixed issue: <-- ✍️ Add GitHub issue number in format `#0000` 
- A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.
- Please don't remove anything.
- You can tick the boxes later after you saved the PR or change the blank between the square brackets by an X or x

-->

## What is your pull request about?
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [x] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order of last name) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ ] I found a bug / an improvement using LLM version: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, JetBrains Junie, VS Code plugin <NAME> etc.]`
    - LLMs and versions: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`

